### PR TITLE
Integrate virtual fitting

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1709,15 +1709,12 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             replace=True, # If there happen to already be some virtual fit result nodes that clash, loading a session will silently overwrite them.
         )
 
-        shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
-        transducer_parent_folder_id = shNode.GetItemParent(shNode.GetItemByDataNode(newly_loaded_transducer.transform_node))
-        
         for vf_node in newly_added_vf_result_nodes:
             preplanning_widget : OpenLIFUPrePlanningWidget = slicer.modules.OpenLIFUPrePlanningWidget
             preplanning_widget.watchVirtualFit(vf_node)
 
             # Place virtual fit results under the transducer folder
-            shNode.SetItemParent(shNode.GetItemByDataNode(vf_node), transducer_parent_folder_id)
+            newly_loaded_transducer.move_node_into_transducer_sh_folder(vf_node)
 
         # === Load transducer tracking results ===
 
@@ -1729,8 +1726,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         )
 
         for (transducer_to_photoscan_node, photoscan_to_volume_node) in newly_added_tt_result_nodes:
-            shNode.SetItemParent(shNode.GetItemByDataNode(transducer_to_photoscan_node), transducer_parent_folder_id)
-            shNode.SetItemParent(shNode.GetItemByDataNode(photoscan_to_volume_node), transducer_parent_folder_id)
+            newly_loaded_transducer.move_node_into_transducer_sh_folder(transducer_to_photoscan_node)
+            newly_loaded_transducer.move_node_into_transducer_sh_folder(photoscan_to_volume_node)
 
         # === Toggle slice visibility and center slices on first target ===
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -40,7 +40,7 @@ from OpenLIFULib.util import (
     display_errors,
     create_noneditable_QStandardItem,
     ensure_list,
-    add_slicer_log_handler,
+    add_slicer_log_handler_for_openlifu_object,
     BusyCursor,
 )
 
@@ -1488,7 +1488,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         self._subjects = {}
 
         self.db = openlifu_lz().Database(path)
-        add_slicer_log_handler(self.db)
+        add_slicer_log_handler_for_openlifu_object(self.db)
 
         subject_ids : List[str] = ensure_list(self.db.get_subject_ids())
         self._subjects = {

--- a/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
+++ b/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
@@ -50,6 +50,7 @@ def linear_to_affine(matrix, translation=None):
 
 def get_IJK2RAS(volume_node: vtkMRMLScalarVolumeNode):
     """Get the trasnfrom from IJK to the _world_ RAS for a given volume node.
+
     This takes into account any transforms that the volume node may be subject to.
 
     Returns a numpy array of shape (4,4).

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -1,4 +1,4 @@
-"""Skin segmentation tools useful mainly for debugging"""
+"""Skin segmentation tools"""
 
 from OpenLIFULib.lazyimport import openlifu_lz
 from slicer import vtkMRMLScalarVolumeNode, vtkMRMLModelNode

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -159,3 +159,11 @@ class SlicerOpenLIFUTransducer:
 
     def stop_observing_transform_modified(self, tag:int) -> None:
         self.transform_node.RemoveObserver(tag)
+
+    def set_current_transform_to_match_transform_node(self, transform_node : vtkMRMLTransformNode) -> None:
+        """Set the matrix on the current transform node of this transducer to match the matrix of a given transform node.
+        (This is done by a copy not reference, so it's a one-time update -- the tranforms do not become linked in any way.)"""
+
+        transform_matrix = vtk.vtkMatrix4x4()
+        transform_node.GetMatrixTransformToParent(transform_matrix)
+        self.transform_node.SetMatrixTransformToParent(transform_matrix)

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -6,6 +6,7 @@ import slicer
 from slicer import (
     vtkMRMLModelNode,
     vtkMRMLTransformNode,
+    vtkMRMLNode,
 )
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.parameter_node_utils import SlicerOpenLIFUTransducerWrapper
@@ -167,3 +168,11 @@ class SlicerOpenLIFUTransducer:
         transform_matrix = vtk.vtkMatrix4x4()
         transform_node.GetMatrixTransformToParent(transform_matrix)
         self.transform_node.SetMatrixTransformToParent(transform_matrix)
+
+    def move_node_into_transducer_sh_folder(self, node : vtkMRMLNode) -> None:
+        """In the subject hiearchy, move the given `node` into this transducer's transform node folder."""
+        shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+        shNode.SetItemParent(
+            shNode.GetItemByDataNode(node),
+            shNode.GetItemParent(shNode.GetItemByDataNode(self.transform_node)),
+        )

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -599,6 +599,7 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
                 rank = i+1,
             )
             vf_result_nodes.append(node)
+            transducer.move_node_into_transducer_sh_folder(node)
         if len(vf_result_nodes)==0:
             return None
         return vf_result_nodes[0]

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -22,7 +22,7 @@ from OpenLIFULib import (
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFUTransducer,
 )
-from OpenLIFULib.util import replace_widget, BusyCursor
+from OpenLIFULib.util import replace_widget, BusyCursor, add_slicer_log_handler
 from OpenLIFULib.virtual_fit_results import (
     add_virtual_fit_result,
     clear_virtual_fit_results,
@@ -556,6 +556,8 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
             target: vtkMRMLMarkupsFiducialNode,
         ) -> Optional[vtkMRMLTransformNode]:
 
+        add_slicer_log_handler("VirtualFit", "Virtual fitting")
+
         # TODO: Many quantities are hard-coded here will not have to be when these two issues are done:
         # https://github.com/OpenwaterHealth/OpenLIFU-python/issues/166
         # https://github.com/OpenwaterHealth/OpenLIFU-python/issues/165
@@ -578,7 +580,6 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
                 (-50, 50), # ax
             ),
         )
