### PR TITLE
Create SlicerOpenLIFUPhotoscan and implement manual workflow

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -26,6 +26,7 @@ from OpenLIFULib import (
     SlicerOpenLIFUSolution,
     SlicerOpenLIFURun,
     SlicerOpenLIFUSession,
+    SlicerOpenLIFUPhotoscan,
     get_target_candidates,
     assign_openlifu_metadata_to_volume_node,
 )
@@ -389,6 +390,80 @@ class AddNewSubjectDialog(qt.QDialog):
 
         return (returncode, subject_name, subject_id)
 
+class LoadPhotoscanDialog(qt.QDialog):
+    """ Load photoscan dialog """
+
+    def __init__(self, parent="mainWindow"):
+        super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
+        self.setWindowTitle("Load photoscan")
+        self.setWindowModality(1)
+        self.setup()
+
+    def setup(self):
+
+        self.setMinimumWidth(400)
+
+        self.formLayout = qt.QFormLayout()
+        self.setLayout(self.formLayout)
+
+        # Model filepath
+        self.photoscanModelFilePath = ctk.ctkPathLineEdit()
+        self.photoscanModelFilePath.filters = ctk.ctkPathLineEdit.Files
+        # Allowable photoscan filetypes
+        self.photoscan_model_extensions = ("Photoscan Model" + " (*.obj *.vtk *.stl *.ply *.vtp *.g *json);;" +
+        "All Files" + " (*)")
+        self.photoscanModelFilePath.nameFilters = [self.photoscan_model_extensions]
+        self.photoscanModelFilePath.currentPathChanged.connect(self.updateDialog)
+        self.formLayout.addRow(_("Model Filepath:"), self.photoscanModelFilePath)
+
+        self.buttonBox = qt.QDialogButtonBox()
+        self.buttonBox.setStandardButtons(qt.QDialogButtonBox.Ok |
+                                          qt.QDialogButtonBox.Cancel)
+        self.formLayout.addWidget(self.buttonBox)
+
+        self.buttonBox.rejected.connect(self.reject)
+        self.buttonBox.accepted.connect(self.validateInputs)
+
+    def updateDialog(self):
+        """If the selected model file path is an .obj (or related format) model file, then
+        the user needs to specify the corresponding texture file. This function updates the 
+        dialog to prompt the user to select the texture image. If the user selects a .json file
+        as the model file, then the model and texture filepaths are determined from the json file."""
+
+        current_filepath = Path(self.photoscanModelFilePath.currentPath)
+        if current_filepath.suffix != '.json' and self.formLayout.rowCount() == 2:
+            # Texture filepath
+            self.photoscanTextureFilePath = ctk.ctkPathLineEdit()
+            self.photoscanTextureFilePath.filters = ctk.ctkPathLineEdit.Files
+            # Allowable photoscan filetypes
+            self.photoscan_texture_extensions = ("Photoscan Texture" + " (*.jpg *. *.png *.tiff *.exr);;" +
+            "All Files" + " (*)")
+            self.photoscanTextureFilePath.nameFilters = [self.photoscan_texture_extensions]
+            self.formLayout.insertRow(1,_("Texture Filepath:"), self.photoscanTextureFilePath)
+        elif current_filepath.suffix == '.json' and self.formLayout.rowCount() == 3:
+            self.formLayout.removeRow(1) 
+
+    def validateInputs(self):
+        photoscan_model_filepath = Path(self.photoscanModelFilePath.currentPath)
+        if photoscan_model_filepath.suffix != 'json':
+            photoscan_texture_filepath = self.photoscanTextureFilePath.currentPath  
+            if not len(photoscan_texture_filepath):
+                slicer.util.errorDisplay("Model and texture files both need to be specified", parent = self)
+                return
+            elif not slicer.app.coreIOManager().fileType(photoscan_model_filepath) == 'ModelFile':
+                slicer.util.errorDisplay("Invalid photoscan filetype specified", parent = self)
+                return
+        self.accept()
+
+    def customexec_(self):
+        returncode = self.exec_()
+        model_filepath = self.photoscanModelFilePath.currentPath
+        texture_filepath = None
+        if Path(model_filepath).suffix != '.json':
+            texture_filepath = self.photoscanTextureFilePath.currentPath
+
+        return returncode, model_filepath, texture_filepath
+    
 class ObjectBeingUnloadedMessageBox(qt.QMessageBox):
     """Warning box for when an object is about to be or has been unloaded"""
 
@@ -532,6 +607,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.loadVolumeButton.clicked.connect(self.onLoadVolumePressed)
         self.ui.loadFiducialsButton.clicked.connect(self.onLoadFiducialsPressed)
         self.ui.loadTransducerButton.clicked.connect(self.onLoadTransducerPressed)
