### PR TITLE
Add session status view and enable saving/loading sessions

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -424,9 +424,10 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             ))
             self.loadedObjectsItemModel.appendRow(row)
         for fiducial_node in slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode'):
+            points_type = "Point" if fiducial_node.GetMaximumNumberOfControlPoints() == 1 else "Points"
             row = list(map(
                 create_noneditable_QStandardItem,
-                [fiducial_node.GetName(), "Points", fiducial_node.GetID()]
+                [fiducial_node.GetName(), points_type, fiducial_node.GetID()]
             ))
             self.loadedObjectsItemModel.appendRow(row)
         if parameter_node.loaded_plan is not None:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -252,6 +252,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
 
         self.updateLoadedObjectsView()
+        self.updateSessionStatus()
 
     @display_errors
     def onLoadDatabaseClicked(self, checked:bool):
@@ -427,8 +428,22 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             ))
             self.loadedObjectsItemModel.appendRow(row)
 
+    def updateSessionStatus(self):
+        loaded_session = self.logic.getParameterNode().loaded_session
+        if loaded_session is None:
+            self.ui.sessionStatusStackedWidget.setCurrentIndex(0)
+        else:
+            session_openlifu : "openlifu.db.Session" = loaded_session.session.session
+            self.ui.sessionStatusNameValueLabel.setText(session_openlifu.name)
+            self.ui.sessionStatusIdValueLabel.setText(session_openlifu.id)
+            self.ui.sessionStatusProtocolValueLabel.setText(session_openlifu.protocol_id)
+            self.ui.sessionStatusTransducerValueLabel.setText(session_openlifu.transducer_id)
+            self.ui.sessionStatusVolumeValueLabel.setText(session_openlifu.volume_id)
+            self.ui.sessionStatusStackedWidget.setCurrentIndex(1)
+
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateLoadedObjectsView()
+        self.updateSessionStatus()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -234,6 +234,9 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.update_sessionLoadButton_enabled()
         self.ui.subjectSessionView.selectionModel().currentChanged.connect(self.update_sessionLoadButton_enabled)
 
+        # Session management buttons
+        self.ui.unloadSessionButton.clicked.connect(self.onUnloadSessionClicked)
+
         # Manual object loading UI and the loaded objects view
         self.loadedObjectsItemModel = qt.QStandardItemModel()
         self.loadedObjectsItemModel.setHorizontalHeaderLabels(['Name', 'Type', 'ID'])
@@ -343,6 +346,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 #Update loaded subjects view
                 self.updateSubjectSessionSelector()
 
+    def onUnloadSessionClicked(self, checked:bool) -> None:
+        self.logic.clear_session(clean_up_scene=True)
 
     @display_errors
     def onLoadProtocolPressed(self, checked:bool) -> None:
@@ -429,9 +434,12 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.loadedObjectsItemModel.appendRow(row)
 
     def updateSessionStatus(self):
+        """Update the active session status view and related buttons"""
         loaded_session = self.logic.getParameterNode().loaded_session
         if loaded_session is None:
             self.ui.sessionStatusStackedWidget.setCurrentIndex(0)
+            self.ui.unloadSessionButton.setEnabled(False)
+            self.ui.unloadSessionButton.setToolTip("There is no active session")
         else:
             session_openlifu : "openlifu.db.Session" = loaded_session.session.session
             self.ui.sessionStatusNameValueLabel.setText(session_openlifu.name)
@@ -440,6 +448,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.sessionStatusTransducerValueLabel.setText(session_openlifu.transducer_id)
             self.ui.sessionStatusVolumeValueLabel.setText(session_openlifu.volume_id)
             self.ui.sessionStatusStackedWidget.setCurrentIndex(1)
+            self.ui.unloadSessionButton.setEnabled(True)
+            self.ui.unloadSessionButton.setToolTip("Unload the active session, cleaning up session-affiliated nodes in the scene")
 
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateLoadedObjectsView()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -247,6 +247,14 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.loadTransducerButton.clicked.connect(self.onLoadTransducerPressed)
         self.addObserver(self.logic.getParameterNode().parameterNode, vtk.vtkCommand.ModifiedEvent, self.onParameterNodeModified)
 
+        self.session_status_field_widgets = [
+            self.ui.sessionStatusSubjectNameIdValueLabel,
+            self.ui.sessionStatusSessionNameIdValueLabel,
+            self.ui.sessionStatusProtocolValueLabel,
+            self.ui.sessionStatusTransducerValueLabel,
+            self.ui.sessionStatusVolumeValueLabel,
+        ]
+
         # ====================================
 
         # Make sure parameter node is initialized (needed for module reload)
