### PR TITLE
Add session loading UI

### DIFF
--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -356,6 +356,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         [session_name, session_id]
                     ))
                     subject_item.appendRow(session_row)
+                self.ui.subjectSessionView.expand(subject_item.index())
 
 
 

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -1,11 +1,14 @@
 import logging
-import os
+import sys
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Optional, Any, List, Tuple, Sequence, Dict, TYPE_CHECKING
+from numpy.typing import NDArray
 import importlib
+import logging
 
 import vtk
 import qt
+import numpy as np
 
 import slicer
 from slicer.i18n import tr as _
@@ -14,6 +17,9 @@ from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from slicer.parameterNodeWrapper import parameterNodeWrapper
 
+if TYPE_CHECKING:
+    import openlifu # This import is deferred to later runtime, but it is done here for IDE and static analysis purposes
+    import openlifu.db
 
 #
 # OpenLIFUHome
@@ -44,7 +50,7 @@ class OpenLIFUHome(ScriptedLoadableModule):
             "and development."
         )
 
-# TODO Move these functions to a place where they can be used by all modules
+# TODO Move some of these functions to more suitable places, e.g. some need to be where all modules can access them.
 class BusyCursor:
     """
     Context manager for showing a busy cursor.  Ensures that cursor reverts to normal in
@@ -96,6 +102,83 @@ def check_and_install_python_requirements(prompt_if_found = False) -> None:
                 windowTitle="Python dependencies still not found"
             )
 
+def import_openlifu_with_check() -> "openlifu":
+    """Import openlifu and return the module, checking that it is installed along the way."""
+    if "openlifu" not in sys.modules:
+        check_and_install_python_requirements(prompt_if_found=False)
+        with BusyCursor():
+            import openlifu
+    return sys.modules["openlifu"]
+
+def display_errors(f):
+    """Decorator to make functions forward their python exceptions along as slicer error displays"""
+    def f_with_forwarded_errors(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            slicer.util.errorDisplay(f'Exception raised in {f.__name__}: {e}')
+            raise e
+    return f_with_forwarded_errors
+
+class SlicerLogHandler(logging.Handler):
+    def __init__(self, name_to_print, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name_to_print = name_to_print
+
+    def emit(self, record):
+        if record.levelno == logging.ERROR:
+            method_to_use = self.handle_error
+        elif record.levelno == logging.WARNING:
+            method_to_use = self.handle_warning
+        else: # info or any other unaccounted for log message level
+            method_to_use = self.handle_info
+        method_to_use(self.format(record))
+
+    def handle_error(self, msg):
+        slicer.util.errorDisplay(f"{self.name_to_print}: {msg}")
+
+    def handle_warning(self, msg):
+        slicer.util.warningDisplay(f"{self.name_to_print}: {msg}")
+
+    def handle_info(self, msg):
+        slicer.util.showStatusMessage(f"{self.name_to_print}: {msg}")
+
+def add_slicer_log_handler(openlifu_object: Any):
+    """Adds an appropriately named SlicerLogHandler to the logger of an openlifu object,
+    and only doing so if that logger doesn't already have a SlicerLogHandler"""
+    if not hasattr(openlifu_object, "logger"):
+        raise ValueError("This object does not have a logger attribute.")
+    if not hasattr(openlifu_object, "__class__"):
+        raise ValueError("This object is not an instance of an openlifu class.")
+    logger : logging.Logger = openlifu_object.logger
+    if not any(isinstance(h, SlicerLogHandler) for h in logger.handlers):
+        handler = SlicerLogHandler(openlifu_object.__class__.__name__)
+        logger.addHandler(handler)
+
+# TODO: Fix the matlab weirdness in openlifu so that we can get rid of ensure_list here.
+# The reason for ensure_list is to deal with the fact that matlab fails to distinguish
+# between a list with one element and the element itself, and so it doesn't write out
+# singleton lists properly
+def ensure_list(item: Any) -> List[Any]:
+    """ Ensure the input is a list. This is a no-op for lists, and returns a singleton list when given non-list input. """
+    if isinstance(item, list):
+        return item
+    else:
+        return [item]
+
+def create_noneditable_QStandardItem(text:str) -> qt.QStandardItem:
+            item = qt.QStandardItem(text)
+            item.setEditable(False)
+            return item
+
+def numpy_to_vtk_4x4(numpy_array_4x4 : NDArray[Any]) -> vtk.vtkMatrix4x4:
+            if numpy_array_4x4.shape != (4, 4):
+                raise ValueError("The input numpy array must be of shape (4, 4).")
+            vtk_matrix = vtk.vtkMatrix4x4()
+            for i in range(4):
+                for j in range(4):
+                    vtk_matrix.SetElement(i, j, numpy_array_4x4[i, j])
+            return vtk_matrix
 
 
 #