+        self.ui.loadPhotoscanButton.clicked.connect(self.onLoadPhotoscanPressed)
        
         self.session_status_field_widgets = [
             self.ui.sessionStatusSubjectNameIdValueLabel,
@@ -823,6 +899,16 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         ioManager = slicer.app.ioManager()
         return ioManager.openDialog("MarkupsFile", slicer.qSlicerFileDialog.Read)
 
+    @display_errors
+    def onLoadPhotoscanPressed(self, checked:bool) -> None:
+        load_photoscan_dlg = LoadPhotoscanDialog()
+        returncode, model_filepath, texture_filepath = load_photoscan_dlg.customexec_()
+        if not returncode:
+            return False
+
+        # self.logic.load_photoscan_from_file(model_filepath, texture_filepath)
+        # self.updateLoadedObjectsView() # Call function here to update view based on node attributes
+           
     def updateLoadedObjectsView(self):
         self.loadedObjectsItemModel.removeRows(0,self.loadedObjectsItemModel.rowCount())
         parameter_node = self._parameterNode

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1773,6 +1773,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             # Otherwise, use default photoscan name and id based on filepath
             else:
                 photoscan_openlifu = openlifu_lz().db.Photoscan.from_filepaths(model_filepath, texture_filepath)
+                self.load_photoscan_from_openlifu(photoscan_openlifu)
 
         # If the user selects a json file, infer photoscan filepath information based on the photoscan_metadata.
         elif Path(model_filepath).suffix == '.json':

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -907,14 +907,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if not returncode:
             return False
 
-        newly_loaded_photoscan = self.logic.load_photoscan_from_file(model_or_json_filepath, texture_filepath)
+        self.logic.load_photoscan_from_file(model_or_json_filepath, texture_filepath)
         self.updateLoadedObjectsView() # Call function here to update view based on node attributes (for texture volume)
-
-        # Visualize textured photoscan. NOTE: This functionality is temporary and 
-        # will be moved to the transducer tracking module once the functionality to
-        #  preview photoscans has been added.
-        if newly_loaded_photoscan:
-            newly_loaded_photoscan.show_model_with_texture()
            
     def updateLoadedObjectsView(self):
         self.loadedObjectsItemModel.removeRows(0,self.loadedObjectsItemModel.rowCount())

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -415,7 +415,7 @@ class LoadPhotoscanDialog(qt.QDialog):
         "All Files" + " (*)")
         self.photoscanModelFilePath.nameFilters = [self.photoscan_model_extensions]
         self.photoscanModelFilePath.currentPathChanged.connect(self.updateDialog)
