### PR TITLE
Create simple login module

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0db543a787fc61b59958f8689987a9308c6fe183
+bcrypt

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -1,4 +1,4 @@
-from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz
+from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz, bcrypt_lz
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPoint,
     SlicerOpenLIFUXADataset,
@@ -27,6 +27,7 @@ from OpenLIFULib.solution import SlicerOpenLIFUSolution
 __all__ = [
     "openlifu_lz",
     "xarray_lz",
+    "bcrypt_lz",
     "SlicerOpenLIFUSolution",
     "SlicerOpenLIFUProtocol",
     "SlicerOpenLIFUTransducer",

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -5,6 +5,7 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFURun,
     SlicerOpenLIFUSolutionAnalysis,
+    SlicerOpenLIFUUser,
 )
 from OpenLIFULib.transducer import SlicerOpenLIFUTransducer
 from OpenLIFULib.photoscan import SlicerOpenLIFUPhotoscan

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "SlicerOpenLIFURun",
     "SlicerOpenLIFUSolutionAnalysis",
     "SlicerOpenLIFUPhotoscan",
+    "SlicerOpenLIFUUser",
     "get_openlifu_data_parameter_node",
     "BusyCursor",
     "get_target_candidates",

--- a/OpenLIFULib/OpenLIFULib/lazyimport.py
+++ b/OpenLIFULib/OpenLIFULib/lazyimport.py
@@ -65,3 +65,11 @@ def xarray_lz() -> "xarray":
         check_and_install_python_requirements(prompt_if_found=False)
         import xarray
     return sys.modules["xarray"]
+
+def bcrypt_lz() -> "bcrypt":
+    """Import bcrypt and return the module, checking that it is installed along the way."""
+    if "bcrypt" not in sys.modules:
+        check_and_install_python_requirements(prompt_if_found=False)
+        with BusyCursor():
+            import bcrypt
+    return sys.modules["bcrypt"]

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -93,6 +93,13 @@ class SlicerOpenLIFUPhotoscanWrapper:
     def __init__(self, photoscan: "Optional[openlifu.Photoscan]" = None):
         self.photoscan = photoscan
 
+# For the same reason we have a thin wrapper around openlifu.User
+class SlicerOpenLIFUUser:
+    """Ultrathin wrapper of openlifu.User. This exists so that users can have parameter node
+    support while we still do lazy-loading of openlifu."""
+    def __init__(self, user: "Optional[openlifu.User]" = None):
+        self.user = user
+
 def SlicerOpenLIFUSerializerBaseMaker(
         serialized_type:type,
         default_args:Optional[list[Any]] = None,

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -97,7 +97,7 @@ class SlicerOpenLIFUPhotoscanWrapper:
 class SlicerOpenLIFUUser:
     """Ultrathin wrapper of openlifu.User. This exists so that users can have parameter node
     support while we still do lazy-loading of openlifu."""
-    def __init__(self, user: "Optional[openlifu.User]" = None):
+    def __init__(self, user: "Optional[openlifu.db.User]" = None):
         self.user = user
 
 def SlicerOpenLIFUSerializerBaseMaker(

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -284,6 +284,25 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().photoscan.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
+class OpenLIFUUserSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUUser)):
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUUser) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        """
+        parameterNode.SetParameter(
+            name,
+            value.user.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUUser:
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        json_string = parameterNode.GetParameter(name)    
+        return SlicerOpenLIFUUser(openlifu_lz().db.User.from_json(json_string))
+
+
+@parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):
     def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUXADataset) -> None:
         """

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -284,25 +284,6 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().photoscan.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
-class OpenLIFUUserSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUUser)):
-    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUUser) -> None:
-        """
-        Writes the value to the parameterNode under the given name.
-        """
-        parameterNode.SetParameter(
-            name,
-            value.user.to_json(compact=True)
-        )
-
-    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUUser:
-        """
-        Reads and returns the value with the given name from the parameterNode.
-        """
-        json_string = parameterNode.GetParameter(name)    
-        return SlicerOpenLIFUUser(openlifu_lz().db.User.from_json(json_string))
-
-
-@parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):
     def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUXADataset) -> None:
         """

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -2,6 +2,7 @@ from typing import Optional, TYPE_CHECKING
 
 from OpenLIFULib.util import (
         get_openlifu_login_parameter_node,
+        get_openlifu_login_logic,
         )
 
 if TYPE_CHECKING:
@@ -11,7 +12,7 @@ def get_current_user() -> "Optional[openlifu.db.User]":
     """Get the active openlifu user. If no user is logged in or user account
     mode is off, a default user is returned, with the intention of being the most
     restricted"""
-    return get_openlifu_login_parameter_node().active_user.user
+    return get_openlifu_login_logic().active_user.user
 
 def get_user_account_mode_state() -> bool:
     """Get user account mode state from the OpenLIFU Login module's parameter node"""

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -1,6 +1,15 @@
+from typing import Optional, TYPE_CHECKING
+
 from OpenLIFULib.util import (
         get_openlifu_login_parameter_node,
         )