@@ -108,7 +191,7 @@ class OpenLIFUHomeParameterNode:
     """
     The parameters needed by this module.
     """
-    pass
+    databaseDirectory : Path
 
 
 #
@@ -148,18 +231,65 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUHomeLogic()
 
-        # Connections
+        # === Connections and UI setup =======
 
         # These connections ensure that we update parameter node when scene is closed
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
-        # Buttons
-        self.ui.installPythonReqsButton.connect("clicked(bool)", self.onInstallPythonRequirements)
+        self.ui.installPythonReqsButton.connect("clicked()", self.onInstallPythonRequirements)
         self.updateInstallButtonText()
+
+        self.ui.databaseLoadButton.clicked.connect(self.onLoadDatabaseClicked)
+        self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).connect("returnPressed()", self.onLoadDatabaseClicked)
+
+        self.subjectSessionItemModel = qt.QStandardItemModel()
+        self.subjectSessionItemModel.setHorizontalHeaderLabels(['Name', 'ID'])
+        self.ui.subjectSessionView.setModel(self.subjectSessionItemModel)
+        self.ui.subjectSessionView.setColumnWidth(0, 200) # make the Name column wider
+
+        self.ui.subjectSessionView.doubleClicked.connect(self.on_item_double_clicked)
+
+        # Selecting an item and clicking sessionLoadButton is equivalent to doubleclicking the item:
+        self.ui.sessionLoadButton.clicked.connect(
+            lambda : self.on_item_double_clicked(self.ui.subjectSessionView.currentIndex())
+        )
+
+        # ====================================
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
+
+    def onLoadDatabaseClicked(self):
+        # Clear any items that are already there
+        self.subjectSessionItemModel.removeRows(0,self.subjectSessionItemModel.rowCount())
+
+        subject_info = self.logic.load_database(self.ui.databaseDirectoryLineEdit.currentPath)
+
+        for subject_id, subject_name in subject_info:
+            subject_row = list(map(
+                create_noneditable_QStandardItem,
+                [subject_name,subject_id]
+            ))
+            self.subjectSessionItemModel.appendRow(subject_row)
+
+    def on_item_double_clicked(self, index : qt.QModelIndex):
+        if index.parent().isValid(): # If this has a parent, then it is a session item rather than a subject item
+            session_id = self.subjectSessionItemModel.itemFromIndex(index.siblingAtColumn(1)).text()
+            subject_id = self.subjectSessionItemModel.itemFromIndex(index.parent().siblingAtColumn(1)).text()
+            self.logic.load_session(subject_id, session_id)
+        else: # This was a top-level item, so it must be a subject
+            subject_id = self.subjectSessionItemModel.itemFromIndex(index.siblingAtColumn(1)).text()
+            subject_item : qt.QStandardItem = self.subjectSessionItemModel.itemFromIndex(index.siblingAtColumn(0))
+            if subject_item.rowCount() == 0: # If we have not already expanded this subject
+                for session_id, session_name in self.logic.get_session_info(subject_id):
+                    session_row = list(map(
+                        create_noneditable_QStandardItem,
+                        [session_name, session_id]
+                    ))
+                    subject_item.appendRow(session_row)
+
+
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -176,7 +306,6 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
             self._parameterNodeGuiTag = None
-            self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self._checkCanApply)
 
     def onSceneStartClose(self, caller, event) -> None:
         """Called just before the scene is closed."""