-        self.formLayout.addRow(_("Model Filepath:"), self.photoscanModelFilePath)
+        self.formLayout.addRow(_("Photoscan JSON or Model Filepath:"), self.photoscanModelFilePath)
 
         self.buttonBox = qt.QDialogButtonBox()
         self.buttonBox.setStandardButtons(qt.QDialogButtonBox.Ok |
@@ -458,12 +458,12 @@ class LoadPhotoscanDialog(qt.QDialog):
 
     def customexec_(self):
         returncode = self.exec_()
-        model_filepath = self.photoscanModelFilePath.currentPath
-        texture_filepath = None
-        if len(model_filepath) and Path(model_filepath).suffix != '.json':
+        model_or_json_filepath = self.photoscanModelFilePath.currentPath
+        if len(model_or_json_filepath) and Path(model_or_json_filepath).suffix != '.json':
             texture_filepath = self.photoscanTextureFilePath.currentPath
-
-        return returncode, model_filepath, texture_filepath
+            return returncode, model_or_json_filepath, texture_filepath
+        else:
+            return returncode, model_or_json_filepath, None
     
 class ObjectBeingUnloadedMessageBox(qt.QMessageBox):
     """Warning box for when an object is about to be or has been unloaded"""
@@ -903,11 +903,11 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     @display_errors
     def onLoadPhotoscanPressed(self, checked:bool) -> None:
         load_photoscan_dlg = LoadPhotoscanDialog()
-        returncode, model_filepath, texture_filepath = load_photoscan_dlg.customexec_()
+        returncode, model_or_json_filepath, texture_filepath = load_photoscan_dlg.customexec_()
         if not returncode:
             return False
 
-        newly_loaded_photoscan = self.logic.load_photoscan_from_file(model_filepath, texture_filepath)
+        newly_loaded_photoscan = self.logic.load_photoscan_from_file(model_or_json_filepath, texture_filepath)
         self.updateLoadedObjectsView() # Call function here to update view based on node attributes (for texture volume)
 
         # Visualize textured photoscan. NOTE: This functionality is temporary and 
@@ -1738,11 +1738,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             volume_json_filepath = Path(parent_dir, volume_id + '.json')
             if volume_json_filepath.exists():
                 volume_metadata = json.loads(volume_json_filepath.read_text())
-                if volume_metadata['data_filename'] == Path(filepath).name:
-                    self.load_volume_from_openlifu(parent_dir, volume_metadata)
-                # If the selected file doesn't match the filename included in the json file, use default volume name and id based on filepath
-                else:
-                    slicer.util.loadVolume(filepath)
+                self.load_volume_from_openlifu(parent_dir, volume_metadata)
             # Otherwise, use default volume name and id based on filepath
             else:
                 slicer.util.loadVolume(filepath)
@@ -1762,38 +1758,31 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         else:
             slicer.util.errorDisplay("Invalid volume filetype specified")
 
-    def load_photoscan_from_file(self, model_filepath: str, texture_filepath = None) -> None:
+    def load_photoscan_from_file(self, model_or_json_filepath: str, texture_filepath = None) -> None:
         """ Given either a model or json filetype, load a photoscan model into the scene and determine whether
-        the photoscan should be loaded based on openlifu metadata or default slicer parameters"""
+        the photoscan should be loaded based on openlifu metadata or default slicer parameters.
+        """
 
-        parent_dir = Path(model_filepath).parent
+        parent_dir = Path(model_or_json_filepath).parent
         photoscan_id = parent_dir.name # assuming the user selected a photoscan within the database
 
-        if slicer.app.coreIOManager().fileType(model_filepath) == 'ModelFile':
-            # If a corresponding json file exists in the photoscans's parent directory,
-            # then use photoscan_metadata included in the json file
+        if slicer.app.coreIOManager().fileType(model_or_json_filepath) == 'ModelFile':
+            # If a corresponding json file exists in the same directory as the selected model file,
+            # then use the photoscan_metadata included in the json file to load the photoscan. 
             photoscan_json_filepath = Path(parent_dir, photoscan_id + '.json')
             if photoscan_json_filepath.exists():
-                photoscan_metadata = json.loads(photoscan_json_filepath.read_text())
-                if photoscan_metadata['model_filename'] == Path(model_filepath).name:
-                    photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(photoscan_json_filepath)
-                    return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = photoscan_json_filepath.parent)
-                # If the selected file doesn't match the filename included in the json file, use the model file and default photoscan name and id based on filepath
-                else:
-                    # Load from data filepaths
-                    newly_loaded_photoscan = SlicerOpenLIFUPhotoscan.initialize_from_data_filepaths(model_filepath, texture_filepath)
-                    self.getParameterNode().loaded_photoscans[newly_loaded_photoscan.photoscan.photoscan.id] = newly_loaded_photoscan
-                    return newly_loaded_photoscan
+                photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(photoscan_json_filepath)
+                return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = photoscan_json_filepath.parent)
             else:
                 # Load from data filepaths
                 newly_loaded_photoscan = SlicerOpenLIFUPhotoscan.initialize_from_data_filepaths(model_filepath, texture_filepath)
                 self.getParameterNode().loaded_photoscans[newly_loaded_photoscan.photoscan.photoscan.id] = newly_loaded_photoscan
                 return newly_loaded_photoscan
             
-        # If the user selects a json file, infer photoscan filepath information based on the photoscan_metadata.
-        elif Path(model_filepath).suffix == '.json':
-                photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(model_filepath)
-                return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = Path(model_filepath).parent)
+        # If the user selects a json file,use the photoscan_metadata included in the json file to load the photoscan.
+        elif Path(model_or_json_filepath).suffix == '.json':
+                photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(model_or_json_filepath)
+                return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = Path(model_or_json_filepath).parent)
         else:
             slicer.util.errorDisplay("Invalid photoscan filetype specified")
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1417,10 +1417,12 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
         volume_info = self.db.get_volume_info(session_openlifu.subject_id, session_openlifu.volume_id)
 
+        affiliated_photoscans = {id:self.db.load_photoscan(subject_id, session_id, id) for id in self.db.get_photoscan_ids(subject_id, session_id)}
         # Create the SlicerOpenLIFU session object; this handles loading volume and targets
         new_session = SlicerOpenLIFUSession.initialize_from_openlifu_session(
             session_openlifu,
-            volume_info
+            volume_info,
+            affiliated_photoscans
         )
 
         # === Load transducer ===

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1724,18 +1724,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         the volume should be loaded based on openlifu metadata or default slicer parameters"""
 
         parent_dir = Path(filepath).parent
-        volume_id = parent_dir.name # assuming the user selected a volume within the database
-
+        # Load volume using use slicer default volume name and id based on filepath
         if slicer.app.coreIOManager().fileType(filepath) == 'VolumeFile':
-            # If a corresponding json file exists in the volume's parent directory,
-            # then use volume_metadata included in the json file
-            volume_json_filepath = Path(parent_dir, volume_id + '.json')
-            if volume_json_filepath.exists():
-                volume_metadata = json.loads(volume_json_filepath.read_text())
-                self.load_volume_from_openlifu(parent_dir, volume_metadata)
-            # Otherwise, use default volume name and id based on filepath
-            else:
-                slicer.util.loadVolume(filepath)
+            slicer.util.loadVolume(filepath)
 
         # If the user selects a json file, infer volume filepath information based on the volume_metadata.
         elif Path(filepath).suffix == '.json':
@@ -1757,21 +1748,11 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         the photoscan should be loaded based on openlifu metadata or default slicer parameters.
         """
 
-        parent_dir = Path(model_or_json_filepath).parent
-        photoscan_id = parent_dir.name # assuming the user selected a photoscan within the database
-
+        # Load from data filepaths
         if slicer.app.coreIOManager().fileType(model_or_json_filepath) == 'ModelFile':
-            # If a corresponding json file exists in the same directory as the selected model file,
-            # then use the photoscan_metadata included in the json file to load the photoscan. 
-            photoscan_json_filepath = Path(parent_dir, photoscan_id + '.json')
-            if photoscan_json_filepath.exists():
-                photoscan_openlifu = openlifu_lz().photoscan.Photoscan.from_file(photoscan_json_filepath)
-                return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = photoscan_json_filepath.parent)
-            else:
-                # Load from data filepaths
-                newly_loaded_photoscan = SlicerOpenLIFUPhotoscan.initialize_from_data_filepaths(model_filepath, texture_filepath)
-                self.getParameterNode().loaded_photoscans[newly_loaded_photoscan.photoscan.photoscan.id] = newly_loaded_photoscan
-                return newly_loaded_photoscan
+            newly_loaded_photoscan = SlicerOpenLIFUPhotoscan.initialize_from_data_filepaths(model_or_json_filepath, texture_filepath)
+            self.getParameterNode().loaded_photoscans[newly_loaded_photoscan.photoscan.photoscan.id] = newly_loaded_photoscan
+            return newly_loaded_photoscan
             
         # If the user selects a json file,use the photoscan_metadata included in the json file to load the photoscan.
         elif Path(model_or_json_filepath).suffix == '.json':

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1765,9 +1765,10 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         else:
             slicer.util.errorDisplay("Invalid volume filetype specified")
 
-    def load_photoscan_from_file(self, model_or_json_filepath: str, texture_filepath = None) -> None:
+    def load_photoscan_from_file(self, model_or_json_filepath: str, texture_filepath:Optional[str] = None) -> SlicerOpenLIFUPhotoscan:
         """ Given either a model or json filetype, load a photoscan model into the scene and determine whether
-        the photoscan should be loaded based on openlifu metadata or default slicer parameters.
+        the photoscan should be loaded based on openlifu metadata or default slicer parameters. If `model_or_json_filepath` is a
+        model filepath, then `texture_filepath` must also be provided.
         """
 
         # Load from data filepaths

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1771,7 +1771,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             # then use the photoscan_metadata included in the json file to load the photoscan. 
             photoscan_json_filepath = Path(parent_dir, photoscan_id + '.json')
             if photoscan_json_filepath.exists():
-                photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(photoscan_json_filepath)
+                photoscan_openlifu = openlifu_lz().photoscan.Photoscan.from_file(photoscan_json_filepath)
                 return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = photoscan_json_filepath.parent)
             else:
                 # Load from data filepaths
@@ -1781,7 +1781,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             
         # If the user selects a json file,use the photoscan_metadata included in the json file to load the photoscan.
         elif Path(model_or_json_filepath).suffix == '.json':
-                photoscan_openlifu = openlifu_lz().db.Photoscan.from_file(model_or_json_filepath)
+                photoscan_openlifu = openlifu_lz().photoscan.Photoscan.from_file(model_or_json_filepath)
                 return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = Path(model_or_json_filepath).parent)
         else:
             slicer.util.errorDisplay("Invalid photoscan filetype specified")

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -325,6 +325,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="loadPhotoscanButton">
+        <property name="text">
+         <string>Load Photoscan</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="loadedObjectsLabel">
         <property name="text">
          <string>Loaded OpenLIFU objects:</string>

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -15,6 +15,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/solution.py
   OpenLIFULib/algorithm_input_widget.py
   OpenLIFULib/coordinate_system_utils.py
+  OpenLIFULib/photoscan.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@9a1590d14fb7dddbc3cc1dcffe3c30188f6ba704
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0233a10efd1669df4a3b74a601f887797ab3229e

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@216d2af8eb6c4ebec6951a6ada0dc7f8f2d9029c
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@9a1590d14fb7dddbc3cc1dcffe3c30188f6ba704

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0233a10efd1669df4a3b74a601f887797ab3229e
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@f9f94cf91e8dc18540a6afc2077aa88611cdc16f

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -7,6 +7,7 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUSolutionAnalysis,
 )
 from OpenLIFULib.transducer import SlicerOpenLIFUTransducer
+from OpenLIFULib.photoscan import SlicerOpenLIFUPhotoscan
 from OpenLIFULib.util import get_openlifu_data_parameter_node, BusyCursor
 from OpenLIFULib.targets import (
     get_target_candidates,
@@ -32,6 +33,7 @@ __all__ = [
     "SlicerOpenLIFUXADataset",
     "SlicerOpenLIFURun",
     "SlicerOpenLIFUSolutionAnalysis",
+    "SlicerOpenLIFUPhotoscan",
     "get_openlifu_data_parameter_node",
     "BusyCursor",
     "get_target_candidates",

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -170,6 +170,7 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
                 self.inputs_dict["Photoscan"].combo_box.setEnabled(True)
                 for photoscan_openlifu in affiliated_photoscans_list:
                     self.add_photoscan_to_combobox(photoscan_openlifu) 
+            self.inputs_dict["Photoscan"].combo_box.setToolTip("These choices are based on the active session")
 
     def update(self):
         """Update the comboboxes, forcing some of them to take values derived from the active session if there is one"""

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -99,15 +99,16 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
                     self.add_transducer_to_combobox(transducer)
 
         # Update volume combo box
+        valid_input_volumes = 0
         if "Volume" in self.inputs_dict:
-            if len(slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode')) == 0:
+            self.inputs_dict["Volume"].combo_box.setEnabled(True)
+            for volume_node in slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode'):
+                # Check that the volume is not an OpenLIFUSolution output volume
+                if volume_node.GetAttribute('isOpenLIFUSolution') is None and volume_node.GetAttribute('isOpenLIFUPhotoscan') is None :
+                    self.add_volume_to_combobox(volume_node)
+                    valid_input_volumes += 1
+            if valid_input_volumes == 0:
                 self.inputs_dict["Volume"].indicate_no_options()
-            else:
-                self.inputs_dict["Volume"].combo_box.setEnabled(True)
-                for volume_node in slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode'):
-                    # Check that the volume is not an OpenLIFUSolution output volume
-                    if volume_node.GetAttribute('isOpenLIFUSolution') is None:
-                        self.add_volume_to_combobox(volume_node)
 
         self.set_session_related_combobox_tooltip("")
 

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -123,6 +123,7 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
                 for photoscan in dataParameterNode.loaded_photoscans.values():
                     photoscan_openlifu = photoscan.photoscan.photoscan
                     self.add_photoscan_to_combobox(photoscan_openlifu)
+            self.inputs_dict["Photoscan"].combo_box.setToolTip("")
 
         self.set_session_related_combobox_tooltip("")
 
@@ -164,13 +165,14 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
 
         # Update photoscan combo box
         if "Photoscan" in self.inputs_dict:
-            if affiliated_photoscans_list is None:
+            if len(affiliated_photoscans_list) == 0:
                 self.inputs_dict["Photoscan"].indicate_no_options()
+                self.inputs_dict["Photoscan"].combo_box.setToolTip("There are no photoscans affiliated with the active session. Add a photoscan to the session using the OpenLIFU Data module.")
             else:
                 self.inputs_dict["Photoscan"].combo_box.setEnabled(True)
                 for photoscan_openlifu in affiliated_photoscans_list:
                     self.add_photoscan_to_combobox(photoscan_openlifu) 
-            self.inputs_dict["Photoscan"].combo_box.setToolTip("These choices are based on the active session")
+                self.inputs_dict["Photoscan"].combo_box.setToolTip("These are the photoscans affiliated with the active session")
 
     def update(self):
         """Update the comboboxes, forcing some of them to take values derived from the active session if there is one"""

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -274,7 +274,7 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         Reads and returns the value with the given name from the parameterNode.
         """
         json_string = parameterNode.GetParameter(name)    
-        return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().db.Photoscan.from_json(json_string))
+        return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().photoscan.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -85,6 +85,14 @@ class SlicerOpenLIFUSolutionAnalysis:
     def __init__(self, analysis: "Optional[openlifu.plan.SolutionAnalysis]" = None):
         self.analysis = analysis
 
