### PR TITLE
Add python dependency install functionality

### DIFF
--- a/OpenLIFUHome/CMakeLists.txt
+++ b/OpenLIFUHome/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
+  Resources/python-requirements.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -226,6 +226,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Buttons
         self.ui.applyButton.connect("clicked(bool)", self.onApplyButton)
         self.ui.installPythonReqsButton.connect("clicked(bool)", self.onInstallPythonRequirements)
+        self.updateInstallButtonText()
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
@@ -309,9 +310,17 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.logic.process(self.ui.inputSelector.currentNode(), self.ui.invertedOutputSelector.currentNode(),
                                    self.ui.imageThresholdSliderWidget.value, not self.ui.invertOutputCheckBox.checked, showResult=False)
 
+    def updateInstallButtonText(self) -> None:
+        """Update the text of the install button based on whether it's 'install' or 'reinstall'"""
+        if python_requirements_exist():
+            self.ui.installPythonReqsButton.text = 'Reinstall Python Requirements'
+        else:
+            self.ui.installPythonReqsButton.text = 'Install Python Requirements'
+
     def onInstallPythonRequirements(self) -> None:
         """Install python requirements button action"""
         check_and_install_python_requirements(prompt_if_found=True)
+        self.updateInstallButtonText()
 
 
 #

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Annotated, Optional
+import importlib
 
 import vtk
 import qt
@@ -122,14 +123,8 @@ def install_python_requirements() -> None:
         slicer.util.pip_install(['-r', requirements_path])
 
 def python_requirements_exist() -> bool:
-    """Check whether python requirements are installed by attempting an import. Return
-    whether the check was successful."""
-    try:
-        with BusyCursor():
-            import openlifu
-    except ModuleNotFoundError:
-        return False
-    return True
+    """Check and return whether python requirements are installed."""
+    return importlib.util.find_spec('openlifu') is not None
 
 def check_and_install_python_requirements(prompt_if_found = False) -> None:
     """Check whether python requirements are installed and prompt to install them if not.

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -188,9 +188,6 @@
       </item>
       <item row="1" column="0">
        <widget class="QPushButton" name="installPythonReqsButton">
-        <property name="text">
-         <string>Install Python Requirements</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -186,6 +186,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="installPythonReqsButton">
+        <property name="text">
+         <string>Install Python Requirements</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/OpenLIFUHome/Resources/python-requirements.txt
+++ b/OpenLIFUHome/Resources/python-requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@fe76a8d8ed4e0759a86c63e51651de47c40b0061


### PR DESCRIPTION
Adds a button to check for and install python dependencies.

The function `check_and_install_python_requirements` can be used in the future to run the check at the time that it's needed, so that the user doesn't have to use that button.

- [x] Merge #2 before reviewing this as this is branched from there.
- [x] Merge https://github.com/OpenwaterHealth/OpenLIFU-python/pull/23 and then update the commit hash in `python-requirements.txt` before merging this.
- [x] Improve the method of checking whether `openlifu` exists (instead of attempting import, use importlib's `find_spec`)
- [x] Check (without prompting) upon module entry whether the dependencies exist. Make the button text change from "install" to "re-install" if they exist.