### PR TITLE
Enforce user permissions

### DIFF
--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -19,7 +19,7 @@
      <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
        <widget class="QLabel" name="databaseDirectoryLabel">
         <property name="text">
@@ -45,31 +45,55 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="newSubjectButton">
-        <property name="text">
-         <string>Add New Subject</string>
+       <widget class="QWidget" name="permissionsWidget2" native="true">
+        <property name="slicer.openlifu.allowed-roles" stdset="0">
+         <stringlist>
+          <string>admin</string>
+          <string>operator</string>
+         </stringlist>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="addVolumeToSubjectButton">
-        <property name="text">
-         <string>Add Volume to Subject</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="newSessionButton">
-        <property name="text">
-         <string>Create New Session</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="addPhotoscanToSessionButton">
-        <property name="text">
-         <string>Add Photoscan to Session</string>
-        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="newSubjectButton">
+           <property name="text">
+            <string>Add New Subject</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="addVolumeToSubjectButton">
+           <property name="text">
+            <string>Add Volume to Subject</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="newSessionButton">
+           <property name="text">
+            <string>Create New Session</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="addPhotoscanToSessionButton">
+           <property name="text">
+            <string>Add Photoscan to Session</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -104,7 +128,7 @@
      <property name="collapsed">
       <bool>true</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
+     <layout class="QVBoxLayout" name="verticalLayout_10">
       <item>
        <widget class="QScrollArea" name="scrollArea">
         <property name="sizePolicy">
@@ -262,10 +286,34 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="saveSessionButton">
-        <property name="text">
-         <string>Save Session</string>
+       <widget class="QWidget" name="permissionsWidget1" native="true">
+        <property name="slicer.openlifu.allowed-roles" stdset="0">
+         <stringlist>
+          <string>admin</string>
+          <string>operator</string>
+         </stringlist>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="saveSessionButton">
+           <property name="text">
+            <string>Save Session</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -284,6 +284,25 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().photoscan.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
+class OpenLIFUUserSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUUser)):
+    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUUser) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        """
+        parameterNode.SetParameter(
+            name,
+            value.user.to_json(compact=True)
+        )
+
+    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUUser:
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        json_string = parameterNode.GetParameter(name)    
+        return SlicerOpenLIFUUser(openlifu_lz().db.User.from_json(json_string))
+
+
+@parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):
     def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUXADataset) -> None:
         """

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -40,6 +40,12 @@ if TYPE_CHECKING:
 
 all_openlifu_modules = ['OpenLIFUData', 'OpenLIFUHome', 'OpenLIFUPrePlanning', 'OpenLIFUProtocolConfig', 'OpenLIFUSonicationControl', 'OpenLIFUSonicationPlanner', 'OpenLIFUTransducerTracker']
 