+# For the same reason we have a thin wrapper around openlifu.Photoscan. But the name SlicerOpenLIFUPhotoscan
+# is reserved for the upcoming parameter pack.
+class SlicerOpenLIFUPhotoscanWrapper:
+    """Ultrathin wrapper of openlifu.Photoscan. This exists so that photoscans can have parameter node
+    support while we still do lazy-loading of openlifu."""
+    def __init__(self, photoscan: "Optional[openlifu.Photoscan]" = None):
+        self.photoscan = photoscan
+
 def SlicerOpenLIFUSerializerBaseMaker(
         serialized_type:type,
         default_args:Optional[list[Any]] = None,
@@ -249,6 +257,24 @@ class OpenLIFUSolutionAnalysisSerializer(SlicerOpenLIFUSerializerBaseMaker(Slice
     def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUSolutionAnalysis:
         json_string = parameterNode.GetParameter(name)
         return SlicerOpenLIFUSolutionAnalysis(openlifu_lz().plan.SolutionAnalysis.from_json(json_string))
+
+@parameterNodeSerializer
+class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUPhotoscanWrapper)):
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUPhotoscanWrapper) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        """
+        parameterNode.SetParameter(
+            name,
+            value.photoscan.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUPhotoscanWrapper:
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        json_string = parameterNode.GetParameter(name)    
+        return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().db.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -51,7 +51,7 @@ class SlicerOpenLIFUPhotoscan:
         Returns: the newly constructed SlicerOpenLIFUPhotoscan object
         """
         with BusyCursor():
