### PR TITLE
Use manual virtual fit as stand-in for automated

### DIFF
--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -455,10 +455,20 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
             volume: vtkMRMLScalarVolumeNode,
             target: vtkMRMLMarkupsFiducialNode,
         ):
-        slicer.util.infoDisplay(
-            text="The virtual fit button is a placeholder. Virtual fit algorithm not yet implemented.",
-            windowTitle="Not implemented"
-        )
+        # Temporary measure of "manual" virtual fitting. See https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/153
+        transducer.transform_node.CreateDefaultDisplayNodes()
+        if not transducer.transform_node.GetDisplayNode().GetEditorVisibility():
+            slicer.util.infoDisplay(
+                text=(
+                    "The automatic virtual fitting algorithm is not yet implemented."
+                    " Use the interaction handles on the transducer to manually fit it."
+                    " You can click the Virtual fit button again to remove the interaction handles."
+                ),
+                windowTitle="Not implemented"
+            )
+            transducer.transform_node.GetDisplayNode().SetEditorVisibility(True)
+        else:
+            transducer.transform_node.GetDisplayNode().SetEditorVisibility(False)
 
 #
 # OpenLIFUPrePlanningTest


### PR DESCRIPTION
This is a temporary measure until we get the automated virtual fitting in place.

When you click "Virtual fit" the interaction handles on the transducer transform are enabled, and you now get this dialog:

![image](https://github.com/user-attachments/assets/245741c1-0f45-4720-9196-09131d3135d5)

Clicking "Virtual fit" again removes the handles