### PR TITLE
Refactor session handling

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -704,26 +704,12 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
         self.clear_session()
 
-        # Identify volume path. This will be simply db.get_volume_filepath after https://github.com/OpenwaterHealth/OpenLIFU-python/pull/123
-        volume_filename_maybe = Path(self.db.get_volume_filename(subject_id, session_openlifu.volume_id))
-        volume_file_candidates = volume_filename_maybe.parent.glob(
-            volume_filename_maybe.name.split('.')[0] + '.*'
-        )
-        volume_files = [
-            volume_path
-            for volume_path in volume_file_candidates
-            if slicer.app.coreIOManager().fileType(volume_path) == 'VolumeFile'
-        ]
-        if len(volume_files) < 1:
-            raise FileNotFoundError(f"Could not find a volume file for subject {subject_id}, session {session_id}.")
-        if len(volume_files) > 1:
-            raise FileNotFoundError(f"Found multiple candidate volume files for subject {subject_id}, session {session_id}.")
-        volume_path = volume_files[0]
+        volume_info = self.db.get_volume_info(session_openlifu.subject_id, session_openlifu.volume_id)
 
         # Create the SlicerOpenLIFU session object; this handles loading volume and targets
         new_session = SlicerOpenLIFUSession.initialize_from_openlifu_session(
             session_openlifu,
-            volume_path,
+            volume_path = volume_info["data_abspath"],
         )
 
         # === Load transducer ===

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -614,6 +614,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
     def get_subject(self, subject_id:str) -> "openlifu.db.subject.Subject":
         """Get the Subject with a given ID"""
+        if self.db is None:
+            raise RuntimeError("Unable to fetch subject info because there is no loaded database.")
         try:
             return self._subjects[subject_id] # use the in-memory Subject if it is in memory
         except KeyError:
@@ -622,6 +624,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
     def get_sessions(self, subject_id:str) -> "List[openlifu.db.session.Session]":
         """Get the collection of Sessions associated with a given subject ID"""
+        if self.db is None:
+            raise RuntimeError("Unable to fetch session info because there is no loaded database.")
         return [
             self.db.load_session(
                 self.get_subject(subject_id),
@@ -646,12 +650,14 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
     def get_session(self, subject_id:str, session_id:str) -> "openlifu.db.session.Session":
         """Fetch the Session with the given ID"""
+        if self.db is None:
+            raise RuntimeError("Unable to fetch session info because there is no loaded database.")
         return self.db.load_session(self.get_subject(subject_id), session_id)
 
     def load_session(self, subject_id, session_id) -> None:
         # === Ensure it's okay to load a session ===
         session = self.get_session(subject_id, session_id)
-        if session.transducer_id in self.getParameterNode().loaded_transducers:
+        if session.transducer_id in self.getParameterNode().loaded_transducers and session.transducer_id != self.session_transducer_id:
             if not slicer.util.confirmYesNoDisplay(
                 f"Loading this session will replace the already loaded transducer with ID {session.transducer_id}. Proceed?",
                 "Confirm replace transducer"

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -211,6 +211,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
 
+        self.updateLoadedObjectsView()
+
     @display_errors
     def onLoadDatabaseClicked(self, checked:bool):
 

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@ae84cbb9f410ad3fb874e4e4feac58781d93044d
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@c53b0296e7c47b12339f8595548a0b954ef694b9

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -26,6 +26,7 @@ from OpenLIFULib.busycursor import BusyCursor
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime, but it is done here for IDE and static analysis purposes
     import xarray
+    from OpenLIFUData.OpenLIFUData import OpenLIFUDataParameterNode
 
 __all__ = [
     "openlifu_lz",
@@ -47,6 +48,10 @@ __all__ = [
     "make_xarray_in_transducer_coords_from_volume",
     "BusyCursor",
 ]
+
+def get_openlifu_data_parameter_node() -> "OpenLIFUDataParameterNode":
+    """Get the parameter node of the OpenLIFU Data module"""
+    return slicer.util.getModuleLogic('OpenLIFUData').getParameterNode()
 
 def display_errors(f):
     """Decorator to make functions forward their python exceptions along as slicer error displays"""

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -310,8 +310,14 @@ class SlicerOpenLIFUTransducer:
 class SlicerOpenLIFUSession:
     """An openlifu Session that has been loaded into Slicer (i.e. has associated scene data)"""
     session : SlicerOpenLIFUSessionWrapper
+
     volume_node : vtkMRMLScalarVolumeNode
+    """The volume of the session. This is meant to be owned by the session."""
+
     target_nodes : List[vtkMRMLMarkupsFiducialNode]
+    """The list of targets that were loaded by loading the session. We remember these here just
+    in order to have the option of unloading them when unloading the session. In SlicerOpenLIFU, all
+    fiducial markups in the scene are potential targets, not necessarily just the ones listed here."""
 
     def get_transducer_id(self) -> Optional[str]:
         """Get the ID of the openlifu transducer associated with this session"""

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -317,6 +317,10 @@ class SlicerOpenLIFUSession:
         """Get the ID of the openlifu transducer associated with this session"""
         return self.session.session.transducer_id
 
+    def get_protocol_id(self) -> Optional[str]:
+        """Get the ID of the openlifu protocol associated with this session"""
+        return self.session.session.protocol_id
+
     def transducer_is_valid(self) -> bool:
         """Return whether this session's transducer is present in the list of loaded objects."""
         return self.get_transducer_id() in get_openlifu_data_parameter_node().loaded_transducers

--- a/OpenLIFULib/OpenLIFULib/lazyimport.py
+++ b/OpenLIFULib/OpenLIFULib/lazyimport.py
@@ -41,7 +41,10 @@ def check_and_install_python_requirements(prompt_if_found = False) -> None:
     if want_install:
         install_python_requirements()
         if python_requirements_exist():
-            slicer.util.infoDisplay(text="Python requirements installed.", windowTitle="Success")
+            slicer.util.infoDisplay(
+                text="Python requirements installed. Please restart the application to ensure it takes effect.",
+                windowTitle="Success"
+            )
         else:
             slicer.util.errorDisplay(
                 text="OpenLIFU python dependencies are still not found. The install may have failed.",

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -11,6 +11,8 @@ from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from slicer.parameterNodeWrapper import parameterNodeWrapper
 
+from OpenLIFULib import get_openlifu_data_parameter_node
+
 #
 # OpenLIFUSonicationControl
 #
@@ -103,7 +105,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateRunEnabled()
     
         self.addObserver(
-            slicer.util.getModuleLogic('OpenLIFUData').getParameterNode().parameterNode,
+            get_openlifu_data_parameter_node().parameterNode,
             vtk.vtkCommand.ModifiedEvent,
             self.onDataParameterNodeModified
         )


### PR DESCRIPTION
Close #106
Close #109 
Close #77 

The session should now be an object that shows up in the loaded objects view

There can be at most one loaded session at a time

Protocols are now part of session and get loaded alongside them

When there is an active session, the session "owns" certain things: a volume, ~~some targets~~, a transducer, a protocol. When a session is unloaded in order for a new one to be loaded, those things are cleared out. 

This should work with `db-extended-example-v04.zip` in [our data folder](https://drive.google.com/drive/folders/1bldoP9VxE9SHyAB0bVAJ2l6WUuTxz3Yu).

---

Remaining tasks after PR review:

- [x] Expose the "clean up scene" option when informing the user that the session is being unloaded.