### PR TITLE
Enable SlicerOpenLIFUTransducer loading (#58)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -422,6 +422,14 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 [protocol.protocol.name, protocol.protocol.id, "Protocol"]
             ))
             self.loadedObjectsItemModel.appendRow(row)
+        for transducer_slicer in parameter_node.loaded_transducers.values():
+            transducer_slicer : SlicerOpenLIFUTransducer
+            transducer_openlifu : "openlifu.Transducer" = transducer_slicer.transducer.transducer
+            row = list(map(
+                OpenLIFULib.create_noneditable_QStandardItem,
+                [transducer_openlifu.name, transducer_openlifu.id, "Transducer"]
+            ))
+            self.loadedObjectsItemModel.appendRow(row)
 
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateLoadedObjectsView()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -268,6 +268,18 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 [transducer_openlifu.name, transducer_openlifu.id, "Transducer"]
             ))
             self.loadedObjectsItemModel.appendRow(row)
+        for volume_node in slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode'):
+            row = list(map(
+                create_noneditable_QStandardItem,
+                [volume_node.GetName(), volume_node.GetID(), "Volume"]
+            ))
+            self.loadedObjectsItemModel.appendRow(row)
+        for fiducial_node in slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode'):
+            row = list(map(
+                create_noneditable_QStandardItem,
+                [fiducial_node.GetName(), fiducial_node.GetID(), "Points"]
+            ))
+            self.loadedObjectsItemModel.appendRow(row)
 
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateLoadedObjectsView()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -116,6 +116,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # This ensures that we properly handle SlicerOpenLIFU objects that become invalid when their nodes are deleted
         self.addObserver(slicer.mrmlScene, slicer.vtkMRMLScene.NodeAboutToBeRemovedEvent, self.onNodeAboutToBeRemoved)
+        self.addObserver(slicer.mrmlScene, slicer.vtkMRMLScene.NodeAddedEvent, self.onNodeAdded)
         self.addObserver(slicer.mrmlScene, slicer.vtkMRMLScene.NodeRemovedEvent, self.onNodeRemoved)
 
         # Buttons
@@ -314,7 +315,12 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # If the volume of the active session was removed, the session becomes invalid.
         if node.IsA('vtkMRMLVolumeNode'):
             self.logic.validate_session()
+        
+        self.updateLoadedObjectsView()
 
+    @vtk.calldata_type(vtk.VTK_OBJECT)
+    def onNodeAdded(self, caller, event, node : slicer.vtkMRMLNode) -> None:
+        self.updateLoadedObjectsView()
 
     def initializeParameterNode(self) -> None:
         """Ensure parameter node exists and observed."""

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -222,8 +222,7 @@ class SlicerOpenLIFUTransducer:
         openlifu2slicer_matrix = OpenLIFULib.linear_to_affine(
             OpenLIFULib.get_xxx2ras_matrix('LPS') * OpenLIFULib.get_xx2mm_scale_factor(transducer.units)
         )
-        slicer2openlifu_matrix = np.linalg.inv(openlifu2slicer_matrix)
-        transform_matrix_numpy = openlifu2slicer_matrix @ transducer.matrix @ slicer2openlifu_matrix
+        transform_matrix_numpy = openlifu2slicer_matrix @ transducer.matrix
 
         transform_matrix_vtk = OpenLIFULib.numpy_to_vtk_4x4(transform_matrix_numpy)
         transform_node.SetMatrixTransformToParent(transform_matrix_vtk)

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -5,13 +5,24 @@ import numpy as np
 from numpy.typing import NDArray
 from pathlib import Path
 import slicer
+from slicer import (
+    vtkMRMLModelNode,
+    vtkMRMLTransformNode,
+)
+from slicer.parameterNodeWrapper import (
+    parameterNodeSerializer,
+    parameterPack,
+    Serializer,
+    ValidatedSerializer,
+    validators,
+)
 import importlib
 import sys
 import logging
 
 
 if TYPE_CHECKING:
