### PR TITLE
Fix computeSolution inputs in OpenLIFUSonicationPlanner.py

### DIFF
--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -284,7 +284,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateInputOptions()
 
     def onComputeSolutionClicked(self):
-        activeProtocol, activeTransducer, activeVolume, activeTarget = self.algorithm_input_widget.get_current_data()
+        activeData = self.algorithm_input_widget.get_current_data()
 
         # In case a PNP was previously being displayed, hide it since it is about to no longer belong to the active solution.
         self.ui.renderPNPCheckBox.checked = False
@@ -294,7 +294,8 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             try:
                 self.ui.solutionProgressBar.maximum = 0
                 slicer.app.processEvents()
-                self.logic.computeSolution(activeVolume, activeTarget, activeTransducer, activeProtocol)
+                self.logic.computeSolution(activeData["Volume"], activeData["Target"],
+                                           activeData["Transducer"], activeData["Protocol"])
             finally:
                 self.updateSolutionProgressBar()
 


### PR DESCRIPTION
Closes #161 

Fixes the usage of `get_current_data()` within
`OpenLIFUSonicationPlannerWidget.onComputeSolutionClicked(self)` to use the dictionary returned by `get_current_data()`.

A prior implementation of `get_current_data()` returned a dictionary as opposed to a tuple. Therefore, when attempting to perform "Compute sonication solution" after loading a session in
`SlicerWithSlicerOpenLIFU`, the following error message occurred:

```
Traceback (most recent call last):
  File "/Users/user/projects/ow/SlicerOpenLIFU-Debug/lib/Slicer-5.7/qt-scripted-modules/OpenLIFUSonicationPlanner.py", line 297, in onComputeSolutionClicked
    self.logic.computeSolution(activeVolume, activeTarget, activeTransducer, activeProtocol)
  File "/Users/user/projects/ow/SlicerOpenLIFU-Debug/lib/Slicer-5.7/qt-scripted-modules/OpenLIFUSonicationPlanner.py", line 516, in computeSolution
    inputProtocol.protocol,
AttributeError: 'str' object has no attribute 'protocol'
```

This commit fixes the corresponding error message within the `SlicerWithSlicerOpenLIFU` app.