### PR TITLE
Add back function to start user account mode in logic

### DIFF
--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -393,3 +393,6 @@ class OpenLIFULoginLogic(ScriptedLoadableModuleLogic):
 
     def clear_session(self) -> None:
         self.current_session = None
+
+    def start_user_account_mode(self):
+        set_user_account_mode_state(True)


### PR DESCRIPTION
#172 was closed and merged, but I realize that the logic function to turn on user account mode is useful to OpenLIFU-app. Therefore, I'm adding it back in a commit.