-            model_data, texture_data = openlifu_lz().db.photoscan.load_data_from_photoscan(photoscan, parent_dir = parent_dir)
+            model_data, texture_data = openlifu_lz().photoscan.load_data_from_photoscan(photoscan, parent_dir = parent_dir)
 
         model_node, texture_node = SlicerOpenLIFUPhotoscan._create_nodes(model_data, texture_data, photoscan.id)
 
@@ -67,13 +67,13 @@ class SlicerOpenLIFUPhotoscan:
         """
 
         with BusyCursor():
-            model_data, texture_data = openlifu_lz().db.photoscan.load_data_from_filepaths(model_abspath, texture_abspath)
+            model_data, texture_data = openlifu_lz().photoscan.load_data_from_filepaths(model_abspath, texture_abspath)
 
         node_name_prefix = Path(model_abspath).stem
         model_node, texture_node = SlicerOpenLIFUPhotoscan._create_nodes(model_data, texture_data, node_name_prefix)
 
         # Create a dummy photoscan to keep track of metadata to apply to the openlifu object. This photoscan is not associated with the database
-        photoscan_openlifu = openlifu_lz().db.photoscan.Photoscan(id = model_node.GetID(), 
+        photoscan_openlifu = openlifu_lz().photoscan.Photoscan(id = model_node.GetID(), 
                                                                   name = node_name_prefix,
                                                                   )
 

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -21,10 +21,10 @@ class SlicerOpenLIFUPhotoscan:
     photoscan : SlicerOpenLIFUPhotoscanWrapper 
     """Underlying openlifu Photoscan in a thin wrapper"""
 
-    model : vtkMRMLModelNode
+    model_node : vtkMRMLModelNode
     """Photoscan model node"""
 
-    texture : vtkMRMLVectorVolumeNode
+    texture_node : vtkMRMLVectorVolumeNode
     """Texture volume node"""
 
     @staticmethod
@@ -86,19 +86,19 @@ class SlicerOpenLIFUPhotoscan:
     def show_model_with_texture(self):
         # Shift/Scale texture map to uchar
         filter = vtk.vtkImageShiftScale()
-        typeString = self.texture.GetImageData().GetScalarTypeAsString()
+        typeString = self.texture_node.GetImageData().GetScalarTypeAsString()
         # default
         scale = 1
         if typeString =='unsigned short':
             scale = 1 / 255.0
         filter.SetScale(scale)
         filter.SetOutputScalarTypeToUnsignedChar()
-        filter.SetInputData(self.texture.GetImageData())
+        filter.SetInputData(self.texture_node.GetImageData())
         filter.SetClampOverflow(True)
         filter.Update()
 
-        self.model.CreateDefaultDisplayNodes()
-        modelDisplayNode = self.model.GetDisplayNode()
+        self.model_node.CreateDefaultDisplayNodes()
+        modelDisplayNode = self.model_node.GetDisplayNode()
         modelDisplayNode.SetBackfaceCulling(0)
         textureImageFlipVert = vtk.vtkImageFlip()
         textureImageFlipVert.SetFilteredAxis(1)

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -1,0 +1,79 @@
+from typing import TYPE_CHECKING
+import vtk
+import slicer
+from slicer import vtkMRMLVectorVolumeNode, vtkMRMLModelNode
+from slicer.parameterNodeWrapper import parameterPack
+from OpenLIFULib.parameter_node_utils import (
+    SlicerOpenLIFUPhotoscanWrapper,
+)
+
+from OpenLIFULib.util import BusyCursor
+
+if TYPE_CHECKING:
+    import openlifu
+
+@parameterPack
+class SlicerOpenLIFUPhotoscan:
+    """"""
+    photoscan : SlicerOpenLIFUPhotoscanWrapper
+    """Underlying openlifu Photoscan in a thin wrapper"""
+
+    model : vtkMRMLModelNode
+    """Photoscan model node"""
+
+    texture : vtkMRMLVectorVolumeNode
+    """Texture volume node"""
+
+    @staticmethod
+    def initialize_from_openlifu_data(photoscan : "openlifu.Photoscan",) -> "SlicerOpenLIFUPhotoscan":
+        """Create a SlicerOpenLIFUPhotoscan from an openlifu Photoscan.
+
+        Args:
+            photoscan: OpenLIFU Photoscan object
+
+        Returns: the newly constructed SlicerOpenLIFUPhotoscan object
+        """
+        with BusyCursor():
+            model_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
+            model_node.SetAndObservePolyData(photoscan.model)
+            model_node.SetAttribute('isOpenLIFUPhotoscan', 'True')
+
+            texture_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode")
+            texture_node.SetAndObserveImageData(photoscan.texture)
+            texture_node.SetAttribute('isOpenLIFUPhotoscan', 'True') 
+
+        return SlicerOpenLIFUPhotoscan(SlicerOpenLIFUPhotoscanWrapper(photoscan),model_node,texture_node)
+
+    def clear_nodes(self) -> None:
+        """Clear associated mrml nodes from the scene. Do this when removing a transducer."""
+        slicer.mrmlScene.RemoveNode(self.model_node)
+        slicer.mrmlScene.RemoveNode(self.texture_node)
+
+    def show_texture_on_model(self):
+        # Shift/Scale texture map to uchar
+        filter = vtk.vtkImageShiftScale()
+        typeString = self.texture.GetImageData().GetScalarTypeAsString()
+        # default
+        scale = 1
+        if typeString =='unsigned short':
+            scale = 1 / 255.0
+        filter.SetScale(scale)
+        filter.SetOutputScalarTypeToUnsignedChar()
+        filter.SetInputData(self.texture.GetImageData())
+        filter.SetClampOverflow(True)
+        filter.Update()
+
+        modelDisplayNode = self.model.GetDisplayNode()
+        modelDisplayNode.SetBackfaceCulling(0)
+        textureImageFlipVert = vtk.vtkImageFlip()
+        textureImageFlipVert.SetFilteredAxis(1)
+        textureImageFlipVert.SetInputConnection(filter.GetOutputPort())
+        modelDisplayNode.SetTextureImageDataConnection(textureImageFlipVert.GetOutputPort())
+
+    def is_approved(self) -> bool:
+        return self.photoscan.photoscan.approved
+                       
+    def toggle_approval(self) -> None:
+        self.photoscan.photoscan.approved = not self.photoscan.photoscan.approved 
+
+        

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -37,10 +37,12 @@ class SlicerOpenLIFUPhotoscan:
             model_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
             model_node.SetAndObservePolyData(photoscan.model)
             model_node.SetAttribute('isOpenLIFUPhotoscan', 'True')
+            model_node.SetName(slicer.mrmlScene.GenerateUniqueName(f"{photoscan.id}-model"))
 
             texture_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode")
             texture_node.SetAndObserveImageData(photoscan.texture)
             texture_node.SetAttribute('isOpenLIFUPhotoscan', 'True') 
+            texture_node.SetName(slicer.mrmlScene.GenerateUniqueName(f"{photoscan.id}-texture"))
 
         return SlicerOpenLIFUPhotoscan(SlicerOpenLIFUPhotoscanWrapper(photoscan),model_node,texture_node)
 
@@ -71,9 +73,9 @@ class SlicerOpenLIFUPhotoscan:
         modelDisplayNode.SetTextureImageDataConnection(textureImageFlipVert.GetOutputPort())
 
     def is_approved(self) -> bool:
-        return self.photoscan.photoscan.approved
+        return self.photoscan.photoscan.photoscan_approved
                        
     def toggle_approval(self) -> None:
-        self.photoscan.photoscan.approved = not self.photoscan.photoscan.approved 
+        self.photoscan.photoscan.approved = not self.photoscan.photoscan.photoscan_approved 
 
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -25,7 +25,7 @@ class SlicerOpenLIFUPhotoscan:
     """Texture volume node"""
 
     @staticmethod
-    def initialize_from_openlifu_data(photoscan : "openlifu.Photoscan",) -> "SlicerOpenLIFUPhotoscan":
+    def initialize_from_openlifu_photoscan(photoscan : "openlifu.Photoscan",) -> "SlicerOpenLIFUPhotoscan":
         """Create a SlicerOpenLIFUPhotoscan from an openlifu Photoscan.
 
         Args:

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -49,7 +49,7 @@ class SlicerOpenLIFUSession:
     affiliated_photoscans : Optional[Dict[str,SlicerOpenLIFUPhotoscanWrapper]] = None
     """Dictionary containing photoscan_id: SlicerOpenLIFUPhotoscanWrapper for any photoscans associated with the session. We keep track of 
     any photoscans associated with the session here so that they can be loaded into slicer as a SlicerOpenLIFUPhotoscan during
-    transducer tracking as required. SlicerOpenLIFUPhotoscanWrapper is a wrapper around an openlifu photoscan so that it is serializable."""
+    transducer tracking as required. SlicerOpenLIFUPhotoscanWrapper is a wrapper around an openlifu photoscan."""
 
     last_generated_solution_id : Optional[str] = None
     """The solution ID of the last solution that was generated for this session, or None if there isn't one.