-        # TODO: add log handler for this
 
         session = get_openlifu_data_parameter_node().loaded_session
         session_id : Optional[str] = session.get_session_id() if session is not None else None


### PR DESCRIPTION
Close #139 

This also close #145 finally, though most of the work to actually close that was in #179.

## Remaining TODO

- [x] Clean out the old WIP commit here which I think contains a function we no longer need
- [x] Clean up commits for final draft
- [x] Make the virtual fit button both update the transducer transform and populate in the virtual fit results
- [x] Add the virtual fit logger that shows which step we are on
- [x] Come up with good defaults to stick in for steering ranges and such until https://github.com/OpenwaterHealth/OpenLIFU-python/issues/165 and https://github.com/OpenwaterHealth/OpenLIFU-python/issues/166 are done
- [x] Put VF nodes under the correct parent folder.


## Outdated comments (ignore this section)

(The below comments are from before virtual fitting was as developed as it is now, I just don't want to delete the history.)

This is intended to be a minimal integration of the virtual fitting algorithm https://github.com/OpenwaterHealth/OpenLIFU-python/issues/147 into SlicerOpenLIFU. After this is done we can work on refining the virtual fitting "workflow" and all that, but here we just want to click "virtual fit", have the algorithm run, and then see the transducer position update.

Some development on openlifu-python is needed before this can be ready.

- [x] a thing I am wondering is where the skin surface is extracted. maybe the skin surface is assumed to be one of the inputs into the virtual fitting algorithm? Since we aren't doing https://github.com/OpenwaterHealth/OpenLIFU-python/issues/148 yet and we haven't decided how we'd approach that
  - answer: a simple skin surface extraction will be included in the virtual fit code to be merged in, but ultimately we do want to have a robust standalone skin surface extraction in openlifu-python, since it is needed for both VF and TT.
- [ ] we are currently resampling the volume into the simulation coordinate grid, ~~but we probably want to have a separate "virtual fitting" coordinate grid, so we might need another version of `make_xarray_in_transducer_coords_from_volume`. see https://github.com/OpenwaterHealth/OpenLIFU-python/issues/165#issuecomment-2486522010~~ Actually the volume should be provided as a raw array without resampling, just needs to be in LPS coords.
- [ ] make sure target is the coordinates in which the target is expected. It should be LPS coordinates, same as the volume. See https://github.com/OpenwaterHealth/OpenLIFU-python/pull/162#discussion_r1848791128
- [ ] make sure transform units are specified in the right coordinates -- see https://github.com/OpenwaterHealth/OpenLIFU-python/pull/162#discussion_r1848947468 -- notice we are switching the output type to ArrayTransform, which comes with units.
- [ ] fix the way the transform is interpreted: it's not an update but rather mapping the transducer into the LPS mri volume space. that means it's always mapping from the transducer's native coordinate system, where it's centered at the origin and "facing up" (forgetting about units -- the transform has its own units which are most likely the volume's units)
- [ ] use protocol to set pitch and yaw ranges. see https://github.com/OpenwaterHealth/OpenLIFU-python/issues/165
- [ ] await merging of https://github.com/OpenwaterHealth/OpenLIFU-python/pull/162, and then update the `python-requirements.txt`


---

Note to self: I started work on the branch `update_vf_placeholder_to_work_with_P#179` at 934e86d5ad3e0e8c881476f897cbcbfc52f43fe1 which is in this PR, and that branch is likely to be merged to main before this PR. So when rebasing this PR to main I may find myself having to remove the first commit.