### PR TITLE
Add functionality to preview photoscan

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1229,6 +1229,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             ):
                 self.clear_solution(clean_up_scene=True)
             clear_virtual_fit_results(session_id = loaded_session.get_session_id(), target_id=None)
+            for photoscan_id in loaded_session.get_affiliated_photoscan_ids():
+                if photoscan_id in self.getParameterNode().loaded_photoscans:
+                    self.remove_photoscan(photoscan_id)
 
     def save_session(self) -> None:
         """Save the current session to the openlifu database.
@@ -1955,11 +1958,11 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         # If the user selects a json file,use the photoscan_metadata included in the json file to load the photoscan. 
         elif Path(model_or_json_filepath).suffix == '.json':
             photoscan_openlifu = openlifu_lz().photoscan.Photoscan.from_file(model_or_json_filepath)
-            return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = Path(model_or_json_filepath).parent)
+            return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = str(Path(model_or_json_filepath).parent))
         else:
             slicer.util.errorDisplay("Invalid photoscan filetype specified")
 
-    def load_photoscan_from_openlifu(self, photoscan_openlifu, load_from_active_session: bool = False, parent_dir: str = None, replace_confirmed : bool = False) -> SlicerOpenLIFUPhotoscan:
+    def load_photoscan_from_openlifu(self, photoscan_openlifu, load_from_active_session: bool = False, parent_dir: Optional[str] = None, replace_confirmed : bool = False) -> SlicerOpenLIFUPhotoscan:
         """Load an openlifu photoscan object into the scene as a SlicerOpenLIFUPhotoscan,
         adding it to the list of loaded openlifu objects.
 

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -213,7 +213,8 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
             Transducer: SlicerOpenLIFUTransducer
             Volume: vtkMRMLScalarVolumeNode
             Target: vtkMRMLMarkupsFiducialNode
