### PR TITLE
Add dummy worflow for manual transducer tracking

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -50,7 +50,8 @@ from OpenLIFULib.virtual_fit_results import (
 )
 
 from OpenLIFULib.transducer_tracking_results import (
-    add_transducer_tracking_results_from_openlifu_session_format
+    add_transducer_tracking_results_from_openlifu_session_format,
+    clear_transducer_tracking_results
 )
 
 if TYPE_CHECKING:
@@ -1180,7 +1181,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
             # TODO: Fix this later.
             approved_tt_photoscans = self.logic.get_transducer_tracking_approvals_in_session()
-            num_tt_approved = 0
+            num_tt_approved = len(approved_tt_photoscans)
             if num_tt_approved > 0:
                 additional_info_messages.append(
                     "Transducer tracking approved for "
@@ -1378,7 +1379,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 if photoscan_id in self.getParameterNode().loaded_photoscans:
                     self.remove_photoscan(photoscan_id)
 
-            #TODO:  clear_transducer_tracking_results
+            clear_transducer_tracking_results
 
     def save_session(self) -> None:
         """Save the current session to the openlifu database.
@@ -2077,13 +2078,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         session = self.getParameterNode().loaded_session
         if session is None:
             raise RuntimeError("No active session.")
-        session_openlifu : "openlifu.db.Session" = session.session.session
-        approved_vf_targets = []
-        for target in session_openlifu.targets:
-            if target.id not in session_openlifu.virtual_fit_results:
-                continue
-            if session_openlifu.virtual_fit_results[target.id][0]:
-                approved_vf_targets.append(target.id)
+        approved_vf_targets = session.get_virtual_fit_approvals()
+        
         return approved_vf_targets
     
     def get_transducer_tracking_approvals_in_session(self) -> List[str]:

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -18,7 +18,8 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/coordinate_system_utils.py
   OpenLIFULib/photoscan.py
   OpenLIFULib/virtual_fit_results.py
-  OpenLIFULib//transform_conversion.py
+  OpenLIFULib/transform_conversion.py
+  OpenLIFULib/transducer_tracking_results.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/virtual_fit_results.py
   OpenLIFULib/transform_conversion.py
   OpenLIFULib/transducer_tracking_results.py
+  OpenLIFULib/skinseg.py
   OpenLIFULib/transducer_tracking_wizard_utils.py
 )
 

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/virtual_fit_results.py
   OpenLIFULib/transform_conversion.py
   OpenLIFULib/transducer_tracking_results.py
+  OpenLIFULib/transducer_tracking_wizard_utils.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@366857aae1b75f770beb64989935506c40325b16
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@05727b0d2b2bf4ffd948ade2f1caab7b76fd063c
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@d78e5edef8fb03b59871b24adc19338ef5f41355
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@366857aae1b75f770beb64989935506c40325b16
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@05727b0d2b2bf4ffd948ade2f1caab7b76fd063c
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@3a78135b308444ca954b958615867c04f4529c76
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
+++ b/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
@@ -48,15 +48,14 @@ def linear_to_affine(matrix, translation=None):
         axis=0,
     )
 
-def get_RAS2IJK(volume_node: vtkMRMLScalarVolumeNode):
-    """Get the _world_ RAS to volume IJK affine matrix for a given volume node.
-
+def get_IJK2RAS(volume_node: vtkMRMLScalarVolumeNode):
+    """Get the trasnfrom from IJK to the _world_ RAS for a given volume node.
     This takes into account any transforms that the volume node may be subject to.
 
     Returns a numpy array of shape (4,4).
     """
     IJK_to_volumeRAS_vtk = vtk.vtkMatrix4x4()
-    volume_node.GetRASToIJKMatrix(IJK_to_volumeRAS_vtk)
+    volume_node.GetIJKToRASMatrix(IJK_to_volumeRAS_vtk)
     IJK_to_volumeRAS = slicer.util.arrayFromVTKMatrix(IJK_to_volumeRAS_vtk)
     if volume_node.GetParentTransformNode():
         volumeRAS_to_worldRAS_vtk = vtk.vtkMatrix4x4()

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -135,14 +135,17 @@ class SlicerOpenLIFUPhotoscan:
             self.tracking_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
             self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([viewNode.GetID()] if viewNode else [])
                         
-    def create_tracking_fiducial_node(self):
+    def create_tracking_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
         """Nodes are created by default at the origin"""
 
         self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
         self.tracking_fiducial_node.SetMaximumNumberOfControlPoints(3)
         self.tracking_fiducial_node.SetName(slicer.mrmlScene.GenerateUniqueName("Photoscan-TrackingFiducials"))
         self.tracking_fiducial_node.SetMarkupLabelFormat("%N")
-        for label in ["Right Ear", "Left Ear","Nasion"]:
-            self.tracking_fiducial_node.AddControlPoint(0,0,0,label)
+        self.tracking_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
+        self.tracking_fiducial_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")
+        self.tracking_fiducial_node.AddControlPoint(nasion_coordinates[0],nasion_coordinates[0],nasion_coordinates[0],"Nasion")
+        
+        return self.tracking_fiducial_node
 
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -92,6 +92,8 @@ class SlicerOpenLIFUPhotoscan:
         """Clear associated mrml nodes from the scene."""
         slicer.mrmlScene.RemoveNode(self.model_node)
         slicer.mrmlScene.RemoveNode(self.texture_node)
+        if self.tracking_fiducial_node:
+            slicer.mrmlScene.RemoveNode(self.tracking_fiducial_node)
 
     def apply_texture_to_model(self):
         """Apply the texture image to the model node"""

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -138,9 +138,9 @@ class SlicerOpenLIFUPhotoscan:
     def create_tracking_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
         """Nodes are created by default at the origin"""
 
-        self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+        photoscan_id = self.photoscan.photoscan.id
+        self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"Photoscan-{photoscan_id}-TrackingFiducials" )
         self.tracking_fiducial_node.SetMaximumNumberOfControlPoints(3)