+anonymous_permissions = []
+restricted_permissions = anonymous_permissions + []
+operator_permissions = restricted_permissions + ['create-session-and-add-data', 'set-target', 'virtual-fitting', 'transducer-tracking', 'create-solution', 'run-sonication']
+admin_permissions = operator_permissions + ['manage-users', 'configure-and-publish-protocol']
+root_permissions = admin_permissions + []
+
 class OpenLIFULogin(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -402,6 +402,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # === Don't enforce if no user account mode ===
 
         if not self._parameterNode.user_account_mode:
+            for widget in self._permissions_widgets:
+                widget.setEnabled(True)
             return
 
         # === Check cache if there is an active user ===

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>OpenLIFULogin</class>
-  <widget class="qMRMLWidget" name="OpenLIFULogin">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>298</width>
-        <height>347</height>
-      </rect>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-        <widget class="QPushButton" name="userAccountModePushButton">
-          <property name="text">
-            <string>Start User Account Mode</string>
-          </property>
-          <property name="autoDefault">
-            <bool>false</bool>
-          </property>
-          <property name="default">
-            <bool>false</bool>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <widget class="QPushButton" name="loginLogoutButton">
-          <property name="text">
-            <string>Login</string>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <widget class="QLabel" name="loginStateNotificationLabel">
-          <property name="alignment">
-            <set>Qt::AlignCenter</set>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <spacer name="verticalSpacer">
-          <property name="orientation">
-            <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-            <size>
-              <width>20</width>
-              <height>40</height>
-            </size>
-          </property>
-        </spacer>
-      </item>
-    </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>qMRMLWidget</class>
-      <extends>QWidget</extends>
-      <header>qMRMLWidget.h</header>
-      <container>1</container>
-    </customwidget>
-  </customwidgets>
-  <resources />
-  <connections />
+ <class>OpenLIFULogin</class>
+ <widget class="qMRMLWidget" name="OpenLIFULogin">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>298</width>
+    <height>347</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPushButton" name="userAccountModePushButton">
+     <property name="text">
+      <string>Start User Account Mode</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="loginLogoutButton">
+     <property name="text">
+      <string>Login</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="loginStateNotificationLabel">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
 </ui>

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -32,13 +32,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="logoutButton">
-     <property name="text">
-      <string>Logout</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QLabel" name="loginStateNotificationLabel">
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -32,6 +32,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="logoutButton">
+     <property name="text">
+      <string>Logout</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="loginStateNotificationLabel">
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -202,7 +202,7 @@ OpenLIFUAlgorithmInputWidget</string>
   <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
-   <header>ctkcollapsiblebutton.h</header>
+   <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -19,159 +19,207 @@
      <property name="collapsed" stdset="0">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
-       <widget class="QListWidget" name="targetListWidget"/>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="positionGroupBox">
-        <property name="title">
-         <string>Target position (RAS)</string>
+       <widget class="QWidget" name="permissionsWidget1" native="true">
+        <property name="slicer.openlifu.allowed-roles" stdset="0">
+         <stringlist>
+          <string>admin</string>
+          <string>operator</string>
+         </stringlist>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          <widget class="QListWidget" name="targetListWidget"/>
          </item>
          <item>
-          <widget class="QLineEdit" name="positionRLineEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QGroupBox" name="positionGroupBox">
+           <property name="title">
+            <string>Target position (RAS)</string>
            </property>
-           <property name="maximumSize">
-            <size>
-             <width>60</width>
-             <height>16777215</height>
-            </size>
-           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="positionRLineEdit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="positionALineEdit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="positionSLineEdit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="lockButton">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="positionALineEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>60</width>
-             <height>16777215</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="positionSLineEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>60</width>
-             <height>16777215</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="lockButton">
+          <widget class="QPushButton" name="newTargetButton">
            <property name="text">
-            <string/>
+            <string>Place new target...</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+          <widget class="QPushButton" name="removeTargetButton">
+           <property name="text">
+            <string>Remove target</string>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="newTargetButton">
-        <property name="text">
-         <string>Place new target...</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="removeTargetButton">
-        <property name="text">
-         <string>Remove target</string>
-        </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="virtualfitCollapsible" native="true">
-     <property name="text" stdset="0">
+    <widget class="ctkCollapsibleButton" name="virtualfitCollapsible">
+     <property name="text">
       <string>Virtual Fitting</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
-       <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+       <widget class="QWidget" name="permissionsWidget2" native="true">
+        <property name="slicer.openlifu.allowed-roles" stdset="0">
+         <stringlist>
+          <string>admin</string>
+          <string>operator</string>
+         </stringlist>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QLabel" name="placeholderLabel">
+          <widget class="QLabel" name="approvalStatusLabel">
            <property name="text">
-            <string>Placeholder for an
+            <string>(approval status displayed here)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QLabel" name="placeholderLabel">
+              <property name="text">
+               <string>Placeholder for an
 OpenLIFUAlgorithmInputWidget</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="approveButton">
+           <property name="text">
+            <string>Approve virtual fit</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="virtualfitButton">
+           <property name="text">
+            <string>Virtual fit</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="virtualfitButton">
-        <property name="text">
-         <string>Virtual fit</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="approveButton">
-        <property name="text">
-         <string>Approve virtual fit</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="approvalStatusLabel">
-        <property name="text">
-         <string>(approval status displayed here)</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>624</width>
+    <width>636</width>
     <height>695</height>
    </rect>
   </property>
@@ -36,222 +36,245 @@
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="createNewProtocolButton">
-     <property name="toolTip">
-      <string>Create a new openlifu protocol</string>
+    <widget class="QWidget" name="configureAndPublishProtocol" native="true">
+     <property name="allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+      </stringlist>
      </property>
-     <property name="text">
-      <string>Create New Protocol</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="protocolEditorSectionGroupBox">
-     <property name="title">
-      <string>Protocol editor</string>
-     </property>
-     <layout class="QFormLayout" name="protocolEditorSectionLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="protocolNameLabel">
-        <property name="text">
-         <string>Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="protocolNameLineEdit">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="createNewProtocolButton">
         <property name="toolTip">
-         <string>Protocol name</string>
+         <string>Create a new openlifu protocol</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="protocolIdLabel">
         <property name="text">
-         <string>Protocol ID</string>
+         <string>Create New Protocol</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="protocolIdLineEdit">
-        <property name="toolTip">
-         <string>Protocol ID</string>
+      <item>
+       <widget class="QGroupBox" name="protocolEditorSectionGroupBox">
+        <property name="title">
+         <string>Protocol editor</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="protocolDescriptionLabel">
-        <property name="text">
-         <string>Description</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPlainTextEdit" name="protocolDescriptionTextEdit">
-        <property name="toolTip">
-         <string>Protocol description</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="pulseFrequencyLabel">
-        <property name="text">
-         <string>Pulse frequency</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="pulseFrequencySpinBox">
-        <property name="toolTip">
-         <string>Frequency of the pulse in Hz</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="pulseDurationLabel">
-        <property name="text">
-         <string>Pulse duration</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QDoubleSpinBox" name="pulseDurationSpinBox">
-        <property name="toolTip">
-         <string>Duration of the pulse in s</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="focalPatternLabel">
-        <property name="text">
-         <string>Focal pattern type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QComboBox" name="focalPatternComboBox">
-        <property name="toolTip">
-         <string>
-                    Type of pattern to use to determine target points
-                  </string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="focalPatternOptionsLabel">
-        <property name="text">
-         <string>Focal pattern options</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QStackedWidget" name="focalPatternOptionsStackedWidget">
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="noFocalPatternPage"/>
-        <widget class="QWidget" name="singlePointPage">
-         <layout class="QVBoxLayout" name="singlePointOptionsLayout">
-          <item>
-           <widget class="QLabel" name="singlePointOptionsLabel">
-            <property name="text">
-             <string>
-                            (No options for the single point pattern)
-                          </string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
+        <layout class="QFormLayout" name="protocolEditorSectionLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="protocolNameLabel">
+           <property name="text">
+            <string>Name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="protocolNameLineEdit">
+           <property name="toolTip">
+            <string>Protocol name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="protocolIdLabel">
+           <property name="text">
+            <string>Protocol ID</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="protocolIdLineEdit">
+           <property name="toolTip">
+            <string>Protocol ID</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="protocolDescriptionLabel">
+           <property name="text">
+            <string>Description</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPlainTextEdit" name="protocolDescriptionTextEdit">
+           <property name="toolTip">
+            <string>Protocol description</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="pulseFrequencyLabel">
+           <property name="text">
+            <string>Pulse frequency</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QDoubleSpinBox" name="pulseFrequencySpinBox">
+           <property name="toolTip">
+            <string>Frequency of the pulse in Hz</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="pulseDurationLabel">
+           <property name="text">
+            <string>Pulse duration</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QDoubleSpinBox" name="pulseDurationSpinBox">
+           <property name="toolTip">
+            <string>Duration of the pulse in s</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="focalPatternLabel">
+           <property name="text">
+            <string>Focal pattern type</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QComboBox" name="focalPatternComboBox">
+           <property name="toolTip">
+            <string>
+                          Type of pattern to use to determine target points
+                        </string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="focalPatternOptionsLabel">
+           <property name="text">
+            <string>Focal pattern options</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QStackedWidget" name="focalPatternOptionsStackedWidget">
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <widget class="QWidget" name="noFocalPatternPage"/>
+           <widget class="QWidget" name="singlePointPage">
+            <layout class="QVBoxLayout" name="singlePointOptionsLayout">
+             <item>
+              <widget class="QLabel" name="singlePointOptionsLabel">
+               <property name="text">
+                <string>
+                                  (No options for the single point pattern)
+                                </string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="wheelPage">
-         <layout class="QFormLayout" name="wheelOptionsLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="wheelCenterLabel">
-            <property name="text">
-             <string>Center?</string>
-            </property>
+           <widget class="QWidget" name="wheelPage">
+            <layout class="QFormLayout" name="wheelOptionsLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="wheelCenterLabel">
+               <property name="text">
+                <string>Center?</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="wheelCenterCheckBox">
+               <property name="toolTip">
+                <string>
+                                  Whether to include the center point of the wheel
+                                  pattern
+                                </string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="numSpokesLabel">
+               <property name="text">
+                <string>Spokes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="numSpokesSpinBox"/>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="spokeRadiusLabel">
+               <property name="text">
+                <string>Spoke Radius</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="spokeRadiusSpinBox"/>
+             </item>
+            </layout>
            </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="wheelCenterCheckBox">
-            <property name="toolTip">
-             <string>
-                            Whether to include the center point of the wheel
-                            pattern
-                          </string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="numSpokesLabel">
-            <property name="text">
-             <string>Spokes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="numSpokesSpinBox"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="spokeRadiusLabel">
-            <property name="text">
-             <string>Spoke Radius</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="spokeRadiusSpinBox"/>
-          </item>
-         </layout>
-        </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="saveStateLabel">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="protocolSaveDeleteButtonsLayout">
+        <item>
+         <widget class="QPushButton" name="protocolFileSaveButton">
+          <property name="text">
+           <string>Save Protocol To File</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="protocolDatabaseSaveButton">
+          <property name="text">
+           <string>Save Protocol To Database</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="protocolDatabaseDeleteButton">
+          <property name="text">
+           <string>Delete Protocol From Database</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QPushButton" name="protocolEditRevertDiscardButton">
+        <property name="text">
+         <string>Edit Protocol</string>
+        </property>
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="saveStateLabel">
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="protocolSaveDeleteButtonsLayout">
-     <item>
-      <widget class="QPushButton" name="protocolFileSaveButton">
-       <property name="text">
-        <string>Save Protocol To File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="protocolDatabaseSaveButton">
-       <property name="text">
-        <string>Save Protocol To Database</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="protocolDatabaseDeleteButton">
-       <property name="text">
-        <string>Delete Protocol From Database</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QPushButton" name="protocolEditRevertDiscardButton">
-     <property name="text">
-      <string>Edit Protocol</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -1,275 +1,275 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>OpenLIFUProtocolConfig</class>
-  <widget class="qMRMLWidget" name="OpenLIFUProtocolConfig">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>559</width>
-        <height>695</height>
-      </rect>
-    </property>
-    <layout class="QVBoxLayout" name="protocolConfigLayout">
-      <item>
-        <widget class="ctkComboBox" name="protocolSelector" />
+ <class>OpenLIFUProtocolConfig</class>
+ <widget class="qMRMLWidget" name="OpenLIFUProtocolConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>624</width>
+    <height>695</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="protocolConfigLayout">
+   <item>
+    <widget class="ctkComboBox" name="protocolSelector"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="protocolButtonsLayout">
+     <item>
+      <widget class="QPushButton" name="loadProtocolFromFileButton">
+       <property name="toolTip">
+        <string>Load an openlifu protocol from json</string>
+       </property>
+       <property name="text">
+        <string>Load Protocol From File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="loadProtocolFromDatabaseButton">
+       <property name="text">
+        <string>Load Protocol From Database</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="createNewProtocolButton">
+     <property name="toolTip">
+      <string>Create a new openlifu protocol</string>
+     </property>
+     <property name="text">
+      <string>Create New Protocol</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="protocolEditorSectionGroupBox">
+     <property name="title">
+      <string>Protocol editor</string>
+     </property>
+     <layout class="QFormLayout" name="protocolEditorSectionLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="protocolNameLabel">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
       </item>
-      <item>
-        <layout class="QHBoxLayout" name="protocolButtonsLayout">
-          <item>
-            <widget class="QPushButton" name="loadProtocolFromFileButton">
-              <property name="toolTip">
-                <string>Load an openlifu protocol from json</string>
-              </property>
-              <property name="text">
-                <string>Load Protocol From File</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <widget class="QPushButton" name="loadProtocolFromDatabaseButton">
-              <property name="text">
-                <string>Load Protocol From Database</string>
-              </property>
-            </widget>
-          </item>
-        </layout>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="protocolNameLineEdit">
+        <property name="toolTip">
+         <string>Protocol name</string>
+        </property>
+       </widget>
       </item>
-      <item>
-        <widget class="QPushButton" name="createNewProtocolButton">
-          <property name="toolTip">
-            <string>Create a new openlifu protocol</string>
-          </property>
-          <property name="text">
-            <string>Create New Protocol</string>
-          </property>
-        </widget>
+      <item row="1" column="0">
+       <widget class="QLabel" name="protocolIdLabel">
+        <property name="text">
+         <string>Protocol ID</string>
+        </property>
+       </widget>
       </item>
-      <item>
-        <widget class="QGroupBox" name="protocolEditorSectionGroupBox">
-          <property name="title">
-            <string>Protocol editor</string>
-          </property>
-          <layout class="QFormLayout" name="protocolEditorSectionLayout">
-            <item row="0" column="0">
-              <widget class="QLabel" name="protocolNameLabel">
-                <property name="text">
-                  <string>Name</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <widget class="QLineEdit" name="protocolNameLineEdit">
-                <property name="toolTip">
-                  <string>Protocol name</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="protocolIdLabel">
-                <property name="text">
-                  <string>Protocol ID</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <widget class="QLineEdit" name="protocolIdLineEdit">
-                <property name="toolTip">
-                  <string>Protocol ID</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="0">
-              <widget class="QLabel" name="protocolDescriptionLabel">
-                <property name="text">
-                  <string>Description</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="1">
-              <widget class="QPlainTextEdit" name="protocolDescriptionTextEdit">
-                <property name="toolTip">
-                  <string>Protocol description</string>
-                </property>
-              </widget>
-            </item>
-            <item row="3" column="0">
-              <widget class="QLabel" name="pulseFrequencyLabel">
-                <property name="text">
-                  <string>Pulse frequency</string>
-                </property>
-              </widget>
-            </item>
-            <item row="3" column="1">
-              <widget class="QDoubleSpinBox" name="pulseFrequencySpinBox">
-                <property name="toolTip">
-                  <string>Frequency of the pulse in Hz</string>
-                </property>
-              </widget>
-            </item>
-            <item row="4" column="0">
-              <widget class="QLabel" name="pulseDurationLabel">
-                <property name="text">
-                  <string>Pulse duration</string>
-                </property>
-              </widget>
-            </item>
-            <item row="4" column="1">
-              <widget class="QDoubleSpinBox" name="pulseDurationSpinBox">
-                <property name="toolTip">
-                  <string>Duration of the pulse in s</string>
-                </property>
-              </widget>
-            </item>
-            <item row="5" column="0">
-              <widget class="QLabel" name="focalPatternLabel">
-                <property name="text">
-                  <string>Focal pattern type</string>
-                </property>
-              </widget>
-            </item>
-            <item row="5" column="1">
-              <widget class="QComboBox" name="focalPatternComboBox">
-                <property name="toolTip">
-                  <string>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="protocolIdLineEdit">
+        <property name="toolTip">
+         <string>Protocol ID</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="protocolDescriptionLabel">
+        <property name="text">
+         <string>Description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPlainTextEdit" name="protocolDescriptionTextEdit">
+        <property name="toolTip">
+         <string>Protocol description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="pulseFrequencyLabel">
+        <property name="text">
+         <string>Pulse frequency</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QDoubleSpinBox" name="pulseFrequencySpinBox">
+        <property name="toolTip">
+         <string>Frequency of the pulse in Hz</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="pulseDurationLabel">
+        <property name="text">
+         <string>Pulse duration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QDoubleSpinBox" name="pulseDurationSpinBox">
+        <property name="toolTip">
+         <string>Duration of the pulse in s</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="focalPatternLabel">
+        <property name="text">
+         <string>Focal pattern type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="focalPatternComboBox">
+        <property name="toolTip">
+         <string>
                     Type of pattern to use to determine target points
                   </string>
-                </property>
-              </widget>
-            </item>
-            <item row="6" column="0">
-              <widget class="QLabel" name="focalPatternOptionsLabel">
-                <property name="text">
-                  <string>Focal pattern options</string>
-                </property>
-              </widget>
-            </item>
-            <item row="6" column="1">
-              <widget class="QStackedWidget" name="focalPatternOptionsStackedWidget">
-                <property name="currentIndex">
-                  <number>0</number>
-                </property>
-                <widget class="QWidget" name="noFocalPatternPage" />
-                <widget class="QWidget" name="singlePointPage">
-                  <layout class="QVBoxLayout" name="singlePointOptionsLayout">
-                    <item>
-                      <widget class="QLabel" name="singlePointOptionsLabel">
-                        <property name="text">
-                          <string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="focalPatternOptionsLabel">
+        <property name="text">
+         <string>Focal pattern options</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QStackedWidget" name="focalPatternOptionsStackedWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="noFocalPatternPage"/>
+        <widget class="QWidget" name="singlePointPage">
+         <layout class="QVBoxLayout" name="singlePointOptionsLayout">
+          <item>
+           <widget class="QLabel" name="singlePointOptionsLabel">
+            <property name="text">
+             <string>
                             (No options for the single point pattern)
                           </string>
-                        </property>
-                        <property name="alignment">
-                          <set>Qt::AlignCenter</set>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-                <widget class="QWidget" name="wheelPage">
-                  <layout class="QFormLayout" name="wheelOptionsLayout">
-                    <item row="0" column="0">
-                      <widget class="QLabel" name="wheelCenterLabel">
-                        <property name="text">
-                          <string>Center?</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="1">
-                      <widget class="QCheckBox" name="wheelCenterCheckBox">
-                        <property name="toolTip">
-                          <string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="wheelPage">
+         <layout class="QFormLayout" name="wheelOptionsLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="wheelCenterLabel">
+            <property name="text">
+             <string>Center?</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="wheelCenterCheckBox">
+            <property name="toolTip">
+             <string>
                             Whether to include the center point of the wheel
                             pattern
                           </string>
-                        </property>
-                        <property name="text">
-                          <string />
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="1" column="0">
-                      <widget class="QLabel" name="numSpokesLabel">
-                        <property name="text">
-                          <string>Spokes</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="1" column="1">
-                      <widget class="QSpinBox" name="numSpokesSpinBox" />
-                    </item>
-                    <item row="2" column="0">
-                      <widget class="QLabel" name="spokeRadiusLabel">
-                        <property name="text">
-                          <string>Spoke Radius</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="2" column="1">
-                      <widget class="QDoubleSpinBox" name="spokeRadiusSpinBox" />
-                    </item>
-                  </layout>
-                </widget>
-              </widget>
-            </item>
-          </layout>
-        </widget>
-      </item>
-      <item>
-        <widget class="QLabel" name="saveStateLabel">
-          <property name="alignment">
-            <set>Qt::AlignCenter</set>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <layout class="QHBoxLayout" name="protocolSaveDeleteButtonsLayout">
-          <item>
-            <widget class="QPushButton" name="protocolFileSaveButton">
-              <property name="text">
-                <string>Save Protocol To File</string>
-              </property>
-            </widget>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
           </item>
-          <item>
-            <widget class="QPushButton" name="protocolDatabaseSaveButton">
-              <property name="text">
-                <string>Save Protocol To Database</string>
-              </property>
-            </widget>
+          <item row="1" column="0">
+           <widget class="QLabel" name="numSpokesLabel">
+            <property name="text">
+             <string>Spokes</string>
+            </property>
+           </widget>
           </item>
-          <item>
-            <widget class="QPushButton" name="protocolDatabaseDeleteButton">
-              <property name="text">
-                <string>Delete Protocol From Database</string>
-              </property>
-            </widget>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="numSpokesSpinBox"/>
           </item>
-        </layout>
-      </item>
-      <item>
-        <widget class="QPushButton" name="protocolEditRevertDiscardButton">
-          <property name="text">
-            <string>Edit Protocol</string>
-          </property>
+          <item row="2" column="0">
+           <widget class="QLabel" name="spokeRadiusLabel">
+            <property name="text">
+             <string>Spoke Radius</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="spokeRadiusSpinBox"/>
+          </item>
+         </layout>
         </widget>
+       </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="saveStateLabel">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="protocolSaveDeleteButtonsLayout">
+     <item>
+      <widget class="QPushButton" name="protocolFileSaveButton">
+       <property name="text">
+        <string>Save Protocol To File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="protocolDatabaseSaveButton">
+       <property name="text">
+        <string>Save Protocol To Database</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="protocolDatabaseDeleteButton">
+       <property name="text">
+        <string>Delete Protocol From Database</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>qMRMLWidget</class>
-      <extends>QWidget</extends>
-      <header>qMRMLWidget.h</header>
-      <container>1</container>
-    </customwidget>
-    <customwidget>
-      <class>ctkComboBox</class>
-      <extends>QComboBox</extends>
-      <header>ctkComboBox.h</header>
-      <container>1</container>
-    </customwidget>
-  </customwidgets>
-  <resources />
-  <connections />
+   </item>
+   <item>
+    <widget class="QPushButton" name="protocolEditRevertDiscardButton">
+     <property name="text">
+      <string>Edit Protocol</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ctkComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
 </ui>

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -36,8 +36,8 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="configureAndPublishProtocol" native="true">
-     <property name="allowed-roles" stdset="0">
+    <widget class="QWidget" name="permissionsWidget1" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
       <stringlist>
        <string>admin</string>
       </stringlist>

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -12,10 +12,34 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QPushButton" name="runPushButton">
-     <property name="text">
-      <string>Run</string>
+    <widget class="QWidget" name="permissionsWidget" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+       <string>operator</string>
+      </stringlist>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="runPushButton">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -10,7 +10,7 @@
     <height>520</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_10">
    <item>
     <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
      <layout class="QVBoxLayout" name="verticalLayout">
@@ -150,43 +150,67 @@ analysis.</string>
     </spacer>
    </item>
    <item>
-    <widget class="QPushButton" name="solutionPushButton">
-     <property name="text">
-      <string>Compute sonication solution</string>
+    <widget class="QWidget" name="permissionsWidget" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+       <string>operator</string>
+      </stringlist>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="solutionProgressBar">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="maximum">
-      <number>1</number>
-     </property>
-     <property name="value">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="renderPNPCheckBox">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Render peak negative pressure</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="approveButton">
-     <property name="text">
-      <string>Approve solution</string>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="solutionPushButton">
+        <property name="text">
+         <string>Compute sonication solution</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="solutionProgressBar">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="maximum">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="renderPNPCheckBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Render peak negative pressure</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="approveButton">
+        <property name="text">
+         <string>Approve solution</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,91 +7,122 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>237</height>
+    <height>272</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="tempWidget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+    <widget class="QWidget" name="permissionsWidget" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+       <string>operator</string>
+      </stringlist>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
-       <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
-        <layout class="QFormLayout" name="formLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="placeholderLabel">
-           <property name="text">
-            <string>Placeholder for an OpenLIFUAlgorithmInputWidget</string>
-           </property>
+       <widget class="QWidget" name="tempWidget" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
+           <layout class="QFormLayout" name="formLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="placeholderLabel">
+              <property name="text">
+               <string>Placeholder for an OpenLIFUAlgorithmInputWidget</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="skinSegmentationModelLabel">
+             <property name="text">
+              <string>Skin segmentation model:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="qMRMLNodeComboBox" name="skinSegmentationModelqMRMLNodeComboBox">
+             <property name="nodeTypes">
+              <stringlist>
+               <string>vtkMRMLModelNode</string>
+              </stringlist>
+             </property>
+             <property name="noneEnabled">
+              <bool>true</bool>
+             </property>
+             <property name="addEnabled">
+              <bool>false</bool>
+             </property>
+             <property name="removeEnabled">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>
       </item>
       <item>
-       <layout class="QFormLayout" name="formLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="skinSegmentationModelLabel">
-          <property name="text">
-           <string>Skin segmentation model:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="qMRMLNodeComboBox" name="skinSegmentationModelqMRMLNodeComboBox">
-          <property name="nodeTypes">
-           <stringlist>
-            <string>vtkMRMLModelNode</string>
-           </stringlist>
-          </property>
-          <property name="noneEnabled">
-           <bool>true</bool>
-          </property>
-          <property name="addEnabled">
-           <bool>false</bool>
-          </property>
-          <property name="removeEnabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QPushButton" name="loadTransducerSurfaceButton">
+        <property name="text">
+         <string>Load transducer registration surface</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="runTrackingButton">
+        <property name="text">
+         <string>Run transducer tracking</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="approveButton">
+        <property name="text">
+         <string>Approve transducer tracking</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="approvalStatusLabel">
+        <property name="text">
+         <string>(approval status label)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>21</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="runTrackingButton">
-     <property name="text">
-      <string>Run transducer tracking</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="approveButton">
-     <property name="text">
-      <string>Approve transducer tracking</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="approvalStatusLabel">
-     <property name="text">
-      <string>(approval status label)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Closes #175

---

## Summary

This PR introduces the general framework for enforcing user roles in the login module by enclosing buttons in permissions widgets. Adding restrictions to buttons and choosing the roles that can interact should be very straightforward.

When testing, try to login and ensure that certain abilities, e.g. editing protocols, can only be done by admins (you can see the full table in [#175](https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/175)). If it works for protocols, it should work for everything else.

Currently, new users cannot be created. When testing, you can login to example users by connecting the database and referring to the credentials in the [PR where the login module was created](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/182).

We'll have to come up with a different way of notifying users they can't do stuff when not logged in than tooltips, but this is an issue for later. For instance, operators cannot edit protocols, but the tooltip on the disabled button is related to what tooltip would have been there regardless of permission (e.g. a protocol is not selected).

---

## Missing implementations and notes

Note that the following could not yet be implemented due to buttons not being defined at this time.  Despite this, what we have is a framework for enforcing permissions through QWidgets.

### Missing implementations:

> Function - Why it's not enforceable

Define Array - Not well defined.
Run Standalone Simulations - Not well defined.
Water Tank Operation - Not well defined.
Manage Users - Buttons not yet implemented.

### Further note:

For "Transducer Tracking", the permissions control the entire widget:
<img width="881" alt="image" src="https://github.com/user-attachments/assets/7d2e92bf-605b-4310-bb22-f36501a111c3" />

I assume that "Create Solution" means "Compute sonication solution" in the OpenLIFUSonicationPlanner module, and so that permission only applies to the buttons here:
<img width="669" alt="image" src="https://github.com/user-attachments/assets/e97e34f2-3a73-4ecc-8ab1-82624adb3035" />

I assume that "Run Sonication" means "Run" in the OpenLIFUSonicationControl module, and so that permission only applies to the button here:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/6147f89c-ccfa-4e8b-8b93-34972f80f18f" />