### PR TITLE
Fix certain planning controls based on active session (#78)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -670,6 +670,14 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             self.clear_session(clean_up_scene=clean_up_scene)
             return False
 
+        # Check protocol is present
+        if not loaded_session.protocol_is_valid():
+            clean_up_scene = sessionInvalidatedDialogDisplay(
+                "The protocol that was in use by the active session is now missing. The session will be unloaded.",
+            )
+            self.clear_session(clean_up_scene=clean_up_scene)
+            return False
+
         return True
 
     def validate_plan(self) -> bool:

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -383,12 +383,32 @@ class SlicerOpenLIFUSession:
         """Return whether this session's transducer is present in the list of loaded objects."""
         return self.get_transducer_id() in get_openlifu_data_parameter_node().loaded_transducers
 
+    def protocol_is_valid(self) -> bool:
+        """Return whether this session's protocol is present in the list of loaded objects."""
+        return self.get_protocol_id() in get_openlifu_data_parameter_node().loaded_protocols
+
     def volume_is_valid(self) -> bool:
         """Return whether this session's volume is present in the scene."""
         return (
             self.volume_node is not None
             and slicer.mrmlScene.GetNodeByID(self.volume_node.GetID()) is not None
         )
+
+    def get_transducer(self) -> SlicerOpenLIFUTransducer:
+        """Return the transducer associated with this session, from the  list of loaded transducers in the scene.
+
+        Does not check that the session is still valid and everything it needs is there in the scene; make sure to
+        check before using this.
+        """
+        return get_openlifu_data_parameter_node().loaded_transducers[self.get_transducer_id()]
+
+    def get_protocol(self) -> SlicerOpenLIFUProtocol:
+        """Return the protocol associated with this session, from the  list of loaded protocols in the scene.
+
+        Does not check that the session is still valid and everything it needs is there in the scene; make sure to
+        check before using this.
+        """
+        return get_openlifu_data_parameter_node().loaded_protocols[self.get_protocol_id()]
 
     def clear_volume_and_target_nodes(self) -> None:
         """Clear the session's affiliated volume and target nodes from the scene."""


### PR DESCRIPTION
When there is an active session, it should fix the planning controls for protocol, transducer, and volume


---

Remaining tasks after the first review:

- ~~[ ] When a session is unloaded after a user runs planning, `clear_session` needs to call `validate_plan` to remove the associated plan~~[on second thought no](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/114#issuecomment-2403269952)
- ~~[ ] Plan/solution volumes should follow similar mechanics to other objects that occur in groups like session-related or transducer-related objects: when the group becomes invalid there should be a dialog that offers a checkbox to optionally clear out the entire group from the scene~~ [wait isn't this already done?](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/114#issuecomment-2403229252)