+
+if TYPE_CHECKING:
+    import openlifu.db
+
+def get_current_user() -> "Optional[openlifu.db.User]":
+    """Get the active openlifu user"""
+    return get_openlifu_login_parameter_node().active_user.user
 
 def get_user_account_mode_state() -> bool:
     """Get user account mode state from the OpenLIFU Login module's parameter node"""

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
     import openlifu.db
 
 def get_current_user() -> "Optional[openlifu.db.User]":
-    """Get the active openlifu user"""
+    """Get the active openlifu user. If no user is logged in or user account
+    mode is off, a default user is returned, with the intention of being the most
+    restricted"""
     return get_openlifu_login_parameter_node().active_user.user
 
 def get_user_account_mode_state() -> bool:

--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -5,6 +5,7 @@ import slicer
 if TYPE_CHECKING:
     from OpenLIFUData.OpenLIFUData import OpenLIFUDataParameterNode
     from OpenLIFULogin.OpenLIFULogin import OpenLIFULoginParameterNode
+    from OpenLIFULogin.OpenLIFULogin import OpenLIFULoginLogic
 
 class BusyCursor:
     """
@@ -26,6 +27,10 @@ def get_openlifu_data_parameter_node() -> "OpenLIFUDataParameterNode":
 def get_openlifu_login_parameter_node() -> "OpenLIFULoginParameterNode":
     """Get the parameter node of the OpenLIFU Login module"""
     return slicer.util.getModuleLogic('OpenLIFULogin').getParameterNode()
+
+def get_openlifu_login_logic() -> "OpenLIFULoginLogic":
+    """Get the logic of the OpenLIFU Login module"""
+    return slicer.util.getModuleLogic('OpenLIFULogin')
 
 def display_errors(f):
     """Decorator to make functions forward their python exceptions along as slicer error displays"""

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -149,6 +149,13 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self._cur_login_state = LoginState.NOT_LOGGED_IN
         self._parameterNode = None
         self._parameterNodeGuiTag = None
+        self._default_anonymous_user = SlicerOpenLIFUUser(openlifu_lz().db.User(
+                id = "anonymous", 
+                password_hash = "",
+                roles = [],
+                name = "Anonymous",
+                description = "This is the default role set when the app opens, without anyone logged in, and when user account mode is deactivated. It has no roles, and therefore is the most restricted."
+        ))
 
     def setup(self) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
@@ -189,14 +196,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.updateUserAccountModeButton()
         self.updateLoginButton()
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
-        default_anonymous_user = SlicerOpenLIFUUser(openlifu_lz().db.User(
-                id = "anonymous", 
-                password_hash = "",
-                roles = [],
-                name = "Anonymous",
-                description = "This is the default anonymous role automatically assigned when the app opens, before anyone is logged in. It has no roles, and therefore is the most restricted."
-                ))
-        self._parameterNode.active_user = default_anonymous_user
+        self._parameterNode.active_user = self._default_anonymous_user
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -258,7 +258,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if new_user_account_mode_state:
             self.logic.start_user_account_mode()
         else:
-            self._parameterNode.active_user = None
+            self._parameterNode.active_user = self._default_anonymous_user
             self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
             set_user_account_mode_state(new_user_account_mode_state)
 
@@ -287,7 +287,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     @display_errors
     def onLogoutClicked(self, checked:bool):
-        self._parameterNode.active_user = None
+        self._parameterNode.active_user = self._default_anonymous_user
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
 
     def updateLoginButton(self):

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -20,6 +20,7 @@ from slicer import (
 
 from OpenLIFULib import (
     openlifu_lz,
+    SlicerOpenLIFUUser,
 )
 
 if TYPE_CHECKING:
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
 # OpenLIFULogin
 #
 
+all_openlifu_modules = ['OpenLIFUData', 'OpenLIFUHome', 'OpenLIFUPrePlanning', 'OpenLIFUProtocolConfig', 'OpenLIFUSonicationControl', 'OpenLIFUSonicationPlanner', 'OpenLIFUTransducerTracker']
+
 class OpenLIFULogin(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
@@ -39,7 +42,7 @@ class OpenLIFULogin(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Login")  # TODO: make this more human readable by adding spaces
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = []  # add here list of module names that this module requires
+        self.parent.dependencies = all_openlifu_modules  # add here list of module names that this module requires
         self.parent.contributors = ["Andrew Howe (Kitware), Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware), Brad Moore (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -61,6 +64,49 @@ class OpenLIFULogin(ScriptedLoadableModule):
 @parameterNodeWrapper
 class OpenLIFULoginParameterNode:
     user_account_mode : bool
+    active_user : "SlicerOpenLIFUUser"
+    
+#
+# OpenLIFULoginDialogs
+#
+
+class UsernamePasswordDialog(qt.QDialog):
+    """ Login with Username and Password dialog """
+
+    def __init__(self, parent="mainWindow"):
+        super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
+        self.setWindowTitle("Login credentials")
+        self.setWindowModality(1)
+        self.setup()
+
+    def setup(self):
+
+        self.setMinimumWidth(200)
+
+        formLayout = qt.QFormLayout()
+        self.setLayout(formLayout)
+
+        self.username = qt.QLineEdit()
+        formLayout.addRow(_("Username:"), self.username)
+
+        self.password = qt.QLineEdit()
+        formLayout.addRow(_("Password:"), self.password)
+
+        self.buttonBox = qt.QDialogButtonBox()
+        self.buttonBox.setStandardButtons(qt.QDialogButtonBox.Ok |
+                                          qt.QDialogButtonBox.Cancel)
+        formLayout.addWidget(self.buttonBox)
+
+        self.buttonBox.rejected.connect(self.reject)
+        self.buttonBox.accepted.connect(self.accept)
+
+    def customexec_(self):
+
+        returncode = self.exec_()
+        subject_name = self.username.text
+        subject_id = self.password.text
+
+        return (returncode, subject_name, subject_id)
 
 #
 # OpenLIFULoginWidget

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -179,6 +179,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.ui.userAccountModePushButton.clicked.connect(self.onUserAccountModeClicked)
         self.ui.loginButton.clicked.connect(self.onLoginClicked)
+        self.ui.logoutButton.clicked.connect(self.onLogoutClicked)
 
         # ====================================
         
@@ -284,6 +285,11 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.updateWidgetLoginState(LoginState.LOGGED_IN)
         slicer.util.selectModule('OpenLIFUHome')
 
+    @display_errors
+    def onLogoutClicked(self, checked:bool):
+        self._parameterNode.active_user = None
+        self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
+
     def updateLoginButton(self):
 
         # === Multiple things can block the login button ===
@@ -321,9 +327,21 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.loginButton.setEnabled(True)
         self.ui.loginButton.setToolTip("Login to an account in the database.")
 
+    def updateLogoutButton(self):
+
+        # === Can only logout when logged in ===
+
+        if self._cur_login_state == LoginState.LOGGED_IN:
+            self.ui.logoutButton.setEnabled(True)
+            self.ui.logoutButton.setToolTip("Logout to an account in the database.")
+        else:
+            self.ui.logoutButton.setEnabled(False)
+            self.ui.logoutButton.setToolTip("You must be logged in to logout")
+
     def updateWidgetLoginState(self, state: LoginState):
         self._cur_login_state = state
         self.updateLoginStateNotificationLabel()
+        self.updateLogoutButton()
 
     def updateLoginStateNotificationLabel(self):
         if self._cur_login_state == LoginState.NOT_LOGGED_IN:

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -68,6 +68,7 @@ class LoginState(Enum):
     NOT_LOGGED_IN=0
     UNSUCCESSFUL_LOGIN=1
     LOGGED_IN=2
+    DEFAULT_ADMIN=3
 
 #
 # OpenLIFULoginParameterNode
@@ -276,7 +277,6 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         matched_user = next((u for u in users if u.id == user_id and verify_password(password_text, u.password_hash)), None)
 
         if not matched_user:
-            self._parameterNode.active_user = None
             self.updateWidgetLoginState(LoginState.UNSUCCESSFUL_LOGIN)
             return
 
@@ -312,6 +312,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     description = "This is the default admin role automatically assigned if an admin user does not exist in the loaded database."
                     ))
             self._parameterNode.active_user = default_admin_user
+            self.updateWidgetLoginState(LoginState.DEFAULT_ADMIN)
             slicer.util.selectModule('OpenLIFUHome')
             return
 
@@ -337,6 +338,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             text_color = palette.color(qt.QPalette.WindowText).name()
             self.ui.loginStateNotificationLabel.setProperty("text", f"Welcome, {self._parameterNode.active_user.user.name}!")
             self.ui.loginStateNotificationLabel.setProperty("styleSheet", f"color: {text_color}; font-weight: bold; font-size: 16px; border: none;")
+        elif self._cur_login_state == LoginState.DEFAULT_ADMIN:
+            self.ui.loginStateNotificationLabel.setProperty("text", f"Welcome! Please create an admin account for user accounts to work.")
 
     def updateUserAccountModeButton(self):
         if self._parameterNode.user_account_mode:

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -204,7 +204,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """Called each time the user opens this module."""
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
-        self.updateLoginStateLabel()
+        self.updateLoginStateNotificationLabel()
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
@@ -320,21 +320,21 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def updateWidgetLoginState(self, state: LoginState):
         self._cur_login_state = state
-        self.updateLoginStateLabel()
+        self.updateLoginStateNotificationLabel()
 
-    def updateLoginStateLabel(self):
+    def updateLoginStateNotificationLabel(self):
         if self._cur_login_state == LoginState.NOT_LOGGED_IN:
-            self.ui.loginStateLabel.setProperty("text", "")  
-            self.ui.loginStateLabel.setProperty("styleSheet", "border: none;")
+            self.ui.loginStateNotificationLabel.setProperty("text", "")  
+            self.ui.loginStateNotificationLabel.setProperty("styleSheet", "border: none;")
         elif self._cur_login_state == LoginState.UNSUCCESSFUL_LOGIN:
-            self.ui.loginStateLabel.setProperty("text", "Unsuccessful login. Please try again.")
-            self.ui.loginStateLabel.setProperty("styleSheet", "color: red; font-size: 16px; border: 1px solid red;")
+            self.ui.loginStateNotificationLabel.setProperty("text", "Unsuccessful login. Please try again.")
+            self.ui.loginStateNotificationLabel.setProperty("styleSheet", "color: red; font-size: 16px; border: 1px solid red;")
         elif self._cur_login_state == LoginState.LOGGED_IN:
             # We want the regular text, night-mode agnostic
             palette = qt.QApplication.instance().palette()
             text_color = palette.color(qt.QPalette.WindowText).name()
-            self.ui.loginStateLabel.setProperty("text", f"Welcome, {self._parameterNode.active_user.user.name}!")
-            self.ui.loginStateLabel.setProperty("styleSheet", f"color: {text_color}; font-weight: bold; font-size: 16px; border: none;")
+            self.ui.loginStateNotificationLabel.setProperty("text", f"Welcome, {self._parameterNode.active_user.user.name}!")
+            self.ui.loginStateNotificationLabel.setProperty("styleSheet", f"color: {text_color}; font-weight: bold; font-size: 16px; border: none;")
 
     def updateUserAccountModeButton(self):
         if self._parameterNode.user_account_mode:

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -256,6 +256,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if new_user_account_mode_state:
             self.logic.start_user_account_mode()
         else:
+            self._parameterNode.active_user = None
+            self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
             set_user_account_mode_state(new_user_account_mode_state)
 
         self.updateLoginButton()

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -398,4 +398,3 @@ class OpenLIFULoginLogic(ScriptedLoadableModuleLogic):
 
     def start_user_account_mode(self):
         set_user_account_mode_state(True)
-        slicer.util.selectModule("OpenLIFULogin")

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -64,7 +64,7 @@ class OpenLIFULogin(ScriptedLoadableModule):
 @parameterNodeWrapper
 class OpenLIFULoginParameterNode:
     user_account_mode : bool
-    active_user : "SlicerOpenLIFUUser"
+    active_user : "Optional[SlicerOpenLIFUUser]"
     
 #
 # OpenLIFULoginDialogs

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -32,7 +32,7 @@
         </widget>
       </item>
       <item>
-        <widget class="QLabel" name="loginStateLabel">
+        <widget class="QLabel" name="loginStateNotificationLabel">
           <property name="alignment">
             <set>Qt::AlignCenter</set>
           </property>

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -1,59 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>OpenLIFULogin</class>
- <widget class="qMRMLWidget" name="OpenLIFULogin">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>298</width>
-    <height>347</height>
-   </rect>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QPushButton" name="userAccountModePushButton">
-     <property name="text">
-      <string>Start User Account Mode</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-     <property name="default">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-    <item>
-      <widget class="QPushButton" name="loginButton">
-        <property name="text">
-          <string>Login</string>
-        </property>
-      </widget>
-    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections/>
+  <class>OpenLIFULogin</class>
+  <widget class="qMRMLWidget" name="OpenLIFULogin">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>298</width>
+        <height>347</height>
+      </rect>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+        <widget class="QPushButton" name="userAccountModePushButton">
+          <property name="text">
+            <string>Start User Account Mode</string>
+          </property>
+          <property name="autoDefault">
+            <bool>false</bool>
+          </property>
+          <property name="default">
+            <bool>false</bool>
+          </property>
+        </widget>
+      </item>
+      <item>
+        <widget class="QPushButton" name="loginButton">
+          <property name="text">
+            <string>Login</string>
+          </property>
+        </widget>
+      </item>
+      <item>
+        <widget class="QLabel" name="loginStateLabel">
+          <property name="alignment">
+            <set>Qt::AlignCenter</set>
+          </property>
+        </widget>
+      </item>
+      <item>
+        <spacer name="verticalSpacer">
+          <property name="orientation">
+            <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+            <size>
+              <width>20</width>
+              <height>40</height>
+            </size>
+          </property>
+        </spacer>
+      </item>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>qMRMLWidget</class>
+      <extends>QWidget</extends>
+      <header>qMRMLWidget.h</header>
+      <container>1</container>
+    </customwidget>
+  </customwidgets>
+  <resources />
+  <connections />
 </ui>

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -24,6 +24,13 @@
      </property>
     </widget>
    </item>
+    <item>
+      <widget class="QPushButton" name="loginButton">
+        <property name="text">
+          <string>Login</string>
+        </property>
+      </widget>
+    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -25,16 +25,9 @@
         </widget>
       </item>
       <item>
-        <widget class="QPushButton" name="loginButton">
+        <widget class="QPushButton" name="loginLogoutButton">
           <property name="text">
             <string>Login</string>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <widget class="QPushButton" name="logoutButton">
-          <property name="text">
-            <string>Logout</string>
           </property>
         </widget>
       </item>

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -32,6 +32,13 @@
         </widget>
       </item>
       <item>
+        <widget class="QPushButton" name="logoutButton">
+          <property name="text">
+            <string>Logout</string>
+          </property>
+        </widget>
+      </item>
+      <item>
         <widget class="QLabel" name="loginStateNotificationLabel">
           <property name="alignment">
             <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Closes #172 

Some decisions are still to be made, such as whether "Login" should be a button, or whether the fields should be directly in the widget.

If you want to test logging in, the credentials are given thus (`username/password`):
```
complex_user/complex_user_hash
example_admin/example_admin_hash
example_operator/example_operator_hash
example_restricted/example_restricted_hash
```

Note that you will have to update the database to the version in OpenLIFU-Python [PR#215](https://github.com/OpenwaterHealth/OpenLIFU-python/pull/215), as passwords are checked against the salted hashes, not the password text.