### PR TITLE
Add button to sonication control module to send solution to hardware before initiating run

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0db543a787fc61b59958f8689987a9308c6fe183
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@15f8e491cd019f7fc21bba3c1464e53fba79328a
 bcrypt

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -288,15 +288,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         if solution is None:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("To run a sonication, first generate and approve a solution in the sonication planning module.")
+        elif not solution.is_approved():
+            self.ui.runPushButton.enabled = False
+            self.ui.runPushButton.setToolTip("Cannot run because the currently active solution is not approved. It can be approved in the sonication planning module.")
         elif not self._cur_solution_hardware_state == SolutionHardwareState.SUCCESSFUL_SEND:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("To run a sonication, you must send an approved solution to the hardware device.")
         elif self.logic.running:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("Currently running...")
-        elif not solution.is_approved():
-            self.ui.runPushButton.enabled = False
-            self.ui.runPushButton.setToolTip("Cannot run because the currently active solution is not approved. It can be approved in the sonication planning module.")
         else:
             self.ui.runPushButton.enabled = True
             self.ui.runPushButton.setToolTip("Run sonication")
@@ -391,17 +391,17 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateWidgetSolutionHardwareState(self, state: SolutionHardwareState):
         self._cur_solution_hardware_state = state
         if state == SolutionHardwareState.SUCCESSFUL_SEND:
-            self.ui.runPushButton.setEnabled(True)
             self.ui.solutionStateLabel.setProperty("text", "Solution sent to device.")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: green; border: 1px solid green; padding: 5px;")
+            self.updateRunEnabled()
         elif state == SolutionHardwareState.FAILED_SEND:
-            self.ui.runPushButton.setEnabled(False)
             self.ui.solutionStateLabel.setProperty("text", "Send to device failed!")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: red; border: 1px solid red; padding: 5px;")
+            self.updateRunEnabled()
         elif state == SolutionHardwareState.NOT_SENT:
-            self.ui.runPushButton.setEnabled(False)
             self.ui.solutionStateLabel.setProperty("text", "")  
             self.ui.solutionStateLabel.setProperty("styleSheet", "border: none;")
+            self.updateRunEnabled()
 
 # OpenLIFUSonicationControlLogic
 #

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -273,6 +273,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
     def onDataParameterNodeModified(self,caller, event) -> None:
+        self.updateSendSonicationSolutionToDevicePushButton()
         self.updateRunEnabled()
         self.updateRunProgressBar()
 
@@ -350,6 +351,22 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.runPushButton.setToolTip("Run the sonication solution on connected hardware.")
         else:
             self.ui.runPushButton.setToolTip("You must send a sonication solution to the hardware to run it.")
+
+    def setSendSonicationSolutionToDevicePushButtonEnabled(self, enabled: bool) -> None:
+        self.ui.sendSonicationSolutionToDevicePushButton.setEnabled(enabled)
+        if enabled:
+            self.ui.sendSonicationSolutionToDevicePushButton.setToolTip("Send the sonication solution to the connected hardware.")
+        else:
+            self.ui.sendSonicationSolutionToDevicePushButton.setToolTip("This feature requires a set sonication solution.")
+
+        self.setRunPushButtonEnabled(enabled)  # must propagate to run button
+
+    def updateSendSonicationSolutionToDevicePushButton(self):
+        if get_openlifu_data_parameter_node().loaded_solution is None:
+            self.setSendSonicationSolutionToDevicePushButtonEnabled(False)
+            return
+
+        self.setSendSonicationSolutionToDevicePushButtonEnabled(True)
 
     def updateWidgetSolutionHardwareState(self, state: SolutionHardwareState):
         self._cur_solution_hardware_state = state

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -363,21 +363,14 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             else:
                 self.ui.runProgressBar.value = 100
 
-    def setRunPushButtonEnabled(self, enabled: bool) -> None:
-        self.ui.runPushButton.setEnabled(enabled)
-        if enabled:
-            self.ui.runPushButton.setToolTip("Run the sonication solution on connected hardware.")
-        else:
-            self.ui.runPushButton.setToolTip("You must send a sonication solution to the hardware to run it.")
-
     def setSendSonicationSolutionToDevicePushButtonEnabled(self, enabled: bool) -> None:
         self.ui.sendSonicationSolutionToDevicePushButton.setEnabled(enabled)
         if enabled:
             self.ui.sendSonicationSolutionToDevicePushButton.setToolTip("Send the sonication solution to the connected hardware.")
         else:
-            self.ui.sendSonicationSolutionToDevicePushButton.setToolTip("This feature requires a set sonication solution.")
+            self.ui.sendSonicationSolutionToDevicePushButton.setToolTip("To run a sonication, first generate and approve a solution in the sonication planning module.")
 
-        self.setRunPushButtonEnabled(enabled)  # must propagate to run button
+        self.ui.runPushButton.setEnabled(enabled)  # must propagate to run button
 
     def updateSendSonicationSolutionToDevicePushButton(self):
         if get_openlifu_data_parameter_node().loaded_solution is None:
@@ -389,15 +382,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateWidgetSolutionHardwareState(self, state: SolutionHardwareState):
         self._cur_solution_hardware_state = state
         if state == SolutionHardwareState.SUCCESSFUL_SEND:
-            self.setRunPushButtonEnabled(True)
+            self.ui.runPushButton.setEnabled(True)
             self.ui.solutionStateLabel.setProperty("text", "Solution sent to device.")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: green; border: 1px solid green; padding: 5px;")
         elif state == SolutionHardwareState.FAILED_SEND:
-            self.setRunPushButtonEnabled(False)
+            self.ui.runPushButton.setEnabled(False)
             self.ui.solutionStateLabel.setProperty("text", "Send to device failed!")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: red; border: 1px solid red; padding: 5px;")
         elif state == SolutionHardwareState.NOT_SENT:
-            self.setRunPushButtonEnabled(False)
+            self.ui.runPushButton.setEnabled(False)
             self.ui.solutionStateLabel.setProperty("text", "")  
             self.ui.solutionStateLabel.setProperty("styleSheet", "border: none;")
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -171,6 +171,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
         self._cur_solution_hardware_state = SolutionHardwareState.NOT_SENT
+        self._cur_solution_id: str | None = None
         self._parameterNode = None
         self._parameterNodeGuiTag = None
 
@@ -225,7 +226,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
 
-        # Update module from data parameter node
+        # After setup, update the module state from the data parameter node
         self.onDataParameterNodeModified()
 
     def cleanup(self) -> None:
@@ -282,6 +283,12 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
         self.updateRunProgressBar()
+        if (solution_parameter_pack := get_openlifu_data_parameter_node().loaded_solution) is None:
+            self._cur_solution_id = None
+            self.updateWidgetSolutionHardwareState(SolutionHardwareState.NOT_SENT)
+        elif solution_parameter_pack.solution.solution.id != self._cur_solution_id:
+            self._cur_solution_id = solution_parameter_pack.solution.solution.id
+            self.updateWidgetSolutionHardwareState(SolutionHardwareState.NOT_SENT)
 
     def updateSendSonicationSolutionToDevicePushButtonEnabled(self):
         solution = get_openlifu_data_parameter_node().loaded_solution

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -399,17 +399,17 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             else:
                 self.ui.runProgressBar.value = 100
 
-    def updateWidgetSolutionHardwareState(self, state: SolutionHardwareState):
-        self._cur_solution_hardware_state = state
-        if state == SolutionHardwareState.SUCCESSFUL_SEND:
+    def updateWidgetSolutionHardwareState(self, solution_state: SolutionHardwareState):
+        if solution_state == SolutionHardwareState.SUCCESSFUL_SEND:
             self.ui.solutionStateLabel.setProperty("text", "Solution sent to device.")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: green; border: 1px solid green; padding: 5px;")
             self.updateRunEnabled()
-        elif state == SolutionHardwareState.FAILED_SEND:
+        elif solution_state == SolutionHardwareState.FAILED_SEND:
+            # TODO: In the event of a failed send, you should add the printout
             self.ui.solutionStateLabel.setProperty("text", "Send to device failed!")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: red; border: 1px solid red; padding: 5px;")
             self.updateRunEnabled()
-        elif state == SolutionHardwareState.NOT_SENT:
+        elif solution_state == SolutionHardwareState.NOT_SENT:
             self.ui.solutionStateLabel.setProperty("text", "")  
             self.ui.solutionStateLabel.setProperty("styleSheet", "border: none;")
             self.updateRunEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -288,6 +288,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         if solution is None:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("To run a sonication, first generate and approve a solution in the sonication planning module.")
+        elif not self._cur_solution_hardware_state == SolutionHardwareState.SUCCESSFUL_SEND:
+            self.ui.runPushButton.enabled = False
+            self.ui.runPushButton.setToolTip("To run a sonication, you must send an approved solution to the hardware device.")
         elif self.logic.running:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("Currently running...")

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -225,6 +225,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
 
+        # Update module from data parameter node
+        self.onDataParameterNodeModified()
+
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
         self.removeObservers()
@@ -275,7 +278,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             # ui element that needs connection.
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
-    def onDataParameterNodeModified(self,caller, event) -> None:
+    def onDataParameterNodeModified(self, caller=None, event=None) -> None:
         self.updateSendSonicationSolutionToDevicePushButton()
         self.updateRunEnabled()
         self.updateRunProgressBar()

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -10,7 +10,14 @@
     <height>311</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPushButton" name="sendSonicationSolutionToDevicePushButton">
+     <property name="text">
+      <string>Send Sonication Solution To Device</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QWidget" name="permissionsWidget" native="true">
      <property name="slicer.openlifu.allowed-roles" stdset="0">
@@ -46,6 +53,13 @@
     <widget class="QPushButton" name="abortPushButton">
      <property name="text">
       <string>Abort</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="solutionStateLabel">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Closes #156 

This implements the button which sends the Data parameter `loaded_solution` to the LIFU device, using the `LIFUInterface` object. The `LIFUInterface` object is initialized using `test_mode=True`, and the state is checked before confirming that the send was successful. In one example, I printed the object and state after initialization, and it looked like this after everything in the `try` block executed (left out of the PR):

```
Interface:  <openlifu.io.LIFUInterface.LIFUInterface object at 0x263c11130>
Status:  LIFUInterfaceStatus.STATUS_READY
```

Note a few things. In this particular case, I assume that hardware-related issues will be propagated through the `LIFUInterface` through exception raising. This is why the implementation for the button (`def onSendSonicationSolutionToDevicePushButtonClicked`) encloses the LIFUInterface initialization and solution setting in a try block. If things work, through a simple state update, the widget will allow the run button to be pressed.  The most recently initialized LIFUInterface is stored in the logic.

Please gloss over the changes and note anything that looks like it doesn't make sense, or note any behaviors that were unexpected.

Please make sure to update the python libraries in the Home module before testing this branch.