@@ -153,9 +153,10 @@ class SlicerOpenLIFUSession:
 
     def update_affiliated_photoscans(self, affiliated_photoscans : Dict[str, "openlifu.Photoscan"]):
         
-        # Serialize list of affiliated openlifu photoscans
-        serialized_openlifu_photoscans = {photoscan.id:SlicerOpenLIFUPhotoscanWrapper(photoscan) for photoscan in affiliated_photoscans.values()}
-        self.affiliated_photoscans = serialized_openlifu_photoscans
+        # Wrap the list of affiliated openlifu photoscans using the SlicerOpenLIFUPhotoscanWrapper for 
+        # compatability with the SlicerOpenLIFUSession parameter pack. 
+        wrapped_openlifu_photoscans = {photoscan.id:SlicerOpenLIFUPhotoscanWrapper(photoscan) for photoscan in affiliated_photoscans.values()}
+        self.affiliated_photoscans = wrapped_openlifu_photoscans
 
     def update_underlying_openlifu_session(self, targets : List[vtkMRMLMarkupsFiducialNode]) -> "openlifu.db.Session":
         """Update the underlying openlifu session and the list of target nodes that are considered to be affiliated with this session.

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -49,7 +49,7 @@ class SlicerOpenLIFUSession:
     affiliated_photoscans : Optional[Dict[str,SlicerOpenLIFUPhotoscanWrapper]] = None
     """Dictionary containing photoscan_id: SlicerOpenLIFUPhotoscanWrapper for any photoscans associated with the session. We keep track of 
     any photoscans associated with the session here so that they can be loaded into slicer as a SlicerOpenLIFUPhotoscan during