-            Photoscan: vtkMRMLModelNode """
+            Photoscan: "openlifu.Photoscan"
+            """
         current_data_dict = {
             input.name : input.combo_box.currentData
             for input in self.inputs_dict.values()

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -72,14 +72,14 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
     def _clear_input_options(self):
         """Clear out input options, remembering what was most recently selected in order to be able to set that again later"""
         for input in self.inputs_dict.values():
-            input.most_recent_selection = input.combo_box.currentData
+            input.most_recent_selection = input.combo_box.currentText 
             input.combo_box.clear()
 
     def _set_most_recent_selections(self):
         """Set input options to their most recent selections when possible."""
         for input in self.inputs_dict.values():
             if input.most_recent_selection is not None:
-                most_recent_selection_index = input.combo_box.findData(input.most_recent_selection)
+                most_recent_selection_index = input.combo_box.findText(input.most_recent_selection)
                 if most_recent_selection_index != -1:
                     input.combo_box.setCurrentIndex(most_recent_selection_index)
 

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -123,9 +123,9 @@ class SlicerOpenLIFUPhotoscan:
         self.photoscan.photoscan.approved = not self.photoscan.photoscan.photoscan_approved 
     
     def toggle_model_display(self, visibility_on: bool = False, viewNode: vtkMRMLViewNode = None):
-        """ If a viewNode is not specified, the model is displayed in the default view"""
+        """ If a viewNode is not specified, the model is displayed in all views by default"""
         self.model_node.GetDisplayNode().SetVisibility(visibility_on)
         if viewNode:
-            self.model_node.GetDisplayNode().AddViewNodeID(viewNode.GetID())
+            self.model_node.GetDisplayNode().SetViewNodeIDs([viewNode.GetID()])
 
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 import vtk
 from pathlib import Path
 import slicer
-from slicer import vtkMRMLVectorVolumeNode, vtkMRMLModelNode
+from slicer import vtkMRMLVectorVolumeNode, vtkMRMLModelNode, vtkMRMLViewNode
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPhotoscanWrapper,
@@ -121,5 +121,11 @@ class SlicerOpenLIFUPhotoscan:
                        
     def toggle_approval(self) -> None:
         self.photoscan.photoscan.approved = not self.photoscan.photoscan.photoscan_approved 
+    
+    def toggle_model_display(self, visibility_on: bool = False, viewNode: vtkMRMLViewNode = None):
+        """ If a viewNode is not specified, the model is displayed in the default view"""
+        self.model_node.GetDisplayNode().SetVisibility(visibility_on)
+        if viewNode:
+            self.model_node.GetDisplayNode().AddViewNodeID(viewNode.GetID())
 
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -120,7 +120,7 @@ class SlicerOpenLIFUPhotoscan:
         return self.photoscan.photoscan.photoscan_approved
                        
     def toggle_approval(self) -> None:
-        self.photoscan.photoscan.approved = not self.photoscan.photoscan.photoscan_approved 
+        self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
     
     def toggle_model_display(self, visibility_on: bool = False, viewNode: vtkMRMLViewNode = None):
         """ If a viewNode is not specified, the model is displayed in all views by default"""

--- a/OpenLIFUTransducerTracker/CMakeLists.txt
+++ b/OpenLIFUTransducerTracker/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
+  Resources/UI/PhotoscanPreview.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -256,14 +256,12 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updatePhotoscanApprovalStatusLabel(photoscan.is_approved())
 
         def onPlaceLandmarksClicked():
-            markupsWidget = photoscanDialogUI.photoscanMarkupsPlaceWidget
+            markupsWidget = self.photoscanPreviewDialogUI.photoscanMarkupsPlaceWidget
             markupsWidget.enabled = True
             markupsWidget.setMRMLScene(slicer.mrmlScene)
             markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
-            #TODO: Markups shouldn't be displayed in main window
-            #markupsNode.GetDisplayNode().SetViewNodeIDs()
+            markupsNode.GetDisplayNode().SetViewNodeIDs([self.photoscanViewWidget.mrmlViewNode().GetID()])
             markupsWidget.setCurrentNode(slicer.mrmlScene.GetNodeByID(markupsNode.GetID()))
-            # w.buttonsVisible=False
     
         # Connect buttons
         self.photoscanPreviewDialogUI.photoscanApprovalButton.clicked.connect(onPhotoscanApproveClicked)

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -281,17 +281,19 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             updatePhotoscanApproveButton()
             updatePhotoscanApprovalStatusLabel()
 
+        def onPlaceLandmarksClicked():
+            markupsWidget = photoscanDialogUI.photoscanMarkupsPlaceWidget
+            markupsWidget.enabled = True
+            markupsWidget.setMRMLScene(slicer.mrmlScene)
+            markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+            #TODO: Markups shouldn't be displayed in main window
+            #markupsNode.GetDisplayNode().SetViewNodeIDs()
+            markupsWidget.setCurrentNode(slicer.mrmlScene.GetNodeByID(markupsNode.GetID()))
+            # w.buttonsVisible=False
+    
         photoscanDialogUI.photoscanApprovalButton.clicked.connect(onPhotoscanApproveClicked)
 
-        # w=slicer.qSlicerMarkupsPlaceWidget()
-        # w.setMRMLScene(slicer.mrmlScene)
-        # markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
-        # #TODO: Markups shouldn't be displayed in main window
-        # #markupsNode.GetDisplayNode().SetViewNodeIDs()
-        # w.setCurrentNode(slicer.mrmlScene.GetNodeByID(markupsNode.GetID()))
-        # # w.buttonsVisible=False
-        # # w.placeButton().show()
-        # photoscanDialogUI.layout.addWidget(w)
+        photoscanDialogUI.placeLandmarksButton.clicked.connect(onPlaceLandmarksClicked)
 
         # Display dialog
         photoscanDialog.exec_()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -220,16 +220,17 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         current_data = self.algorithm_input_widget.get_current_data()
         selected_photoscan_openlifu = current_data['Photoscan']
 
-        # Session-based workflow
-        if get_openlifu_data_parameter_node().loaded_session:
-            loaded_slicer_photoscan = slicer.util.getModuleLogic('OpenLIFUData').load_photoscan_from_openlifu(
-                selected_photoscan_openlifu,
-                load_from_active_session = True)
-        
-        # Manual workflow
-        else:
+        # In the manual workflow or if the photoscan has been previously loaded as part of a session
+        if selected_photoscan_openlifu.id in get_openlifu_data_parameter_node().loaded_photoscans:
             loaded_slicer_photoscan = get_openlifu_data_parameter_node().loaded_photoscans[selected_photoscan_openlifu.id]
-            
+        elif get_openlifu_data_parameter_node().loaded_session:
+            loaded_slicer_photoscan = slicer.util.getModuleLogic('OpenLIFUData').load_photoscan_from_openlifu(
+                    selected_photoscan_openlifu,
+                    load_from_active_session = True)
+        # This shouldn't happen - can't click the Preview button without a loaded photoscan or session
+        else:
+            raise RuntimeError("No photoscans found to preview.") 
+        
         self.DisplayPhotoscanPreviewDialog(loaded_slicer_photoscan)
 
     def DisplayPhotoscanPreviewDialog(self,photoscan: SlicerOpenLIFUPhotoscan):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -123,6 +123,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.runTrackingButton.clicked.connect(self.onRunTrackingClicked)
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
         self.ui.skinSegmentationModelqMRMLNodeComboBox.currentNodeChanged.connect(self.checkCanRunTracking)
+        self.ui.previewPhotoscanButton.clicked.connect(self.onPreviewPhotoscanClicked)
 
         self.updateApproveButton()
         self.updateApprovalStatusLabel()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -268,9 +268,14 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             markupsNode.GetDisplayNode().SetViewNodeIDs([self.photoscanViewWidget.mrmlViewNode().GetID()])
             markupsWidget.setCurrentNode(slicer.mrmlScene.GetNodeByID(markupsNode.GetID()))
     
-        # Connect buttons
+        def onDialogFinished():
+            # Turn off model visibility
+            photoscan.toggle_model_display(False)
+
+        # Connect buttons and signals
         self.photoscanPreviewDialogUI.photoscanApprovalButton.clicked.connect(onPhotoscanApproveClicked)
-        self.photoscanPreviewDialogUI.placeLandmarksButton.clicked.connect(onPlaceLandmarksClicked)
+        self.photoscanPreviewDialogUI.placeLandmarksButton.clicked.connect(onPlaceLandmarksClicked) 
+        self.photoscanPreviewDialog.finished.connect(onDialogFinished)
 
         # Display dialog
         self.photoscanPreviewDialog.exec_()
@@ -316,7 +321,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # IDs of all the view nodes in the main Window. This excludes the photoscan widget's view node
         views_mainwindow = [node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') if node.GetName() != photoscan_view_node.GetName()]
         
-        # Set the view nodes for all displayable nodes
+        # Set the view nodes for all displayable nodes.
         for displayable_node in list(slicer.util.getNodesByClass('vtkMRMLDisplayableNode')):
             if displayable_node.IsA('vtkMRMLScalarVolumeNode'):
                 # Check for any volume renderings

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -129,7 +129,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         self.ui.runTrackingButton.clicked.connect(self.onRunTrackingClicked)
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
-        self.ui.skinSegmentationModelqMRMLNodeComboBox.currentNodeChanged.connect(self.checkCanRunTracking)
+        self.ui.skinSegmentationModelqMRMLNodeComboBox.currentNodeChanged.connect(self.checkCanRunTracking) # Temporary functionality
         self.ui.previewPhotoscanButton.clicked.connect(self.onPreviewPhotoscanClicked)
 
         self.updateApproveButton()
@@ -211,6 +211,9 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # Determine whether transducer tracking can be run based on the status of combo boxes
         self.checkCanRunTracking()
+
+        # Determine whether a photoscan can be previewed based on the status of the photoscan combo box
+        self.checkCanPreviewPhotoscan()
             
     def onPreviewPhotoscanClicked(self):
 
@@ -368,6 +371,16 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 self.photoscanPreviewDialogUI.photoscanApprovalStatusLabel.text = "Photoscan is not approved for transducer tracking"
         else:
             self.photoscanPreviewDialogUI.photoscanApprovalStatusLabel.text = f"Photoscan approval status: {photoscan_is_approved}."
+
+    def checkCanPreviewPhotoscan(self,caller = None, event = None) -> None:
+        # If the photoscan combo box has valid data selected then enable the preview photoscan button
+        current_data = self.algorithm_input_widget.get_current_data()
+        if current_data['Photoscan'] is None:
+            self.ui.previewPhotoscanButton.enabled = False
+            self.ui.previewPhotoscanButton.setToolTip("Please specify a photoscan to preview")
+        else:
+            self.ui.previewPhotoscanButton.enabled = True
+            self.ui.previewPhotoscanButton.setToolTip("Preview and toggle approval of the selected photoscan before registration")
 
     def checkCanRunTracking(self,caller = None, event = None) -> None:
         # If all the needed objects/nodes are loaded within the Slicer scene, all of the combo boxes will have valid data selected

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -242,6 +242,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Create dialog for photoscan preview and add threeD view widget to dialog
         self.photoscanPreviewDialog = slicer.util.loadUI(self.resourcePath("UI/PhotoscanPreview.ui"))
         self.photoscanPreviewDialogUI = slicer.util.childWidgetVariables(self.photoscanPreviewDialog)
+        self.photoscanPreviewDialog.setWindowTitle("Photoscan Preview")
         replace_widget(self.photoscanPreviewDialogUI.photoscanPlaceholderWidget, self.photoscanViewWidget, self.photoscanPreviewDialogUI)
         
         self.updatePhotoscanApproveButton(photoscan.is_approved())

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -399,6 +399,11 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             elif transducer.surface_model_node is None and self.ui.skinSegmentationModelqMRMLNodeComboBox.currentNode():
                 self.ui.runTrackingButton.enabled = False
                 self.ui.runTrackingButton.setToolTip("The selected transducer does not have an affiliated registration surface model, which is needed to run tracking.")
+            else:
+                # transducer surface model is None and skin segmentation model is None
+                self.ui.runTrackingButton.enabled = False
+                self.ui.runTrackingButton.setToolTip(
+                    "The selected transducer does not have an affiliated registration surface model, which is needed to run tracking. Please also specify a skin segmentation model.")
         else:
             self.ui.runTrackingButton.enabled = False
             self.ui.runTrackingButton.setToolTip("Please specify the required inputs")

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -505,8 +505,7 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
                               inputProtocol: SlicerOpenLIFUProtocol,
                               inputTransducer : SlicerOpenLIFUTransducer,
                               inputSkinSegmentation: vtkMRMLModelNode,
-                              inputPhotoscan: vtkMRMLModelNode,
-                              inputTRS: vtkMRMLModelNode
+                              inputPhotoscan: vtkMRMLModelNode
                               ) -> Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]:
         ## Need to integrate with transducer tracking library here
         slicer.util.infoDisplay(

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -81,23 +81,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="loadTransducerSurfaceButton">
-        <property name="text">
-         <string>Load transducer registration surface</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QPushButton" name="previewPhotoscanButton">
         <property name="text">
          <string>Preview Photoscan</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="loadTransducerSurfaceButton">
-        <property name="text">
-         <string>Load transducer registration surface</string>
         </property>
        </widget>
       </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -88,6 +88,20 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="previewPhotoscanButton">
+        <property name="text">
+         <string>Preview Photoscan</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="loadTransducerSurfaceButton">
+        <property name="text">
+         <string>Load transducer registration surface</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="runTrackingButton">
         <property name="text">
          <string>Run transducer tracking</string>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -33,10 +33,37 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="placeLandmarksButton">
+       <property name="text">
+        <string>Place Registration Landmarks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="qSlicerMarkupsPlaceWidget" name="photoscanMarkupsPlaceWidget">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerMarkupsPlaceWidget</class>
+   <extends>qSlicerWidget</extends>
+   <header>qSlicerMarkupsPlaceWidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>518</width>
+    <width>526</width>
     <height>384</height>
    </rect>
   </property>
@@ -15,21 +15,21 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="layout">
-     <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
       <widget class="QWidget" name="photoscanPlaceholderWidget" native="true"/>
      </item>
      <item>
-      <widget class="QLabel" name="photoscanApprovalStatus">
+      <widget class="QLabel" name="photoscanApprovalStatusLabel">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="approvePushButton">
+      <widget class="QPushButton" name="photoscanApprovalButton">
        <property name="text">
-        <string>PushButton</string>
+        <string>Approve Photoscan</string>
        </property>
       </widget>
      </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>PhotoscanPreview</class>
+ <widget class="QDialog" name="PhotoscanPreview">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>518</width>
+    <height>384</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="layout">
+     <item>
+      <widget class="QWidget" name="photoscanPlaceholderWidget" native="true"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="photoscanApprovalStatus">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="approvePushButton">
+       <property name="text">
+        <string>PushButton</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Closes #148 
Partly addresses the manual step of putting facial landmarks on the photoscans by introducing the markups widget within the preview dialog (#149)

In this PR, when the user clicks 'Place Registration Landmarks' a markups node is added to the scene and associated with the markups widget in the preview dialog. Further work is needed to add the created markups node to the photoscan object, ensure that any previously created markups node shows up in the dialog etc. This will be handled as part of a separate PR addressing https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/149. The current PR focuses on introducing the preview dialog and toggling the approval status of a photoscan during the session-based workflow. 

- [x] Rebase to main after merging https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/159
- [x] Disable the photoscan preview button when there are no valid inputs selected.