-        self.tracking_fiducial_node.SetName(slicer.mrmlScene.GenerateUniqueName("Photoscan-TrackingFiducials"))
         self.tracking_fiducial_node.SetMarkupLabelFormat("%N")
         self.tracking_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
         self.tracking_fiducial_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -205,7 +205,21 @@ class SlicerOpenLIFUSession:
         approved_tt_photoscans = [
             photoscan_id for photoscan_id in self.get_affiliated_photoscan_ids()
             for tt_result in session_openlifu.transducer_tracking_results
-            if photoscan_id == tt_result.photoscan_id and tt_result.transducer_tracking_approved
+            if photoscan_id == tt_result.photoscan_id 
+            and tt_result.transducer_to_photoscan_tracking_approved 
+            and tt_result.photoscan_to_volume_tracking_approved 
         ]
 
         return approved_tt_photoscans
+    
+    def get_virtual_fit_approvals(self):
+
+        session_openlifu = self.session.session
+        approved_vf_targets = []
+        for target in session_openlifu.targets:
+            if target.id not in session_openlifu.virtual_fit_results:
+                continue
+            if session_openlifu.virtual_fit_results[target.id][0]:
+                approved_vf_targets.append(target.id)
+        
+        return approved_vf_targets

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -16,6 +16,7 @@ from OpenLIFULib.targets import (
 )
 from OpenLIFULib.transform_conversion import transform_node_to_openlifu
 from OpenLIFULib.virtual_fit_results import get_virtual_fit_results_in_openlifu_session_format
+from OpenLIFULib.transducer_tracking_results import get_transducer_tracking_results_in_openlifu_session_format
 
 if TYPE_CHECKING:
     import openlifu
@@ -191,6 +192,12 @@ class SlicerOpenLIFUSession:
 
         # Update virtual fit results
         self.session.session.virtual_fit_results = get_virtual_fit_results_in_openlifu_session_format(
+            session_id=self.get_session_id(),
+            units = transducer_openlifu.units,
+        )
+
+        #Update transducer tracking results
+        self.session.session.transducer_tracking_results = get_transducer_tracking_results_in_openlifu_session_format(
             session_id=self.get_session_id(),
             units = transducer_openlifu.units,
         )

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -197,10 +197,15 @@ class SlicerOpenLIFUSession:
 
         return self.session.session
 
-    def toggle_transducer_tracking_approval(self) -> None:
-        """Approve transducer tracking if it was not approved. Revoke approval if it was approved."""
-        self.session.session.transducer_tracking_approved = not self.session.session.transducer_tracking_approved
+    def get_transducer_tracking_approvals(self):
+        """Get the transducer tracking approval state in the current session object, a list of photoscan IDs for which
+        transducer tracking is approved.
+        """
+        session_openlifu = self.session.session
+        approved_tt_photoscans = [
+            photoscan_id for photoscan_id in self.get_affiliated_photoscan_ids()
+            for tt_result in session_openlifu.transducer_tracking_results
+            if photoscan_id == tt_result.photoscan_id and tt_result.transducer_tracking_approved
+        ]
 
-    def transducer_tracking_is_approved(self) -> bool:
-        """Return whether transducer tracking has been approved"""
-        return self.session.session.transducer_tracking_approved
+        return approved_tt_photoscans

--- a/OpenLIFULib/OpenLIFULib/simulation.py
+++ b/OpenLIFULib/OpenLIFULib/simulation.py
@@ -5,7 +5,7 @@ import vtk
 from vtk.util import numpy_support
 import slicer
 from slicer import vtkMRMLScalarVolumeNode