-    transducer tracking as required. SlicerOpenLIFUPhotoscanWarpper is a wrapper around an openlifu photoscan so that it is serializable."""
+    transducer tracking as required. SlicerOpenLIFUPhotoscanWrapper is a wrapper around an openlifu photoscan so that it is serializable."""
 
     last_generated_solution_id : Optional[str] = None
     """The solution ID of the last solution that was generated for this session, or None if there isn't one.
@@ -108,11 +108,11 @@ class SlicerOpenLIFUSession:
         return get_openlifu_data_parameter_node().loaded_protocols[self.get_protocol_id()]
 
     def get_affiliated_photoscan_ids(self):
-        return self.affiliated_photoscans.keys() if self.affiliated_photoscans else None
+        return self.affiliated_photoscans.keys() if self.affiliated_photoscans else []
     
     def get_affiliated_photoscans(self):
         """Returns a list of openlifu photoscans associated with this session"""
-        return [photoscan.photoscan for photoscan in self.affiliated_photoscans.values()] if self.affiliated_photoscans else None
+        return [photoscan.photoscan for photoscan in self.affiliated_photoscans.values()] if self.affiliated_photoscans else []
 
     def clear_volume_and_target_nodes(self) -> None:
         """Clear the session's affiliated volume and target nodes from the scene."""