@@ -242,9 +371,197 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
         """Called when the logic class is instantiated. Can be used for initializing member variables."""
         ScriptedLoadableModuleLogic.__init__(self)
 
+        self.db : Optional[openlifu.Database] = None
+        self.current_session : Optional[openlifu.db.session.Session] = None
+        self._subjects : Dict[str, openlifu.db.subject.Subject] = {} # Mapping from subject id to Subject
+
     def getParameterNode(self):
         return OpenLIFUHomeParameterNode(super().getParameterNode())
 
+    def clear_session(self) -> None:
+        self.current_session = None
+        self._subjects = {}
+        # slicer.mrmlScene.Clear() # TODO: Re-introduce this once we figure out how to make the parameter node persist
+
+    @display_errors
+    def load_database(self, path: Path) -> Sequence[Tuple[str,str]]:
+        """Load an openlifu database from a local folder hierarchy.
+
+        This sets the internal openlifu database object and reads in all the subjects,
+        and returns the subject information.
+
+        Args:
+            path: Path to the openlifu database folder on disk.
+
+        Returns: A sequence of pairs (subject_id, subject_name) running over all subjects
+            in the database.
+        """
+        openlifu = import_openlifu_with_check()
+
+        self.clear_session()
+        self.db = openlifu.Database(path)
+        add_slicer_log_handler(self.db)
+
+        subject_ids : List[str] = ensure_list(self.db.get_subject_ids())
+        self._subjects = {
+            subject_id : self.db.load_subject(subject_id)
+            for subject_id in subject_ids
+        }
+
+        subject_names = [subject.name for subject in self._subjects.values()]
+
+        return zip(subject_ids, subject_names)
+
+    def get_subject(self, subject_id:str) -> "openlifu.db.subject.Subject":
+        """Get the Subject with a given ID"""
+        try:
+            return self._subjects[subject_id] # use the in-memory Subject if it is in memory
+        except KeyError:
+            # otherwise attempt to load it:
+            return self.db.load_subject(subject_id)
+
+    def get_sessions(self, subject_id:str) -> "List[openlifu.db.session.Session]":
+        """Get the collection of Sessions associated with a given subject ID"""
+        return [
+            self.db.load_session(
+                self.get_subject(subject_id),
+                session_id
+            )
+            for session_id in ensure_list(self.db.get_session_ids(subject_id))
+        ]
+
+    @display_errors
+    def get_session_info(self, subject_id:str) -> Sequence[Tuple[str,str]]:
+        """Fetch the session names and IDs for a particular subject.
+
+        This requires that an openlifu database be loaded.
+
+        Args:
+            subject_id: ID of the subject for which to query session info.
+
+        Returns: A sequence of pairs (session_id, session_name) running over all sessions
+            for the given subject.
+        """
+        sessions = self.get_sessions(subject_id)
+        return [(session.id, session.name) for session in sessions]
+
+    @display_errors
+    def get_session(self, subject_id:str, session_id:str) -> "openlifu.db.session.Session":
+        """Fetch the Session with the given ID"""
+        return self.db.load_session(self.get_subject(subject_id), session_id)
+
+    @display_errors
+    def load_session(self, subject_id, session_id):
+        self.clear_session()
+        self.current_session = self.get_session(subject_id, session_id)
+        volume_id = self.current_session.volume_id
+        volume_filename_maybe = Path(self.db.get_volume_filename(subject_id, volume_id))
+        volume_file_candidates = volume_filename_maybe.parent.glob(
+            volume_filename_maybe.name.split('.')[0] + '.*'
+        )
+
+        # === Loading volume ===
+
+        volume_files = [
+            volume_path
+            for volume_path in volume_file_candidates
+            if slicer.app.coreIOManager().fileType(volume_path) == 'VolumeFile'
+        ]
+        if len(volume_files) < 1:
+            raise FileNotFoundError(f"Could not find a volume file for subject {subject_id}, session {session_id}.")
+        if len(volume_files) > 1:
+            raise FileNotFoundError(f"Found multiple candidate volume files for subject {subject_id}, session {session_id}.")
+
+        volume_path = volume_files[0]
+
+        volume_node = slicer.util.loadVolume(volume_path)
+        volume_node.SetName(volume_id)
+
+        # === Loading targets ===
+
+        directions_in_RAS_coords_dict = {
+            'R' : np.array([1,0,0]),
+            'A' : np.array([0,1,0]),
+            'S' : np.array([0,0,1]),
+            'L' : np.array([-1,0,0]),
+            'P' : np.array([0,-1,0]),
+            'I' : np.array([0,0,-1]),
+        }
+
+        def get_xxx2ras_matrix(dims:Sequence[str]) -> NDArray[Any]:
+            return np.array([
+                directions_in_RAS_coords_dict[dim] for dim in dims
+            ]).transpose()
+
+        def get_xx2mm_scale_factor(length_unit:str) -> float:
+            openlifu = import_openlifu_with_check()
+            return openlifu.util.units.getsiscale(length_unit, 'distance') / openlifu.util.units.getsiscale('mm', 'distance')
+
+        target_nodes = []
+
+        for target in self.current_session.targets:
+
+            target_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+            target_nodes.append(target_node)
+            target_node.SetName(target.id)
+
+                # Get target position and convert it to Slicer coordinates
+            position = np.array(target.position)
+            position = get_xxx2ras_matrix(target.dims) @ position
+            position = get_xx2mm_scale_factor(target.units) * position
+
+            target_node.SetControlPointLabelFormat(target.name)
+            target_display_node = target_node.GetDisplayNode()
+            target_display_node.SetSelectedColor(target.color)
+            target_node.SetLocked(True)
+
+            target_node.AddControlPoint(
+                position
+            )
+
+        # === Loading transducer ===
+
+        transducer_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
+        transducer_node.SetName(self.current_session.transducer.id)
+        transducer_node.SetAndObservePolyData(self.current_session.transducer.get_polydata())
+        transducer_transform_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+        transducer_transform_node.SetName(f"{self.current_session.transducer.id}-matrix")
+        transducer_node.SetAndObserveTransformNodeID(transducer_transform_node.GetID())
+
+        def linear_to_affine(matrix, translation=None):
+            """Convert linear 3x3 transform to an affine 4x4 with
+            the given translation vector (the default being no translation)"""
+            if translation is None:
+                translation = np.zeros(3)
+            if matrix.shape != (3, 3):
+                raise ValueError("The input numpy array must be of shape (3, 3).")
+            return np.concatenate(
+                [
+                    np.concatenate([matrix,translation.reshape(-1,1)], axis=1),
+                    np.array([[0,0,0,1]], dtype=float),
+                ],
+                axis=0,
+            )
+
+        # Hardcoding LPS here is bad!
+        openlifu2slicer_matrix = linear_to_affine(get_xxx2ras_matrix('LPS') * get_xx2mm_scale_factor(self.current_session.transducer.units))
+        slicer2openlifu_matrix = np.linalg.inv(openlifu2slicer_matrix)
+        transform_matrix_numpy = openlifu2slicer_matrix @ self.current_session.transducer.matrix @ slicer2openlifu_matrix
+
+        transform_matrix_vtk = numpy_to_vtk_4x4(transform_matrix_numpy)
+        transducer_transform_node.SetMatrixTransformToParent(transform_matrix_vtk)
+        transducer_node.CreateDefaultDisplayNodes() # toggles the "eyeball" on
+
+        # === Toggle slice visibility and center slices on first target ===
+        slices_center_point = target_nodes[0].GetNthControlPointPosition(0)
+        for slice_node_name in ["Red", "Green", "Yellow"]:
+            sliceNode = slicer.util.getFirstNodeByClassByName("vtkMRMLSliceNode", slice_node_name)
+            sliceNode.JumpSliceByCentering(*slices_center_point)
+            sliceNode.SetSliceVisible(True)
+        sliceNode = slicer.util.getFirstNodeByClassByName("vtkMRMLSliceNode", "Green")
+        sliceNode.SetSliceVisible(True)
+        sliceNode = slicer.util.getFirstNodeByClassByName("vtkMRMLSliceNode", "Yellow")
+        sliceNode.SetSliceVisible(True)
 
 #
 # OpenLIFUHomeTest

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -16,7 +16,49 @@
      <property name="text" stdset="0">
       <string>Sessions</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2"/>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="databaseDirectoryLabel">