-from OpenLIFULib.coordinate_system_utils import get_RAS2IJK
+from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.lazyimport import xarray_lz
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ def make_xarray_in_transducer_coords_from_volume(volume_node:vtkMRMLScalarVolume
     # IJK : the volume node's underlying data array indices
     ijk2xyz = np.concatenate([np.concatenate([np.diag(spacing),origin.reshape(3,1)], axis=1), np.array([0,0,0,1],dtype=origin.dtype).reshape(1,4)])
     xyz2ras = slicer.util.arrayFromTransformMatrix(transducer.transform_node)
-    ras2IJK = get_RAS2IJK(volume_node)
+    ras2IJK = np.linalg.inv(get_IJK2RAS(volume_node))
     ijk2IJK = ras2IJK @ xyz2ras @ ijk2xyz
     volume_resampled_array = affine_transform(
         slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)), # the array indices come in KJI rather than IJK so we permute them

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -1,0 +1,16 @@
+"""Skin segmentation tools useful mainly for debugging"""
+
+from OpenLIFULib.lazyimport import openlifu_lz
+from slicer import vtkMRMLScalarVolumeNode, vtkMRMLModelNode
+from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
+import slicer
+
+def generate_skin_mesh(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLModelNode:
+    volume_array = slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)) # the array indices come in KJI rather than IJK so we permute them
+    volume_affine_RAS = get_IJK2RAS(volume_node)
+    foreground_mask_array = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+    foreground_mask_vtk_image = openlifu_lz().seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
+    skin_mesh = openlifu_lz().seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
+    skin_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
+    skin_node.SetAndObservePolyData(skin_mesh)
+    return skin_node

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -1,0 +1,207 @@
+import slicer
+from slicer import vtkMRMLTransformNode
+from typing import Iterable, Optional, Tuple, Union, List, TYPE_CHECKING
+from OpenLIFULib.transform_conversion import transform_node_to_openlifu, transform_node_from_openlifu
+from OpenLIFULib.lazyimport import openlifu_lz
+
+if TYPE_CHECKING:
+    from openlifu.db.session import TransducerTrackingResult
+    from openlifu import Transducer
+
+def add_transducer_tracking_result(
+        transducer_to_photoscan_transform_node: vtkMRMLTransformNode,
+        photoscan_to_volume_transform_node: vtkMRMLTransformNode,
+        photoscan_id: str,
+        session_id: Optional[str] = None,
+        transducer_to_photoscan_approval_status: bool = False,
+        photoscan_to_volume_approval_status: bool = False,
+        replace = False,
+        ) -> Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]:
+    
+    # Should only be one per photoscan/per session
+    existing_tt_result_nodes = get_transducer_tracking_results(photoscan_id=photoscan_id, session_id=session_id) # Returns a list of tuples
+    if session_id is None:
+        existing_tt_result_nodes = filter(
+            lambda t : t.GetAttribute("TT:sessionID") is None,
+            existing_tt_result_nodes,
+        ) # if a sessionless TT result is being added, conflict should only occur among other sessionless results, hence this filtering
+
+    for existing_tt_result_node in existing_tt_result_nodes:
+        if replace:
+            slicer.mrmlScene.RemoveNode(existing_tt_result_node[0])  
+            slicer.mrmlScene.RemoveNode(existing_tt_result_node[1]) 
+        else:
+            raise RuntimeError("There is already a transducer tracking result node for this photoscan+session and replace is False")
+    
+    transducer_to_photoscan_transform_node.SetName(f"TT transducer-photoscan {photoscan_id}")
+    transducer_to_photoscan_transform_node.SetAttribute("isTT-TransducerPhotoscanResult","1")
+    transducer_to_photoscan_transform_node.SetAttribute("TT:approvalStatus", "1" if transducer_to_photoscan_approval_status else "0")
+    transducer_to_photoscan_transform_node.SetAttribute("TT:photoscanID", photoscan_id)
+    if session_id is not None:
+        transducer_to_photoscan_transform_node.SetAttribute("TT:sessionID", session_id)
+    
+    photoscan_to_volume_transform_node.SetName(f"TT photoscan-volume {photoscan_id}")
+    photoscan_to_volume_transform_node.SetAttribute("isTT-PhotoscanVolumeResult","1")
+    photoscan_to_volume_transform_node.SetAttribute("TT:approvalStatus", "1" if photoscan_to_volume_approval_status else "0")
+    photoscan_to_volume_transform_node.SetAttribute("TT:photoscanID", photoscan_id)
+    if session_id is not None:
+        photoscan_to_volume_transform_node.SetAttribute("TT:sessionID", session_id)
+    
+    return [transducer_to_photoscan_transform_node, photoscan_to_volume_transform_node]
+
+def get_transducer_tracking_results_in_openlifu_session_format(session_id:str, units:str) -> List["TransducerTrackingResult"]:
+    """Parse through transducer tracking transform nodes in the scene and return the information in Session representation.
+
+    Args:
+        session_id: The ID of the session whose transducer tracking result transform nodes we are interested in.
+        units: The units of the transducer that the virtual fit transform nodes are meant to apply to.
+            (If the transducer model is not in "mm" then there is a built in unit conversion in the transform
+            node matrix and this has to be removed to represent the transform in openlifu format.)
+
+    Returns the transducer tracking results in openlifu Session format. To understand this format, see the documentation of
+    openlifu.db.Session.transducer_tracking_results.
+
+    See also the reverse function `add_transducer_tracking_results_from_openlifu_session_format`.
+    """
+    
+    tt_nodes_for_session = get_transducer_tracking_results(session_id=session_id)
+    photoscan_ids = [transducer_photoscan.GetAttribute("TT:photoscanID") for (transducer_photoscan, photoscan_volume) in tt_nodes_for_session]
+    transducer_tracking_results_openlifu = []
+    for photoscan_id in photoscan_ids:
+        tt_nodes_for_photoscan = get_transducer_tracking_results(
+            session_id=session_id,
+            photoscan_id=photoscan_id,
+        )
+        # Confirm that length == 1
+        transducer_photoscan_node, photoscan_volume_node = tt_nodes_for_photoscan[0]
+        approved : bool = transducer_photoscan_node.GetAttribute("TT:approvalStatus") == "1" and photoscan_volume_node.GetAttribute("TT:approvalStatus") == "1" 
+        transducer_tracking_results_openlifu.append(
+            TransducerTrackingResult(
+                    photoscan_id,
+                    transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
+                    transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
+                    approved
+                    )
+        )
+
+    return transducer_tracking_results_openlifu
+
+def add_transducer_tracking_results_from_openlifu_session_format(
+        tt_results_openlifu : List["TransducerTrackingResult"],
+        session_id:str,
+        transducer:"Transducer",
+        replace = False,
+        ) -> List[Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]]:
+    """Read the openlifu session format and load the data into the slicer scene as 
+    two transducer tracking result nodes representing the tranducer to photoscan and photoscan to volume
+     transforms respectively .
+
+    Args:
+        tt_results_openlifu: Transducer tracking results in the openlifu session format. 
+        session_id: The ID of the session with which to tag these virtual fit result nodes.
+        transducer: The openlifu Transducer of the session. It is needed to configure transforms to be
+            in the correct units.
+        replace: Whether to replace any existing transducer tracking results that have the
+            same session ID and photoscan ID. If this is off, then an error is raised
+            in the event that there is already a matching transducer tracking result in the scene.
+
+    Returns a list of tuples, with the pairs of nodes added.
+
+    See also the reverse function `get_transducer_tracking_results_in_openlifu_session_format`
+    """
+    nodes_that_have_been_added = []
+    for tt_result in tt_results_openlifu:
+
+        transducer_to_photoscan_transform_node = transform_node_from_openlifu(
+                openlifu_transform_matrix = tt_result.transducer_to_photoscan_transform.matrix,
+                transform_units = tt_result.transducer_to_photoscan_transform.units,
+                transducer = transducer,
+            )
+        
+        photoscan_to_volume_transform_node = transform_node_from_openlifu(
+                openlifu_transform_matrix = tt_result.photoscan_to_volume_transform.matrix,
+                transform_units = tt_result.photoscan_to_volume_transform.units,
+                transducer = transducer,
+            )
+        
+        nodes_added = add_transducer_tracking_result(
+            transducer_to_photoscan_transform_node = transducer_to_photoscan_transform_node,
+            photoscan_to_volume_transform_node = photoscan_to_volume_transform_node,
+            photoscan_id = tt_result.photoscan_id,
+            transducer_to_photoscan_approval_status = tt_result.transducer_tracking_approved,
+            photoscan_to_volume_approval_status = tt_result.transducer_tracking_approved,
+            session_id = session_id,
+            replace=replace
+        )
+        nodes_that_have_been_added.append(nodes_added)
+
+    return nodes_that_have_been_added
+
+def get_transducer_tracking_results(
+        photoscan_id : Optional[str] = None,
+        session_id : Optional[str] = None) -> Iterable[Tuple[vtkMRMLTransformNode,vtkMRMLTransformNode]]:
+    
+    """Retrieve a list of all transducer tracking result nodes, filtered as desired.
+    Each transducer tracking result is given as a Tuple (Transducer-Photoscan transform node, Photoscan-Volume transform node)
+
+    Args:
+        photoscan_id: filter for only this photoscan ID
+        session_id: filter for only this session ID
+
+    Returns the list of matching transducer tracking results that are currently in the scene.
+    """
+
+    tp_nodes = [t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if t.GetAttribute("isTT-TransducerPhotoscanResult") == "1"]
+    pv_nodes = [t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if t.GetAttribute("isTT-PhotoscanVolumeResult") == "1"]
+    tt_result_nodes : Iterable[Tuple[vtkMRMLTransformNode,vtkMRMLTransformNode]] = [
+        (t, p) for t in tp_nodes for p in pv_nodes if t.GetAttribute("TT:photoscanID") == p.GetAttribute("TT:photoscanID")]
+
+    if session_id is not None:
+        tt_result_nodes = filter(lambda t : t[0].GetAttribute("TT:sessionID") == session_id, tt_result_nodes)
+
+    if photoscan_id is not None:
+        tt_result_nodes = filter(lambda t : t[0].GetAttribute("TT:photoscanID") == photoscan_id, tt_result_nodes)
+
+    return tt_result_nodes
+
+def get_approved_photoscan_ids(session_id: str) -> List[str]:
+    """List all photoscan IDs for which there is a transducer tracking result node in the scene that has an approval on it.
+
+    Args:
+        session_id: optional session ID. If None then **only transducer results with no session ID are included**.
+    """
+
+    nodes = get_transducer_tracking_results(session_id=session_id)
+
+    # If session_id None, then at this point `nodes`` is not filtered for session ID
+    # So here we specifically filter for nodes that are have *no* session id:
+    if session_id is None:
+        nodes = filter(lambda t : t[0].GetAttribute("TT:sessionID") is None, nodes)
+
+    # Both transform nodes need to be approved for the photoscan to be approved
+    return [t.GetAttribute("TT:photoscanID") for (t,p) in nodes if (t.GetAttribute("TT:approvalStatus") == "1") and (p.GetAttribute("TT:approvalStatus") == "1")]
+
+def set_transducer_tracking_approval_for_node(approval_state: bool, transform_node: vtkMRMLTransformNode) -> None:
+    """Set approval state on the given transducer tracking transform node.
+
+    Args:
+        approval_state: new approval state to apply
+        transform_node: vtkMRMLTransformNode
+    """
+    transform_node.SetAttribute("TT:approvalStatus", "1" if approval_state else "0")
+
+def get_photoscan_id_from_transducer_tracking_result(result: Union[vtkMRMLTransformNode, Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]]) -> str:
+    
+    if isinstance(result, vtkMRMLTransformNode):
+        transform_node = result
+    elif isinstance(result,tuple):
+        if result[0].GetAttribute("TT:photoscanID") != result[1].GetAttribute("TT:photoscanID"):
+            raise RuntimeError("Transducer tracking transducer-photoscan and photoscan-volume transforms have mismatched photoscan IDs.")
+        elif result[0].GetAttribute("TT:photoscanID") is None or result[1].GetAttribute("TT:photoscanID") is None:
+            raise RuntimeError("Transducer tracking result does not have a photoscan ID.")
+        # Following the above checks, we can return the photoscanID attribute using either transform node
+        transform_node = result[0]
+    else:
+        raise ValueError("Invalid transducer tracking result type.")
+    
+    return transform_node.GetAttribute("TT:photoscanID")

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -1,0 +1,96 @@
+import slicer
+import qt
+from typing import Tuple, Optional
+from slicer import qMRMLThreeDWidget, vtkMRMLViewNode
+from OpenLIFULib.util import replace_widget
+from OpenLIFULib import SlicerOpenLIFUPhotoscan
+
+
+def create_dialog_with_viewnode(dialog_title : str, view_node: vtkMRMLViewNode, ui_path: str) -> Tuple[slicer.qMRMLThreeDWidget, qt.QDialog]:
+        
+    # Create a threeD widget with the viewNode for displaying the photoscan
+    # This widget gets destroyed with the dialog so needs to be created each time
+    photoscanViewWidget = slicer.qMRMLThreeDWidget()
+    photoscanViewWidget.setMRMLScene(slicer.mrmlScene)
+    photoscanViewWidget.setMRMLViewNode(view_node)
+    
+    # Create dialog for photoscan preview and add threeD view widget to dialog
+    dialog = slicer.util.loadUI(ui_path)
+    ui = slicer.util.childWidgetVariables(dialog)
+    dialog.setWindowTitle(dialog_title)
+    replace_widget(ui.photoscanPlaceholderWidget, photoscanViewWidget, ui)
+
+    return dialog 
+
+def create_threeD_photoscan_view_node():
+    
+    # Layout name is used to create and identify the underlying view node 
+    layoutName = "PhotoscanCoordinates"
+    layoutLabel = "Photoscan Co-ordinate Space"
+    layoutColor = [0.97, 0.54, 0.12] # Orange
+    # ownerNode manages this view instead of the layout manager (it can be any node in the scene)
+    viewOwnerNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode")
+
+    # Create a view node if it hasn't been previously created
+    viewNode = slicer.util.getFirstNodeByClassByName('vtkMRMLViewNode','ViewPhotoscan')
+    if not viewNode:
+        viewLogic = slicer.vtkMRMLViewLogic()
+        viewLogic.SetMRMLScene(slicer.mrmlScene)
+        viewNode = viewLogic.AddViewNode(layoutName)
+        viewNode.SetName('ViewPhotoscan')
+        viewNode.SetLayoutLabel(layoutLabel)
+        viewNode.SetLayoutColor(layoutColor)
+        viewNode.SetAndObserveParentLayoutNodeID(viewOwnerNode.GetID())
+
+        # Customize view node. 
+        viewNode.SetBackgroundColor(0.98, 0.9,0.77) # shades of orange
+        viewNode.SetBackgroundColor2(0.98,0.58,0.4)
+        viewNode.SetBoxVisible(False) # Turn off bounding box visibility
+        viewNode.SetAxisLabelsVisible(False) # Turn off axis labels visibility
+
+    return viewNode
+
+def display_photoscan_in_viewnode(photoscan: SlicerOpenLIFUPhotoscan, view_node: vtkMRMLViewNode, reset_camera_view: bool = False) -> None:
+    """ When a display node is created, by default, no viewIDs are set. When GetViewNodeIDs is null, the node is displayed
+    in all views. Therefore, to restrict nodes from being displayed in the photoscan preview widget, we need to set the 
+    viewNodeIDs of any displayed nodes to IDs of all viewNodes in the scene, excluding the photoscan widget."""
+
+    # IDs of all the view nodes in the main Window. This excludes the photoscan widget's view node
+    views_mainwindow = [node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') if node.GetID() != view_node.GetID()]
+    
+    # Set the view nodes for all displayable nodes.
+    # If GetViewNodeIDs() is (), the node is displayed in all views so we need to exclude the photoscan view
+    for displayable_node in list(slicer.util.getNodesByClass('vtkMRMLDisplayableNode')):
+        if displayable_node.IsA('vtkMRMLScalarVolumeNode'):
+            # Check for any volume renderings
+            vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(displayable_node)
+            if vrDisplayNode and vrDisplayNode.GetVisibility() and not vrDisplayNode.GetViewNodeIDs():
+                    vrDisplayNode.SetViewNodeIDs(views_mainwindow)
+        elif displayable_node.GetDisplayVisibility() and not displayable_node.GetDisplayNode().GetViewNodeIDs():
+            displayable_node.GetDisplayNode().SetViewNodeIDs(views_mainwindow)
+    
+    # Set the view nodes for the Red, Green and Yellow slice nodes if empty
+    for slice_node in list(slicer.util.getNodesByClass('vtkMRMLSliceNode')):
+        if slice_node.GetNumberOfThreeDViewIDs() == 0:
+            for view_nodeID in views_mainwindow:
+                slice_node.AddThreeDViewID(view_nodeID)
+
+    # Display the photoscan 
+    photoscan.toggle_model_display(visibility_on = True, viewNode = view_node) # Specify a view node for display
+
+    # Center and fit displayed photoscan in 3D view.
+    # This should only happen when the user is viewing the photoscan for the first time. 
+    # If the user has previously interacted with the 3Dview widget, then
+    # maintain the previous camera/focal point. 
+    if reset_camera_view:
+        layoutManager = slicer.app.layoutManager()
+        for threeDViewIndex in range(layoutManager.threeDViewCount):
+            view = layoutManager.threeDWidget(threeDViewIndex).threeDView()
+            if view.mrmlViewNode().GetID() == view_node.GetID():
+                photoscanViewIndex = threeDViewIndex
+        
+        threeDWidget = layoutManager.threeDWidget(photoscanViewIndex)
+        threeDView = threeDWidget.threeDView() 
+        threeDView.rotateToViewAxis(3)  # look from anterior direction
+        threeDView.resetFocalPoint()  # reset the 3D view cube size and center it
+        threeDView.resetCamera()  # reset camera zoom

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -23,26 +23,28 @@ def create_dialog_with_viewnode(dialog_title : str, view_node: vtkMRMLViewNode, 
 
     return dialog 
 
-def create_threeD_photoscan_view_node(layout_name = "PhotoscanCoordinates"):
+def create_threeD_photoscan_view_node(photoscan_id: str):
     """Creates view node for displaying the photoscan model. Before transducer tracking registration,
      a subject's photoscan lives in a different coordinate space than their volume. Therefore we need to create
-    a separate view node for visualizing the photoscan before registration"""
+    a separate view node for visualizing the photoscan before registration
+    
+    Args: photoscan_id This is used to set the name of the view node"""
     
     # Layout name is used to create and identify the underlying view node 
-    layoutName = layout_name
+    layoutName = f"PhotoscanCoordinates-{photoscan_id}"
     layoutLabel = "Photoscan Co-ordinate Space"
     layoutColor = [0.97, 0.54, 0.12] # Orange background
     # ownerNode manages this view instead of the layout manager (it can be any node in the scene)
     viewOwnerNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode")
 
-    viewNode = slicer.util.getFirstNodeByClassByName('vtkMRMLViewNode',f'view{layout_name}')
+    viewNode = slicer.util.getFirstNodeByClassByName('vtkMRMLViewNode',f'view-{photoscan_id}')
     if not viewNode:
         viewLogic = slicer.vtkMRMLViewLogic()
         viewLogic.SetMRMLScene(slicer.mrmlScene)
         viewNode = viewLogic.AddViewNode(layoutName)
-        viewNode.SetName(f'view{layout_name}')
         viewNode.SetLayoutLabel(layoutLabel)
         viewNode.SetLayoutColor(layoutColor)
+        viewNode.SetName(f'view-{photoscan_id}')
         viewNode.SetAndObserveParentLayoutNodeID(viewOwnerNode.GetID())
 
     # Customize view node. 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -322,12 +322,16 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateTrackingApprovalStatus(self) -> None:
         loaded_session = get_openlifu_data_parameter_node().loaded_session
         if loaded_session is not None:
-            if loaded_session.transducer_tracking_is_approved():
-                self.ui.trackingApprovalStatusLabel.text = f"(Transducer tracking is approved)"
-                self.ui.trackingApprovalStatusLabel.styleSheet = ""
-            else:
-                self.ui.trackingApprovalStatusLabel.text = f"WARNING: Transducer tracking is currently unapproved!"
+            photoscan_ids = loaded_session.get_transducer_tracking_approvals()
+            if len(photoscan_ids) == 0:
+                self.ui.trackingApprovalStatusLabel.text = f"WARNING: Transducer tracking is not approved for any photoscans!"
                 self.ui.trackingApprovalStatusLabel.styleSheet = "color:red;"
+            else:
+                self.ui.trackingApprovalStatusLabel.text = (
+                    "Transducer tracking is approved for the following photoscans:\n- "
+                    + "\n- ".join(photoscan_ids)
+                )
+                self.ui.trackingApprovalStatusLabel.styleSheet = ""
         else:
             self.ui.trackingApprovalStatusLabel.text = ""
 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -24,7 +24,7 @@ from OpenLIFULib import (
     OpenLIFUAlgorithmInputWidget,
     SlicerOpenLIFUSolutionAnalysis,
 )
-from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem
+from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem, get_openlifu_data_parameter_node
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -306,9 +306,9 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.logic.hide_pnp()
 
     def updateVirtualFitApprovalStatus(self) -> None:
-        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        if data_logic.validate_session():
-            target_ids = data_logic.get_virtual_fit_approvals_in_session()
+        loaded_session = get_openlifu_data_parameter_node().loaded_session
+        if loaded_session is not None:
+            target_ids = loaded_session.get_virtual_fit_approvals()
             if len(target_ids) == 0:
                 self.ui.virtualFitApprovalStatusLabel.text = ""
             else:
@@ -329,7 +329,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 self.ui.trackingApprovalStatusLabel.text = f"WARNING: Transducer tracking is currently unapproved!"
                 self.ui.trackingApprovalStatusLabel.styleSheet = "color:red;"
         else:
-            self.ui.virtualFitApprovalStatusLabel.text = ""
+            self.ui.trackingApprovalStatusLabel.text = ""
 
     def updateApproveButton(self):
         data_parameter_node = get_openlifu_data_parameter_node()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -28,7 +28,7 @@ from OpenLIFULib.transducer_tracking_results import (
     add_transducer_tracking_result,
     get_photoscan_id_from_transducer_tracking_result,
     set_transducer_tracking_approval_for_node,
-    get_approved_photoscan_ids
+    get_photoscan_ids_with_results,
 )
 
 from OpenLIFULib.transducer_tracking_wizard_utils import (
@@ -645,7 +645,7 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
         
         session = get_openlifu_data_parameter_node().loaded_session
         session_id = None if session is None else session.get_session_id()
-        approved_photoscan_ids = get_approved_photoscan_ids(session_id=session_id)
+        approved_photoscan_ids = get_photoscan_ids_with_results(session_id=session_id, approved_only = True)
         return approved_photoscan_ids
     
     def load_openlifu_photoscan(self, photoscan: "openlifu.Photoscan") -> SlicerOpenLIFUPhotoscan:

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -205,12 +205,10 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.algorithm_input_widget.connect_combobox_indexchanged_signal(self.checkCanRunTracking)
 
         self.ui.runTrackingButton.clicked.connect(self.onRunTrackingClicked)
-        self.ui.approveButton.clicked.connect(self.onApproveClicked)
         self.ui.skinSegmentationModelqMRMLNodeComboBox.currentNodeChanged.connect(self.checkCanRunTracking) # Temporary functionality
         self.ui.previewPhotoscanButton.clicked.connect(self.onPreviewPhotoscanClicked)
 
         self.updatePhotoscanGenerationButtons()
-        self.updateApproveButton()
         self.updateApprovalStatusLabel()
 
     def cleanup(self) -> None:
@@ -263,7 +261,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def onDataParameterNodeModified(self, caller, event) -> None:
         self.updatePhotoscanGenerationButtons()
-        # self.updateApproveButton()
         # self.updateApprovalStatusLabel()
         self.updateInputOptions()
         
@@ -610,25 +607,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateAddPhotocollectionToSessionButton()
         self.updateStartPhotoscanGenerationButton()
 
-    def updateApproveButton(self):
-        if get_openlifu_data_parameter_node().loaded_session is None:
-            self.ui.approveButton.setEnabled(False)
-            self.ui.approveButton.setToolTip("There is no active session to write the approval")
-            self.ui.approveButton.setText("Approve transducer tracking")
-        else:
-            self.ui.approveButton.setEnabled(True)
-            session_openlifu = get_openlifu_data_parameter_node().loaded_session.session.session
-            if session_openlifu.transducer_tracking_approved:
-                self.ui.approveButton.setText("Unapprove transducer tracking")
-                self.ui.approveButton.setToolTip(
-                    "Revoke approval that the current transducer positioning is accurately tracking the real transducer configuration relative to the subject"
-                )
-            else:
-                self.ui.approveButton.setText("Approve transducer tracking")
-                self.ui.approveButton.setToolTip(
-                    "Approve the current transducer positioning as accurately tracking the real transducer configuration relative to the subject"
-                )
-
     def updateApprovalStatusLabel(self):
         
         approved_photoscan_ids = self.logic.get_approved_photoscan_ids()
@@ -640,8 +618,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 + "\n- ".join(approved_photoscan_ids)
             )
 
-    def onApproveClicked(self):
-        self.logic.toggleTransducerTrackingApproval()
 
 #
 # OpenLIFUTransducerTrackerLogic

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -145,13 +145,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="approveButton">
-        <property name="text">
-         <string>Approve transducer tracking</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QLabel" name="approvalStatusLabel">
         <property name="text">
          <string>(approval status label)</string>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>526</width>
+    <width>520</width>
     <height>384</height>
    </rect>
   </property>
@@ -16,9 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
-      <widget class="QWidget" name="photoscanPlaceholderWidget" native="true"/>
-     </item>
      <item>
       <widget class="QLabel" name="photoscanApprovalStatusLabel">
        <property name="text">
@@ -26,25 +23,76 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="photoscanApprovalButton">
-       <property name="text">
-        <string>Approve Photoscan</string>
+     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+      <widget class="QWidget" name="photoscanPlaceholderWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="placeLandmarksButton">
-       <property name="text">
-        <string>Place Registration Landmarks</string>
+      <widget class="QStackedWidget" name="dialogControls">
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="qSlicerMarkupsPlaceWidget" name="photoscanMarkupsPlaceWidget">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
+       <widget class="QWidget" name="photoscanPreview">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QPushButton" name="photoscanApprovalButton">
+           <property name="text">
+            <string>Approve Photoscan</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="photoscanMarkup">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QPushButton" name="placeLandmarksButton">
+           <property name="text">
+            <string>Place Registration Landmarks</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="qSlicerMarkupsPlaceWidget" name="photoscanMarkupsPlaceWidget">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>520</width>
-    <height>384</height>
+    <width>580</width>
+    <height>751</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,87 +15,93 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QLabel" name="photoscanApprovalStatusLabel">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
-      <widget class="QWidget" name="photoscanPlaceholderWidget" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QStackedWidget" name="dialogControls">
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QWidget" name="photoscanPreview">
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QPushButton" name="photoscanApprovalButton">
-           <property name="text">
-            <string>Approve Photoscan</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="photoscanMarkup">
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QPushButton" name="placeLandmarksButton">
-           <property name="text">
-            <string>Place Registration Landmarks</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="qSlicerMarkupsPlaceWidget" name="photoscanMarkupsPlaceWidget">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QLabel" name="photoscanApprovalStatusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="photoscanPlaceholderWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>560</width>
+       <height>560</height>
+      </size>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="dialogControls">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="photoscanPreview">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QPushButton" name="photoscanApprovalButton">
+         <property name="text">
+          <string>Approve Photoscan</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="photoscanMarkup">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QPushButton" name="placeLandmarksButton">
+         <property name="text">
+          <string>Place/Edit Registration Landmarks</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
+         <property name="nodeSelectorVisible">
+          <bool>false</bool>
+         </property>
+         <property name="optionsVisible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton">
+         <property name="text">
+          <string>Next</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -107,9 +113,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>qSlicerMarkupsPlaceWidget</class>
+   <class>qSlicerSimpleMarkupsWidget</class>
    <extends>qSlicerWidget</extends>
-   <header>qSlicerMarkupsPlaceWidget.h</header>
+   <header>qSlicerSimpleMarkupsWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/PhotoscanPreview.ui
@@ -93,7 +93,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButton">
+        <widget class="QPushButton" name="nextStepButton">
          <property name="text">
           <string>Next</string>
          </property>


### PR DESCRIPTION
Closes #157 
Partly addresses #149 

Following the changes in this PR, things to test are:

_Related to #157_ 
- Sessions using the new transducer tracking result format i.e. session `demo_4_simulated` with the changes introduced in https://github.com/OpenwaterHealth/OpenLIFU-python/pull/189 can be loaded into Slicer. If the session has a TT result,  two associated transducer tracking transform nodes are added under the transder folder. If the transducer transforms are both approved, then there is also a transducer tracking approval status message in the data and transducer tracking module. Similar to VF, the results are stored as transform node attributes.
     -  When a session is cleared, the transform nodes get cleared
     -   When you save the session, it should write the transducer tracking result to the database. I tested this after modifying the approval status programtically for session `demo_4_simulated` that has a dummy transducer tracking result:
     `m = slicer.util.getNode("TT photoscan-volume scan123");
m.SetAttribute("TT:approvalStatus","0")`
     - Things to complete:
          -**TODO:** When the approval state of a transform node is toggled, the approval status message should update accordingly. This will be implemeted once the UI and workflow for toggling transform approval is in place. 
          -**TO THINK ABOUT:** Is any action taken when a transform node is removed. Should a user get prompted that a transducer tracking result node was removed and that saving the session would clear the result from the database?
        
_Related to issue #149_ 
- The photoscan preview dialog only allows toggling of photoscan approval. When the preview is opened for the first time, the photoscan is centered in the view. If the user moves the photoscan around/zoom in etc, these view settings are preserved the next time the preview is opened. If there are associated registration landmarks, these are also visible in the view. Approval of the photoscan can only be toggled in the preview mode.
- When `Run Transducer Tracking` is clicked, a dialog with the photoscan view opens up. The user now has the option to place landmarks on the photoscan. The fiducial node is added with 3 labelled control points at the origin - additional points cannot be added. This will be updated when addressing #196.
- When `Next` is clicked in the TT wizard, for now, the skin segmentation is computed and added to the scene. The next PR will continue building the end-to-end TT wizard workflow, further addressing #149 . 
- Things to complete later:
   - **TODO**: When there is an active session, the `Run Transducer Tracking` button should not be enabled unless the photoscan is approved. In the manual workflow, approval does not matter. This will be addressed in the next PR, when the skin segmentation model option is removed.
   - **TO THINK ABOUT:** Adding checks for if fiducial nodes are deleted/control points are removed etc. 