### PR TITLE
Add SlicerOpenLIFURun class and implement sonication control module

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1407,7 +1407,6 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             run_openlifu = run.run
             self.db.write_run(run_openlifu, session_openlifu)
             
-    @display_errors
     def add_subject_to_database(self, subject_name, subject_id):
         """ Adds new subject to loaded openlifu database.
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -79,6 +79,10 @@ class OpenLIFUDataParameterNode:
     loaded_solution : "Optional[SlicerOpenLIFUSolution]"
     loaded_session : "Optional[SlicerOpenLIFUSession]"
 
+#
+# OpenLIFUDataDialogs
+#
+
 class CreateNewSessionDialog(qt.QDialog):
     """ Create new session dialog """
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -742,7 +742,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             run_openlifu = parameter_node.loaded_run.run
             row = list(map(
                 create_noneditable_QStandardItem,
-                [run_openlifu.id, "Run", run_openlifu.id]
+                [run_openlifu.name, "Run", run_openlifu.id]
             ))
             self.loadedObjectsItemModel.appendRow(row)
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1402,10 +1402,14 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         if self.validate_session():
             if self.db is None: # This should not happen -- if there is an active session then there should be a database connection as well.
                 raise RuntimeError("Unable to write run to the session because there is no database connection")
-            session_openlifu = self.getParameterNode().loaded_session.session.session
-            
+            loaded_session = self.getParameterNode().loaded_session
+            session_openlifu = loaded_session.session.session
+            protocol_openlifu = loaded_session.get_protocol().protocol
+
             run_openlifu = run.run
-            self.db.write_run(run_openlifu, session_openlifu)
+            
+            # Session and protocol snapshots are optional arguments
+            self.db.write_run(run_openlifu, session_openlifu, protocol_openlifu)
             
     def add_subject_to_database(self, subject_name, subject_id):
         """ Adds new subject to loaded openlifu database.

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -3,6 +3,7 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPoint,
     SlicerOpenLIFUXADataset,
     SlicerOpenLIFUProtocol,
+    SlicerOpenLIFURun,
 )
 from OpenLIFULib.transducer import SlicerOpenLIFUTransducer
 from OpenLIFULib.util import get_openlifu_data_parameter_node, BusyCursor
@@ -28,6 +29,7 @@ __all__ = [
     "SlicerOpenLIFUTransducer",
     "SlicerOpenLIFUPoint",
     "SlicerOpenLIFUXADataset",
+    "SlicerOpenLIFURun",
     "get_openlifu_data_parameter_node",
     "BusyCursor",
     "get_target_candidates",

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -70,6 +70,13 @@ class SlicerOpenLIFUXADataset:
     def __init__(self, dataset: "Optional[xarray.Dataset]" = None):
         self.dataset = dataset
 
+# For the same reason we have a thin wrapper around openlifu.Run.
+class SlicerOpenLIFURun:
+    """Ultrathin wrapper of openlifu.Run. This exists so that runs can have parameter node
+    support while we still do lazy-loading of openlifu."""
+    def __init__(self, run: "Optional[openlifu.Run]" = None):
+        self.run = run
+
 def SlicerOpenLIFUSerializerBaseMaker(
         serialized_type:type,
         default_args:Optional[list[Any]] = None,
@@ -211,6 +218,18 @@ class OpenLIFUPointSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUPo
         json_string = parameterNode.GetParameter(name)
         return SlicerOpenLIFUPoint(openlifu_lz().Point.from_json(json_string))
 
+@parameterNodeSerializer
+class OpenLIFURunSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFURun)):
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFURun) -> None:
+        parameterNode.SetParameter(
+            name,
+            value.run.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFURun:
+        json_string = parameterNode.GetParameter(name)
+        return SlicerOpenLIFURun(openlifu_lz().plan.Run.from_json(json_string))
+    
 @parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):
     def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUXADataset) -> None:

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -53,6 +53,44 @@ class OpenLIFUSonicationControlParameterNode:
 
     """
 
+#
+# OpenLIFUSonicationControlDialogs
+#
+
+class onRunCompletedDialog(qt.QDialog):
+    """ Dialog to save run """
+
+    def __init__(self, parent="mainWindow"):
+        super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
+        self.setWindowTitle("Run completed")
+        self.setWindowModality(1)
+        self.setup()
+
+    def setup(self):
+
+        self.setMinimumWidth(200)
+
+        vBoxLayout = qt.QVBoxLayout()
+        self.setLayout(vBoxLayout)
+
+        self.label = qt.QLabel()
+        self.label.setText("Sonication control completed. Do you want to save this run? ")
+        vBoxLayout.addWidget(self.label)
+
+        self.successfulCheckBox = qt.QCheckBox('Check this box if the run was successful.')
+        self.successfulCheckBox.setStyleSheet("font-weight: bold")
+        vBoxLayout.addWidget(self.successfulCheckBox)
+
+        self.label_notes = qt.QLabel()
+        self.label_notes.setText("Enter additional notes to include (optional):")
+        vBoxLayout.addWidget(self.label_notes)
+        self.textBox = qt.QTextEdit()
+        vBoxLayout.addWidget(self.textBox)
+
+        self.buttonBox = qt.QDialogButtonBox()
+        self.buttonBox.setStandardButtons(qt.QDialogButtonBox.Save |
+                                          qt.QDialogButtonBox.Discard)
+        vBoxLayout.addWidget(self.buttonBox)
 
 #
 # OpenLIFUSonicationControlWidget
@@ -192,6 +230,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         solution = get_openlifu_data_parameter_node().loaded_solution
 
         self.logic.run(solution)
+        runCompleteDialog = onRunCompletedDialog()
+        runCompleteDialog.exec_()
+
 
     def onAbortClicked(self):
         self.logic.abort()

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -10,22 +10,29 @@
     <height>311</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="2">
-    <widget class="QPushButton" name="abortPushButton">
-     <property name="text">
-      <string>Abort</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QPushButton" name="runPushButton">
      <property name="text">
       <string>Run</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item>
+    <widget class="QPushButton" name="abortPushButton">
+     <property name="text">
+      <string>Abort</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="runProgressBar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Closes #86 
Closes #87 
- [x] Take user input from Save run dialog
- [x] Distinguish run ending due to completion vs abort signal
- [x] protocol and session snapshot
- [x] Add progress bar
- [x] Wait for #124 to be merged and then rebase this to the new main

There can only be one loaded_run at a time. Similar to solutions