### PR TITLE
Adapt session loading to use transducer_id from session definition

### DIFF
--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -196,7 +196,7 @@ def make_volume_from_xarray_in_transducer_coords(data_array: "xarray.DataArray",
     imageData.GetPointData().SetScalars(vtk_array)
 
     # Create volume node
-    volumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", nodeName)
+    volumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", slicer.mrmlScene.GenerateUniqueName(nodeName))
     volumeNode.SetOrigin([float(coords[x][0]) for x in coords])
     volumeNode.SetSpacing([np.diff(coords[x][:2]).item() for x in coords])
     volumeNode.SetAndObserveImageData(imageData)

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -1,6 +1,6 @@
 import qt
 import vtk
-from typing import Any, List, Sequence, TYPE_CHECKING, NamedTuple
+from typing import Any, List, Sequence, TYPE_CHECKING, NamedTuple, Optional
 from scipy.ndimage import affine_transform
 from vtk.util import numpy_support
 import numpy as np
@@ -248,8 +248,22 @@ class SlicerOpenLIFUTransducer:
     transform_node : vtkMRMLTransformNode
 
     @staticmethod
-    def initialize_from_openlifu_transducer(transducer : "openlifu.Transducer") -> "SlicerOpenLIFUTransducer":
-        """Initialize object with needed scene nodes from just the openlifu object."""
+    def initialize_from_openlifu_transducer(
+            transducer : "openlifu.Transducer",
+            transducer_matrix: Optional[np.ndarray]=None,
+            transducer_matrix_units: Optional[str]=None,
+        ) -> "SlicerOpenLIFUTransducer":
+        """Initialize object with needed scene nodes from just the openlifu object.
+        
+        Args:
+            transducer: The openlifu Transducer object
+            transducer_matrix: The transform matrix of the transducer. Assumed to be the identity if None.
+            transducer_matrix_units: The units in which to interpret the transform matrix.
+                The transform matrix operates on a version of the coordinate space of the transducer that has been scaled to
+                these units. If left as None then the transducer's native units (Transducer.units) will be assumed.
+        
+        Returns: the newly constructed SlicerOpenLIFUTransducer object
+        """
 
         model_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
         model_node.SetName(slicer.mrmlScene.GenerateUniqueName(transducer.id))
@@ -259,24 +273,21 @@ class SlicerOpenLIFUTransducer:
         model_node.SetAndObserveTransformNodeID(transform_node.GetID())
 
         # TODO: Instead of harcoding 'LPS' here, use something like a "dims" attribute that should be associated with
-        # self.current_session.transducer.matrix. There is no such attribute yet but it should exist eventually once this is done:
+        # the `transducer` object. There is no such attribute yet but it should exist eventually once this is done:
         # https://github.com/OpenwaterHealth/opw_neuromod_sw/issues/3
         openlifu2slicer_matrix = linear_to_affine(
             get_xxx2ras_matrix('LPS') * get_xx2mm_scale_factor(transducer.units)
         )
-        transform_matrix_numpy = openlifu2slicer_matrix @ transducer.matrix
+        if transducer_matrix is None:
+            transducer_matrix = np.eye(4)
+        if transducer_matrix_units is None:
+            transducer_matrix_units = transducer.units
+        transform_in_native_transducer_coordinates = transducer.convert_transform(transducer_matrix, transducer_matrix_units)
+        transform_matrix_numpy = openlifu2slicer_matrix @ transform_in_native_transducer_coordinates
 
         transform_matrix_vtk = numpy_to_vtk_4x4(transform_matrix_numpy)
         transform_node.SetMatrixTransformToParent(transform_matrix_vtk)
         model_node.CreateDefaultDisplayNodes() # toggles the "eyeball" on
-
-        # Transducers should not have a transform matrix; it can mess up simulation down the line;
-        # openlifu functions can try to be clever and use the transform matrix inside the transducer,
-        # while here we put the transform into a slicer transform node and use that.
-        # See https://github.com/OpenwaterHealth/OpenLIFU-python/issues/97
-        # Once that issue is resolved we should no longer need this line.
-        # And we will have to pass the transform into this initialization function as a separate parameter.
-        transducer.matrix=np.eye(4)
 
         return SlicerOpenLIFUTransducer(
             SlicerOpenLIFUTransducerWrapper(transducer), model_node, transform_node


### PR DESCRIPTION
Depends on issue [#92 in openLIFU-python](https://github.com/OpenwaterHealth/OpenLIFU-python/issues/92). I adapted the session loading to use the load_transducer function in openLIFU database. This build won't work until the remaining fixes for serializing transducers in #92 are completed. 

This update also depends on #97  - in the current database, some transducers include the identity matrix definition and some don't. 

- [ ] Remember to merge https://github.com/OpenwaterHealth/OpenLIFU-python/pull/110 and update the python requirements version here before merging this.

Close #100
Close #102 
Close #103 