@@ -441,6 +449,9 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """Update the active session status view and related buttons"""
         loaded_session = self.logic.getParameterNode().loaded_session
         if loaded_session is None:
+            for label in self.session_status_field_widgets:
+                label.setText("") # Doing this before setCurrentIndex(0) results in the desired scrolling behavior
+                # (Doing it after makes Qt maintain the possibly larger size of page 1 of the stacked widget, providing unnecessary scroll bars)
             self.ui.sessionStatusStackedWidget.setCurrentIndex(0)
             for button in [self.ui.unloadSessionButton, self.ui.saveSessionButton]:
                 button.setEnabled(False)

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -447,8 +447,13 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 button.setToolTip("There is no active session")
         else:
             session_openlifu : "openlifu.db.Session" = loaded_session.session.session
-            self.ui.sessionStatusNameValueLabel.setText(session_openlifu.name)
-            self.ui.sessionStatusIdValueLabel.setText(session_openlifu.id)
+            subject_openlifu = self.logic.get_subject(session_openlifu.subject_id)
+            self.ui.sessionStatusSubjectNameIdValueLabel.setText(
+                f"{subject_openlifu.name} ({session_openlifu.subject_id})"
+            )
+            self.ui.sessionStatusSessionNameIdValueLabel.setText(
+                f"{session_openlifu.name} ({session_openlifu.id})"
+            )
             self.ui.sessionStatusProtocolValueLabel.setText(session_openlifu.protocol_id)
             self.ui.sessionStatusTransducerValueLabel.setText(session_openlifu.transducer_id)
             self.ui.sessionStatusVolumeValueLabel.setText(session_openlifu.volume_id)

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>687</height>
+    <height>718</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -160,6 +160,13 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="saveSessionButton">
+        <property name="text">
+         <string>Save Session</string>
+        </property>
        </widget>
       </item>
       <item>

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -7,14 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>749</height>
+    <height>648</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="ctkCollapsibleButton" name="sessionsCollapsibleButton">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="sessionsCollapsibleButton" native="true">
+     <property name="text" stdset="0">
       <string>Sessions</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
@@ -25,8 +28,8 @@
        </widget>
       </item>
       <item>
-       <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit">
-        <property name="filters">
+       <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit" native="true">
+        <property name="filters" stdset="0">
          <string>ctkPathLineEdit::Dirs</string>
         </property>
         <property name="SlicerParameterName" stdset="0">
@@ -77,89 +80,126 @@
      <property name="text" stdset="0">
       <string>Active session</string>
      </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <widget class="QGroupBox" name="sessionStatusGroupBox">
-        <property name="title">
-         <string>Active session status</string>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
-          <widget class="QStackedWidget" name="sessionStatusStackedWidget">
-           <property name="currentIndex">
-            <number>1</number>
-           </property>
-           <widget class="QWidget" name="noSession">
-            <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>200</height>
+         </size>
+        </property>
+        <property name="verticalScrollBarPolicy">
+         <enum>Qt::ScrollBarAsNeeded</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>299</width>
+           <height>198</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QGroupBox" name="sessionStatusGroupBox">
+            <property name="title">
+             <string>Active session status</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
              <item>
-              <widget class="QLabel" name="noSessionLabel">
-               <property name="text">
-                <string>No active session.</string>
+              <widget class="QStackedWidget" name="sessionStatusStackedWidget">
+               <property name="currentIndex">
+                <number>1</number>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
+               <widget class="QWidget" name="noSession">
+                <layout class="QVBoxLayout" name="verticalLayout_6">
+                 <item>
+                  <widget class="QLabel" name="noSessionLabel">
+                   <property name="text">
+                    <string>No active session.</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+               <widget class="QWidget" name="activeSession">
+                <layout class="QFormLayout" name="formLayout">
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="sessionStatusSubjectNameIdLabel">
+                   <property name="text">
+                    <string>Subject Name (ID):</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="sessionStatusSessionNameIdLabel">
+                   <property name="text">
+                    <string>Session Name (ID):</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="sessionStatusProtocolLabel">
+                   <property name="text">
+                    <string>Protocol:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="sessionStatusTransducerLabel">
+                   <property name="text">
+                    <string>Transducer:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="sessionStatusVolumeLabel">
+                   <property name="text">
+                    <string>Volume:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="sessionStatusSubjectNameIdValueLabel"/>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QLabel" name="sessionStatusSessionNameIdValueLabel"/>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QLabel" name="sessionStatusProtocolValueLabel"/>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QLabel" name="sessionStatusTransducerValueLabel"/>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="QLabel" name="sessionStatusVolumeValueLabel"/>
+                 </item>
+                </layout>
+               </widget>
               </widget>
              </item>
             </layout>
            </widget>