-    import openlifu # This import is deferred to later runtime, but it is done here for IDE and static analysis purposes
+    import openlifu # This import is deferred at runtime, but it is done here for IDE and static analysis purposes
 
 class BusyCursor:
     """
@@ -71,6 +82,7 @@ def import_openlifu_with_check() -> "openlifu":
         with BusyCursor():
             import openlifu
     return sys.modules["openlifu"]
+openlifu_lz = import_openlifu_with_check # A handy alternative short name. Stands for "openlifu lazy import"
 
 def display_errors(f):
     """Decorator to make functions forward their python exceptions along as slicer error displays"""
@@ -175,3 +187,172 @@ def linear_to_affine(matrix, translation=None):
         axis=0,
     )
 
+# This very thin wrapper around openlifu.Protocol is needed to do our lazy importing of openlifu
+# while still providing type annotations that the parameter node wrapper can use.
+# If we tried to make openlifu.Protocol directly supported as a type by parameter nodes, we would
+# get errors from parameterNodeWrapper as it tries to use typing.get_type_hints. This fails because
+# get_type_hints tries to *evaluate* the type annotations like "openlifu.Protocol" possibly before
+# the user has installed openlifu, and possibly before the main window widgets exist that would allow
+# an install prompt to even show up.
+class SlicerOpenLIFUProtocol:
+    """Ultrathin wrapper of openlifu.Protocol. This exists so that protocols can have parameter node
+    support while we still do lazy-loading of openlifu."""
+    def __init__(self, protocol: "openlifu.Protocol"):
+        self.protocol = protocol
+
+# For the same reason we have a then wrapper around openlifu.Transducer. But the name SlicerOpenLIFUTransducer
+# is reserved for the upcoming parameter pack.
+class SlicerOpenLIFUTransducerWrapper:
+    """Ultrathin wrapper of openlifu.Transducer. This exists so that transducers can have parameter node
+    support while we still do lazy-loading of openlifu."""
+    def __init__(self, transducer: "openlifu.Transducer"):
+        self.transducer = transducer
+
+@parameterNodeSerializer
+class OpenLIFUProtocolSerializer(Serializer):
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        """
+        Whether the serializer can serialize the given type if it is properly instantiated.
+        """
+        return type_ == SlicerOpenLIFUProtocol
+
+    @staticmethod
+    def create(type_):
+        """
+        Creates a new serializer object based on the given type. If this class does not support the given type,
+        None is returned.
+        """
+        if OpenLIFUProtocolSerializer.canSerialize(type_):
+            # Add custom validators as we need them to the list here. For now just IsInstance.
+            return ValidatedSerializer(OpenLIFUProtocolSerializer(), [validators.IsInstance(SlicerOpenLIFUProtocol)])
+        return None
+
+    def default(self):
+        """
+        The default value to use if another default is not specified.
+        """
+        return SlicerOpenLIFUProtocol(openlifu_lz().Protocol())
+
+    def isIn(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> bool:
+        """
+        Whether the parameterNode contains a parameter of the given name.
+        Note that most implementations can just use parameterNode.HasParameter(name).
+        """
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUProtocol) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        """
+        parameterNode.SetParameter(
+            name,
+            value.protocol.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUProtocol:
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        json_string = parameterNode.GetParameter(name)
+        return SlicerOpenLIFUProtocol(openlifu_lz().Protocol.from_json(json_string))
+
+    def remove(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> None:
+        """
+        Removes the value of the given name from the parameterNode.
+        """
+        parameterNode.UnsetParameter(name)
+
+@parameterNodeSerializer
+class OpenLIFUTransducerSerializer(Serializer):
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        """
+        Whether the serializer can serialize the given type if it is properly instantiated.
+        """
+        return type_ == SlicerOpenLIFUTransducerWrapper
+
+    @staticmethod
+    def create(type_):
+        """
+        Creates a new serializer object based on the given type. If this class does not support the given type,
+        None is returned.
+        """
+        if OpenLIFUTransducerSerializer.canSerialize(type_):
+            # Add custom validators as we need them to the list here. For now just IsInstance.
+            return ValidatedSerializer(OpenLIFUTransducerSerializer(), [validators.IsInstance(SlicerOpenLIFUTransducerWrapper)])
+        return None
+
+    def default(self):
+        """
+        The default value to use if another default is not specified.
+        """
+        return SlicerOpenLIFUTransducerWrapper(openlifu_lz().Transducer())
+
+    def isIn(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> bool:
+        """
+        Whether the parameterNode contains a parameter of the given name.
+        Note that most implementations can just use parameterNode.HasParameter(name).
+        """
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUTransducerWrapper) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        """
+        parameterNode.SetParameter(
+            name,
+            value.transducer.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUTransducerWrapper:
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        json_string = parameterNode.GetParameter(name)
+        return SlicerOpenLIFUTransducerWrapper(openlifu_lz().Transducer.from_json(json_string))
+
+    def remove(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> None:
+        """
+        Removes the value of the given name from the parameterNode.
+        """
+        parameterNode.UnsetParameter(name)
+
+@parameterPack
+class SlicerOpenLIFUTransducer:
+    """An openlifu Trasducer that has been loaded into Slicer (has a model node and transform node)"""
+    transducer : SlicerOpenLIFUTransducerWrapper
+    model_node : vtkMRMLModelNode
+    transform_node : vtkMRMLTransformNode
+
+    @staticmethod
+    def initialize_from_openlifu_transducer(transducer : "openlifu.Transducer") -> "SlicerOpenLIFUTransducer":
+        """Initialize object with needed scene nodes from just the openlifu object."""
+
+        model_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
+        model_node.SetName(transducer.id)
+        model_node.SetAndObservePolyData(transducer.get_polydata())
+        transform_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+        transform_node.SetName(f"{transducer.id}-matrix")
+        model_node.SetAndObserveTransformNodeID(transform_node.GetID())
+
+        # TODO: Instead of harcoding 'LPS' here, use something like a "dims" attribute that should be associated with
+        # self.current_session.transducer.matrix. There is no such attribute yet but it should exist eventually once this is done:
+        # https://github.com/OpenwaterHealth/opw_neuromod_sw/issues/3
+        openlifu2slicer_matrix = linear_to_affine(
+            get_xxx2ras_matrix('LPS') * get_xx2mm_scale_factor(transducer.units)
+        )
+        transform_matrix_numpy = openlifu2slicer_matrix @ transducer.matrix
+
+        transform_matrix_vtk = numpy_to_vtk_4x4(transform_matrix_numpy)
+        transform_node.SetMatrixTransformToParent(transform_matrix_vtk)
+        model_node.CreateDefaultDisplayNodes() # toggles the "eyeball" on
+
+        return SlicerOpenLIFUTransducer(
+            SlicerOpenLIFUTransducerWrapper(transducer), model_node, transform_node
+        )
+
+    def clear_nodes(self) -> None:
+        """Clear associated mrml nodes from the scene. Do this when removing a transducer."""
+        slicer.mrmlScene.RemoveNode(self.model_node)
+        slicer.mrmlScene.RemoveNode(self.transform_node)


### PR DESCRIPTION
Close #58 
Close #65

- [x] Enable serialization of transformers
- [x] Enable the loading of transducers from json file
- [x] Refactor existing transducer loading code under `load_session` to use this transducer loading code
- [x] Make loaded transducers show up in the loaded objects view
- [x] Refactor session loading code to use the transducers in the loaded openlifu objects list rather than maintaining its own. (So there should be a way to add and remove objects from this list (by ID) that does the proper cleanup)
- [x] Make sure something reasonable happens when the user deletes one or both of a `SlicerOpenLIFUTransducer`'s nodes.
- [x] Invalidate session when session's transducer gets wiped out by manual deletion of an affiliated node
- [x] Move error display decorators to widget methods so they are more easily guaranteed to not repeat in a call stack
- [x] Look into why the M2 transducer loads with the wrong spatial scale
- [x] Move things to OpenLIFULib that I think would probably be used by other modules.