+        <property name="text">
+         <string>Database directory:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit" native="true">
+        <property name="filters" stdset="0">
+         <string>ctkPathLineEdit::Dirs</string>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>databaseDirectory</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="databaseLoadButton">
+        <property name="text">
+         <string>Load Database</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="subjectSessionLabel">
+        <property name="text">
+         <string>Subject/session selector:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTreeView" name="subjectSessionView"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="sessionLoadButton">
+        <property name="text">
+         <string>Load</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -61,6 +103,11 @@
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkpathlineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -49,7 +49,11 @@
        </widget>
       </item>
       <item>
-       <widget class="QTreeView" name="subjectSessionView"/>
+       <widget class="QTreeView" name="subjectSessionView">
+        <property name="expandsOnDoubleClick">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QPushButton" name="sessionLoadButton">

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -12,198 +12,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
-     <property name="text">
-      <string>Inputs</string>
+    <widget class="ctkCollapsibleButton" name="sessionsCollapsibleButton" native="true">
+     <property name="text" stdset="0">
+      <string>Sessions</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Input volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputSelector">
-        <property name="toolTip">
-         <string>Pick the input to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>inputVolume</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Image threshold:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkSliderWidget" name="imageThresholdSliderWidget">
-        <property name="toolTip">
-         <string>Set threshold value for computing the output image. Voxels that have intensities lower than this value will set to zero.</string>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="minimum">
-         <double>-100.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>500.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.500000000000000</double>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>imageThreshold</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <layout class="QFormLayout" name="formLayout_2"/>
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="outputsCollapsibleButton">
-     <property name="text">
-      <string>Outputs</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Thresholded volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputSelector">
-        <property name="toolTip">
-         <string>Pick the output to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>thresholdedVolume</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Inverted volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="invertedOutputSelector">
-        <property name="toolTip">
-         <string>Result with inverted threshold will be written into this volume</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>invertedVolume</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton" native="true">
+     <property name="text" stdset="0">
       <string>Advanced</string>
      </property>