@@ -140,9 +140,6 @@ class SlicerOpenLIFUSession:
             session: OpenLIFU Session
             volume_info: Dictionary containing the metadata (name, id and filepath) of the volume
             being loaded as part of the session
-            photoscan_absolute_filepaths_info: Dictionary containing the metadata (name, id, approval status and absolute 
-            data filepaths) for each of the photoscans affiliated with the session. The photoscans are only loaded as SlicerOpenLIFUPhotoscans
-            when the user runs tranducer tracking.
         """
 
         # Load volume

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -123,7 +123,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         replace_widget(self.ui.algorithmInputWidgetPlaceholder, self.algorithm_input_widget, self.ui)
         self.updateInputOptions()
 
-        self.ui.loadPhotoscanButton.clicked.connect(self.onLoadPhotoscanClicked)
         self.ui.loadTransducerSurfaceButton.clicked.connect(self.onLoadTransducerRegistrationSurfaceClicked)
         self.ui.runTrackingButton.clicked.connect(self.onRunTrackingClicked)
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
@@ -207,22 +206,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # Determine whether transducer tracking can be run based on the status of combo boxes
         self.checkCanRunTracking()
-
-    def onLoadPhotoscanClicked(self):
-        # Using a custom file dialog instead of slicer.util.openAddModelDialog() incase database specific 
-        # customizations are required later 
-        qsettings = qt.QSettings()
-
-        filepath: str = qt.QFileDialog.getOpenFileName(
-            slicer.util.mainWindow(), # parent
-            'Load photoscan', # title of dialog
-            qsettings.value('OpenLIFU/databaseDirectory','.'), # starting dir, with default of '.'
-            "Model (*.obj *.vtk);;All Files (*)", # file type filter
-        )
-        if filepath:
-            modelNode = slicer.util.loadModel(filepath)
-            modelNode.SetAttribute('isOpenLIFUPhotoscan', 'True')
-            self.updateInputOptions() # OnNodeAdded is called before the attribute is set
             
     def onLoadTransducerRegistrationSurfaceClicked(self):
         qsettings = qt.QSettings()

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>235</height>
+    <height>237</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -57,13 +57,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="loadPhotoscanButton">
-     <property name="text">
-      <string>Load photoscan</string>
-     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Closes #143 
Closes #147 
Closes #160 

This PR should be merged after PR #155. 

- [x] Create SlicerOpenLIFUPhotoscan
- [x] Add load photoscan button for user to select model or json file
- [x] Load openlifu photoscan using either json or model/texture filepaths and create SlicerOpenLIFU Photoscan object
- [x] Have a list of photoscans in the openlifu data module parameter node, and showing the loaded photoscans in the loaded objects view
- [x] Populate the list of photoscans in the transducer tracking module using these SlicerOpenLIFUPhotoscans
- [x] When should the texture get applied to the model node? - In the manual workflow, when a photoscan is loaded through the data module, the model and texture files are loaded into the scene and the texture gets displayed on the model node. In the treatment workflow, the dropdown bar shows all the photoscans that are in the 'loaded_photoscans' parameter node in a manual workflow, or all the photoscans associated with a session, if there is an active session. When there is an active session, the photoscans are not loaded into the scene. They will only get loaded when the user presses a button in the transducer tracking module to 'Load Photoscan into Scene' or 'Preview photoscan'.
- [x] Remove 'Load Photoscan' button from transducer tracking module. This will be replaced in a separate issue with a shortcut button to 'Add Photoscan to Session' - similar in functionality to the one included in the data module. 
- [x] Add a check to `OnNodeAboutToBeRemoved`. When the model or texture node associated with a SlicerOpenLIFUPhotoscan object is deleted, the associated photoscan object should be removed. Similar to how transducers work. 
- [x] TODO: Update open-lifu python version. Depends on https://github.com/OpenwaterHealth/OpenLIFU-python/pull/186
- [x] Depends on https://github.com/OpenwaterHealth/OpenLIFU-python/pull/199. Update open-lifu python version