### PR TITLE
Add solution analysis display (#97)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@d23aecc2ff49a4bcc45b8829fe5897b4829899d9
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@68764106dd54fcc6aca3f6feb2ee9421f0c3ac9f

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -4,6 +4,7 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUXADataset,
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFURun,
+    SlicerOpenLIFUSolutionAnalysis,
 )
 from OpenLIFULib.transducer import SlicerOpenLIFUTransducer
 from OpenLIFULib.util import get_openlifu_data_parameter_node, BusyCursor
@@ -30,6 +31,7 @@ __all__ = [
     "SlicerOpenLIFUPoint",
     "SlicerOpenLIFUXADataset",
     "SlicerOpenLIFURun",
+    "SlicerOpenLIFUSolutionAnalysis",
     "get_openlifu_data_parameter_node",
     "BusyCursor",
     "get_target_candidates",

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -265,6 +265,9 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateTrackingApprovalStatus()
         self.updateApproveButton()
 
+        if get_openlifu_data_parameter_node().loaded_solution is None:
+            self.logic.getParameterNode().solution_analysis = None
+
     def watch_fiducial_node(self, node:vtkMRMLMarkupsFiducialNode):
         """Add observers so that point-list changes in this fiducial node are tracked by the module."""
         self.addObserver(node,slicer.vtkMRMLMarkupsNode.PointAddedEvent,self.onPointAddedOrRemoved)

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -379,7 +379,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
                     "Cannot compute analysis",
                 )
                 self.clear_solution_analysis_tables()
-                self.ui.analysisStackedWidget.setCurrentIndex(1) # set the page to show an empty table; this is an error state
+                self.ui.analysisStackedWidget.setCurrentIndex(2) # set the page to show that this is an error state
                 return
             self.logic.getParameterNode().solution_analysis = analysis
 

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>258</width>
-    <height>213</height>
+    <height>432</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -37,6 +37,55 @@ OpenLIFUAlgorithmInputWidget</string>
      <property name="text">
       <string>(transducer tracking approval here)</string>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="analysisCollapsible" native="true">
+     <property name="text" stdset="0">
+      <string>Solution analysis</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QStackedWidget" name="analysisStackedWidget">
+        <widget class="QWidget" name="noSolutionPage">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QGroupBox" name="noSolutionGroupBox">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <item>
+              <widget class="QLabel" name="noSolutionLabel">
+               <property name="text">
+                <string>No solution</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="analysisPage">
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QTableView" name="focusAnalysisTableView"/>
+          </item>
+          <item>
+           <widget class="QTableView" name="globalAnalysisTableView"/>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -99,6 +148,12 @@ OpenLIFUAlgorithmInputWidget</string>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>258</width>
-    <height>432</height>
+    <height>520</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -79,10 +79,36 @@ OpenLIFUAlgorithmInputWidget</string>
         <widget class="QWidget" name="analysisPage">
          <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
-           <widget class="QTableView" name="focusAnalysisTableView"/>
+           <widget class="QGroupBox" name="focusAnalysisGroupBox">
+            <property name="title">
+             <string>Metrics by focus point</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8">
+             <item>
+              <widget class="QTableView" name="focusAnalysisTableView">
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item>
-           <widget class="QTableView" name="globalAnalysisTableView"/>
+           <widget class="QGroupBox" name="globalAnalysisGroupBox">
+            <property name="title">
+             <string>Overall metrics</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_9">
+             <item>
+              <widget class="QTableView" name="globalAnalysisTableView">
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -50,6 +50,9 @@ OpenLIFUAlgorithmInputWidget</string>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <widget class="QStackedWidget" name="analysisStackedWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
         <widget class="QWidget" name="noSolutionPage">
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
@@ -80,6 +83,25 @@ OpenLIFUAlgorithmInputWidget</string>
           </item>
           <item>
            <widget class="QTableView" name="globalAnalysisTableView"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="errorPage">
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QLabel" name="errorLabel">
+            <property name="styleSheet">
+             <string notr="true">color:red;</string>
+            </property>
+            <property name="text">
+             <string>Error: Could not
+compute solution
+analysis.</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Close #97 

## changes

- Solution analysis is displayed in two tables in the sonication planning module
- If there's no solution, then there's also no solution analysis, and the widget will just say "No solution" instead of showing blank tables.
- Once a solution is computed, the analysis is set. It's in the planning module parameter node.
- The first table has a column for each focus point, while the second table shows the metrics that are "global" rather than per-focus-point in just one column.
- If the solution is removed (e.g. by changing or unloading session) then the analysis is unset.
- Given the current application logic, it should not be possible for there to be a solution in the scene and have the solution analysis variable get cleared out (set to None). However I am worried that it might happen in some situations what with all the power that the manual workflow provides, so if that does happen then the analysis gets recomputed. Just to be safe. To test this behavior you can trigger the hopefully not possible state by doing the following in the python console after computing a solution: `slicer.modules.OpenLIFUSonicationPlannerWidget.logic.getParameterNode().solution_analysis = None`.

## remaining todo 

- [x] await the merging of https://github.com/OpenwaterHealth/OpenLIFU-python/pull/155
- [x] update the python-requirements.txt
- [x] await merging of https://github.com/OpenwaterHealth/OpenLIFU-python/pull/157
- [x] update the python-requirements.txt
- [x] I always get something very close to 1 for `mainlobe_pnp_MPa`. Maybe because of solution scaling, but is that how it's supposed to work? Check with Peter, and if it's not how it's supposed to work open a bug on OpenLIFU-python
  - this is likely related to the regression https://github.com/OpenwaterHealth/OpenLIFU-python/issues/141
- [x] don't just show blank tables but rather display an error label in the analysis widget when it ends up in an error state
- [x] put the two tables into groupboxes  with headings that explain one is per-focus and the other is not.
- [x] turn off `verticalHeaderVisible` for the tables