-           <widget class="QWidget" name="activeSession">
-            <layout class="QFormLayout" name="formLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="sessionStatusSubjectNameIdLabel">
-               <property name="text">
-                <string>Subject Name (ID):</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="sessionStatusSessionNameIdLabel">
-               <property name="text">
-                <string>Session Name (ID):</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="sessionStatusProtocolLabel">
-               <property name="text">
-                <string>Protocol:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="sessionStatusTransducerLabel">
-               <property name="text">
-                <string>Transducer:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="sessionStatusVolumeLabel">
-               <property name="text">
-                <string>Volume:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="sessionStatusSubjectNameIdValueLabel"/>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLabel" name="sessionStatusSessionNameIdValueLabel"/>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="sessionStatusProtocolValueLabel"/>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLabel" name="sessionStatusTransducerValueLabel"/>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLabel" name="sessionStatusVolumeValueLabel"/>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-        </layout>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item>
@@ -183,6 +223,9 @@
     <widget class="ctkCollapsibleButton" name="objectsCollapsibleButton" native="true">
      <property name="text" stdset="0">
       <string>OpenLIFU Objects</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
@@ -238,6 +281,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>489</height>
+    <height>687</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -73,8 +73,101 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="widget">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="activeSessionCollapsibleButton" native="true">
+     <property name="text" stdset="0">
+      <string>Active session</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QGroupBox" name="sessionStatusGroupBox">
+        <property name="title">
+         <string>Active session status</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QStackedWidget" name="sessionStatusStackedWidget">
+           <property name="currentIndex">
+            <number>1</number>
+           </property>
+           <widget class="QWidget" name="noSession">
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+             <item>
+              <widget class="QLabel" name="noSessionLabel">
+               <property name="text">
+                <string>No active session.</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="activeSession">
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="sessionStatusNameLabel">
+               <property name="text">
+                <string>Name:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="sessionStatusIdLabel">
+               <property name="text">
+                <string>ID:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="sessionStatusProtocolLabel">
+               <property name="text">
+                <string>Protocol:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="sessionStatusTransducerLabel">
+               <property name="text">
+                <string>Transducer:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="sessionStatusVolumeLabel">
+               <property name="text">
+                <string>Volume:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="sessionStatusNameValueLabel"/>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="sessionStatusIdValueLabel"/>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="sessionStatusProtocolValueLabel"/>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="sessionStatusTransducerValueLabel"/>
+             </item>
+             <item row="4" column="1">
+              <widget class="QLabel" name="sessionStatusVolumeValueLabel"/>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="objectsCollapsibleButton" native="true">
+     <property name="text" stdset="0">
       <string>OpenLIFU Objects</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>718</height>
+    <height>749</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -106,16 +106,16 @@
            <widget class="QWidget" name="activeSession">
             <layout class="QFormLayout" name="formLayout">
              <item row="0" column="0">
-              <widget class="QLabel" name="sessionStatusNameLabel">
+              <widget class="QLabel" name="sessionStatusSubjectNameIdLabel">
                <property name="text">
-                <string>Name:</string>
+                <string>Subject Name (ID):</string>
                </property>
               </widget>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="sessionStatusIdLabel">
+              <widget class="QLabel" name="sessionStatusSessionNameIdLabel">
                <property name="text">
-                <string>ID:</string>
+                <string>Session Name (ID):</string>
                </property>
               </widget>
              </item>
@@ -141,10 +141,10 @@
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QLabel" name="sessionStatusNameValueLabel"/>
+              <widget class="QLabel" name="sessionStatusSubjectNameIdValueLabel"/>
              </item>
              <item row="1" column="1">
-              <widget class="QLabel" name="sessionStatusIdValueLabel"/>
+              <widget class="QLabel" name="sessionStatusSessionNameIdValueLabel"/>
              </item>
              <item row="2" column="1">
               <widget class="QLabel" name="sessionStatusProtocolValueLabel"/>

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -162,6 +162,13 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="QPushButton" name="unloadSessionButton">
+        <property name="text">
+         <string>Unload Session</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -191,6 +191,7 @@ def openlifu_point_to_fiducial(point : "openlifu.Point") -> vtkMRMLMarkupsFiduci
     target_display_node = fiducial_node.GetDisplayNode()
     target_display_node.SetSelectedColor(point.color)
     fiducial_node.SetLocked(True)
+    fiducial_node.SetMaximumNumberOfControlPoints(1)
 
     fiducial_node.AddControlPoint(
         position


### PR DESCRIPTION
- Adds a view of the session status
- Enables saving and loading of sessions
- Sets maximum number of points to 1 when creating a fiducial node from an openlifu `Point`.

Close #80 
Close #81
Close #89

- [x] Rebase to main after #107 is merged
- [x] Complete #81 