-     <property name="collapsed">
+     <property name="collapsed" stdset="0">
       <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="formLayout_3">
       <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Invert threshold: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="invertOutputCheckBox">
-        <property name="toolTip">
-         <string>If checked, values above threshold are set to 0. If unchecked, values below are set to 0.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="invertThreshold" stdset="0">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="installPythonReqsButton">
-       </widget>
+       <widget class="QPushButton" name="installPythonReqsButton"/>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="toolTip">
-      <string>Run the algorithm.</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
     </widget>
    </item>
    <item>
@@ -223,11 +51,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -239,61 +62,7 @@
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
-  </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>OpenLIFUHome</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>inputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>122</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>248</x>
-     <y>61</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>OpenLIFUHome</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>outputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>82</x>
-     <y>135</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>220</x>
-     <y>161</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>OpenLIFUHome</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>invertedOutputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>161</x>
-     <y>8</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>173</x>
-     <y>176</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/OpenLIFUHome/Resources/python-requirements.txt
+++ b/OpenLIFUHome/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@fe76a8d8ed4e0759a86c63e51651de47c40b0061
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@38b8deb948fd7107bd8d1ec68896add53e1f1c73


### PR DESCRIPTION
Before merging this:
- [x] Make it so that when you click "Load" while a subject is selected, the item is also expanded in the tree view. (feedback from @peterhollender)
- [x] Complete and merge https://github.com/OpenwaterHealth/OpenLIFU-python/pull/81
- [x] Update the version of openlifu used here to one that includes those changes
- ~~[ ] Make sure targets are handled correctly -- I had misunderstood that the the target point stored in a session is actually the center and that the protocol's focal pattern will have be taken into account to determine the actual set of points that will be focused on.~~ (This will actually be handled by some upcoming refactoring)
- ~~[ ] Move the generic standalone utility functions (commented on [below](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/50#discussion_r1700867971)) to an appropriate place.~~ (#55 will handle this)