### PR TITLE
Integrate Hardware Interface and Test Mode Toggle

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@153dede6fcd51826a2ee0e9319d55ca79b43a9b7 # keep this version and switch back later
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@3824006773a98216e4bdbf9c62a39002d9408dd2
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@3824006773a98216e4bdbf9c62a39002d9408dd2
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@153dede6fcd51826a2ee0e9319d55ca79b43a9b7 # keep this version and switch back later
 bcrypt

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -390,10 +390,10 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             import traceback
             traceback.print_exc()
             self.logic.cur_lifu_interface = None
-            self.ui.manuallyGetDeviceStatusLabel.setProperty("text", "Operation failed.")
+            slicer.util.infoDisplay(text=f"Operation failed.", windowTitle="Device Status")
             return
 
-        self.ui.manuallyGetDeviceStatusLabel.setProperty("text", f"{self.logic.cur_lifu_interface.get_status()}")
+        slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status()}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -218,7 +218,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
         # Buttons
-        self.ui.connectLIFUDevicePushButton.clicked.connect(self.onConnectLIFUDevicePushButtonClicked)
+        self.ui.reinitializeLIFUInterfacePushButton.clicked.connect(self.onReinitializeLIFUInterfacePushButtonClicked)
         self.ui.sendSonicationSolutionToDevicePushButton.clicked.connect(self.onSendSonicationSolutionToDevicePushButtonClicked)
         self.ui.runPushButton.clicked.connect(self.onRunClicked)
         self.ui.abortPushButton.clicked.connect(self.onAbortClicked)
@@ -312,17 +312,17 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._cur_solution_id = solution_parameter_pack.solution.solution.id
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
-    def updateConnectLIFUDevicePushButtonEnabled(self):
+    def updateReinitializeLIFUInterfacePushButtonEnabled(self):
 
         if self.logic.running:
             enabled = False
-            tooltip = "Cannot reset connection while a sonication is running."
+            tooltip = "Cannot reinitialize LIFUInterface while a sonication is running."
         else:
             enabled = True
-            tooltip = "Connect or reconnect to the connected hardware."
+            tooltip = "Reinitialize LIFUInterface, an interface to the connected hardware."
 
-        self.ui.connectLIFUDevicePushButton.setEnabled(enabled) # TODO: all references to this button should instead refer to initializing a LIFUInterface instead
-        self.ui.connectLIFUDevicePushButton.setToolTip(tooltip)
+        self.ui.reinitializeLIFUInterfacePushButton.setEnabled(enabled)
+        self.ui.reinitializeLIFUInterfacePushButton.setToolTip(tooltip)
 
     @display_errors
     def updateManuallyGetDeviceStatusPushButtonEnabled(self, checked=False):
@@ -380,7 +380,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.abortPushButton.setEnabled(self.logic.running)
 
     def updateAllButtonsEnabled(self):
-        self.updateConnectLIFUDevicePushButtonEnabled()
+        self.updateReinitializeLIFUInterfacePushButtonEnabled()
         self.updateManuallyGetDeviceStatusPushButtonEnabled()
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
@@ -420,7 +420,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateAllButtonsEnabled()
 
     @display_errors
-    def onConnectLIFUDevicePushButtonClicked(self, checked=False):
+    def onReinitializeLIFUInterfacePushButtonClicked(self, checked=False):
         if self.ui.testModeCheckBox.isChecked():
             self.logic.reinitialize_lifu_interface(test_mode=True)
             slicer.util.infoDisplay(text="LIFUInterface reinitialized in test_mode")
@@ -454,7 +454,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status().name}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
-        self.updateConnectLIFUDevicePushButtonEnabled()
+        self.updateReinitializeLIFUInterfacePushButtonEnabled()
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
         self.updateAbortEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -251,6 +251,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # Update the state of any buttons that may not yet have been updated
         self.updateAllButtonsEnabled()
+        self.updateAllButtons()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -386,6 +387,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateRunEnabled()
         self.updateAbortEnabled()
 
+    def updateReinitializeLIFUInterfacePushButton(self):
+        if self.logic.cur_lifu_interface._test_mode:
+            self.ui.reinitializeLIFUInterfacePushButton.setText("Reinitialize LIFUInterface not in test_mode")
+        else:
+            self.ui.reinitializeLIFUInterfacePushButton.setText("Reinitialize LIFUInterface in test_mode")
+
+    def updateAllButtons(self):
+        self.updateReinitializeLIFUInterfacePushButton()
+
     @display_errors
     def onRunCompleted(self, new_sonication_run_complete_state: bool):
         """If the soniction_run_complete variable changes from False to True, then open the RunComplete 
@@ -421,15 +431,17 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     @display_errors
     def onReinitializeLIFUInterfacePushButtonClicked(self, checked=False):
-        if self.ui.testModeCheckBox.isChecked():
+        new_test_mode_state = not self.logic.cur_lifu_interface._test_mode
+        if new_test_mode_state:
             self.logic.reinitialize_lifu_interface(test_mode=True)
             slicer.util.infoDisplay(text="LIFUInterface reinitialized in test_mode")
         else:
             self.logic.reinitialize_lifu_interface(test_mode=False)
-            slicer.util.infoDisplay(text="LIFUInterface reinitialized")
+            slicer.util.infoDisplay(text="LIFUInterface reinitialized not in test_mode")
 
         self.updateDeviceConnectedStateFromDevice()
         self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
+        self.updateAllButtons()
         self.updateAllButtonsEnabled()
 
     @display_errors

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -393,7 +393,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             slicer.util.infoDisplay(text=f"Operation failed.", windowTitle="Device Status")
             return
 
-        slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status()}", windowTitle="Device Status")
+        slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status().name}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
@@ -433,7 +433,8 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateRunHardwareStatusLabel(self, new_run_hardware_status_value=None):
         """Update the label indicating the hardware status of the running hardware."""
         if self.logic.running:
-            self.ui.runHardwareStatusLabel.setProperty("text", f"Hardware status: {new_run_hardware_status_value}")
+            if new_run_hardware_status_value is not None:
+                self.ui.runHardwareStatusLabel.setProperty("text", f"Hardware status: {new_run_hardware_status_value.name}")
         else: # not running
             self.ui.runHardwareStatusLabel.setProperty("text", "Run not in progress.")
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -53,7 +53,7 @@ class OpenLIFUSonicationControl(ScriptedLoadableModule):
             "and development."
         )
 
-class SolutionHardwareState(Enum):
+class SolutionOnHardwareState(Enum):
     SUCCESSFUL_SEND=0
     FAILED_SEND=1
     NOT_SENT=2
@@ -171,14 +171,14 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
-        self._cur_solution_hardware_state : SolutionHardwareState = SolutionHardwareState.NOT_SENT
+        self._cur_solution_on_hardware_state : SolutionOnHardwareState = SolutionOnHardwareState.NOT_SENT
         self._cur_solution_id: str | None = None
         self._parameterNode = None
         self._parameterNodeGuiTag = None
 
     @property
-    def cur_solution_hardware_state(self) -> SolutionHardwareState:
-        return self._cur_solution_hardware_state
+    def cur_solution_on_hardware_state(self) -> SolutionOnHardwareState:
+        return self._cur_solution_on_hardware_state
 
     def setup(self) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
@@ -223,7 +223,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # Initialize UI
         self.updateRunProgressBar()
-        self.updateWidgetSolutionHardwareState(SolutionHardwareState.NOT_SENT)
+        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
         # Add an observer on the Data module's parameter node
         self.addObserver(
@@ -296,10 +296,10 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateRunProgressBar()
         if (solution_parameter_pack := get_openlifu_data_parameter_node().loaded_solution) is None:
             self._cur_solution_id = None
-            self.updateWidgetSolutionHardwareState(SolutionHardwareState.NOT_SENT)
+            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
         elif solution_parameter_pack.solution.solution.id != self._cur_solution_id:
             self._cur_solution_id = solution_parameter_pack.solution.solution.id
-            self.updateWidgetSolutionHardwareState(SolutionHardwareState.NOT_SENT)
+            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
     def updateSendSonicationSolutionToDevicePushButtonEnabled(self):
         solution = get_openlifu_data_parameter_node().loaded_solution
@@ -328,7 +328,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         elif not solution.is_approved():
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("Cannot run because the currently active solution is not approved. It can be approved in the sonication planning module.")
-        elif not self._cur_solution_hardware_state == SolutionHardwareState.SUCCESSFUL_SEND:
+        elif not self._cur_solution_on_hardware_state == SolutionOnHardwareState.SUCCESSFUL_SEND:
             self.ui.runPushButton.enabled = False
             self.ui.runPushButton.setToolTip("To run a sonication, you must send an approved solution to the hardware device.")
         elif self.logic.running:
@@ -370,11 +370,11 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             import traceback
             traceback.print_exc()
             self.logic.cur_lifu_interface = None
-            self.updateWidgetSolutionHardwareState(SolutionHardwareState.FAILED_SEND)
+            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.FAILED_SEND)
             return
         
         self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
-        self.updateWidgetSolutionHardwareState(SolutionHardwareState.SUCCESSFUL_SEND)
+        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.SUCCESSFUL_SEND)
 
         self.updateWorkflowControls()
 
@@ -438,18 +438,18 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         else: # not running
             self.ui.runHardwareStatusLabel.setProperty("text", "Run not in progress.")
 
-    def updateWidgetSolutionHardwareState(self, solution_state: SolutionHardwareState):
-        self._cur_solution_hardware_state = solution_state
-        if solution_state == SolutionHardwareState.SUCCESSFUL_SEND:
+    def updateWidgetSolutionOnHardwareState(self, solution_state: SolutionOnHardwareState):
+        self._cur_solution_on_hardware_state = solution_state
+        if solution_state == SolutionOnHardwareState.SUCCESSFUL_SEND:
             self.ui.solutionStateLabel.setProperty("text", "Solution sent to device.")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: green; border: 1px solid green; padding: 5px;")
             self.updateRunEnabled()
-        elif solution_state == SolutionHardwareState.FAILED_SEND:
+        elif solution_state == SolutionOnHardwareState.FAILED_SEND:
             # TODO: In the event of a failed send, you should add the printout
             self.ui.solutionStateLabel.setProperty("text", "Send to device failed!")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: red; border: 1px solid red; padding: 5px;")
             self.updateRunEnabled()
-        elif solution_state == SolutionHardwareState.NOT_SENT:
+        elif solution_state == SolutionOnHardwareState.NOT_SENT:
             self.ui.solutionStateLabel.setProperty("text", "")  
             self.ui.solutionStateLabel.setProperty("styleSheet", "border: none;")
             self.updateRunEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -218,6 +218,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.logic.call_on_running_changed(self.onRunningChanged)
         self.logic.call_on_sonication_complete(self.onRunCompleted)
         self.logic.call_on_run_progress_updated(self.updateRunProgressBar)
+        self.logic.call_on_run_hardware_status_updated(self.updateRunHardwareStatusLabel)
 
         # Initialize UI
         self.updateRunProgressBar()
@@ -380,6 +381,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
         self.updateAbortEnabled()
+        self.updateRunHardwareStatusLabel()
 
     def onRunClicked(self):
         if not slicer.util.getModuleLogic('OpenLIFUData').validate_solution():
@@ -410,7 +412,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             else:
                 self.ui.runProgressBar.value = 100
 
+    def updateRunHardwareStatusLabel(self, new_run_hardware_status_value=None):
+        """Update the label indicating the hardware status of the running hardware."""
+        if self.logic.running:
+            self.ui.runHardwareStatusLabel.setProperty("text", f"Hardware status: {new_run_hardware_status_value}")
+        else: # not running
+            self.ui.runHardwareStatusLabel.setProperty("text", "Run not in progress.")
+
     def updateWidgetSolutionHardwareState(self, solution_state: SolutionHardwareState):
+        self._cur_solution_hardware_state = solution_state
         if solution_state == SolutionHardwareState.SUCCESSFUL_SEND:
             self.ui.solutionStateLabel.setProperty("text", "Solution sent to device.")
             self.ui.solutionStateLabel.setProperty("styleSheet", "color: green; border: 1px solid green; padding: 5px;")
@@ -464,6 +474,12 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._on_run_progress_updated_callbacks: List[Callable[[int],None]] = []
         """List of functions to call when `run_progress` property is changed."""
 
+        self._run_hardware_status = -1
+        """ The live status of the hardware device as returned during the sonication run."""
+
+        self._on_run_hardware_status_updated_callbacks = []
+        """List of functions to call when `run_hardware_status` property is changed."""
+
         self.cur_lifu_interface: Optional[openlifu.io.LIFUInterface] = None
         """The active LIFUInterface object to the ultrasound hardware."""
 
@@ -491,6 +507,13 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         of progress made by the sonication control algorithm.
         """
         self._on_run_progress_updated_callbacks.append(f)
+
+    def call_on_run_hardware_status_updated(self, f) -> None:
+        """Set a function to be called whenever the `run_hardware_status` property is changed.
+        The provided callback should accept a single int value (from a status enum) which will indicate status
+        of the running openlifu harware device.
+        """
+        self._on_run_hardware_status_updated_callbacks.append(f)
 
     @property
     def running(self) -> bool:
@@ -525,6 +548,17 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         for f in self._on_run_progress_updated_callbacks:
             f(self._run_progress)
 
+    @property
+    def run_hardware_status(self):
+        """The amount of progress made by the sonication algorithm on a scale of 0-100"""
+        return self._run_hardware_status
+    
+    @run_hardware_status.setter
+    def run_hardware_status(self, run_hardware_status_value):
+        self._run_hardware_status = run_hardware_status_value
+        for f in self._on_run_hardware_status_updated_callbacks:
+            f(self._run_hardware_status)
+
     def run(self):
         " Returns True when the sonication control algorithm is done"
 
@@ -532,29 +566,26 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
             raise RuntimeError("No solution loaded; cannot run sonication.")
 
         self.running = True
-        slicer.util.infoDisplay(
-            text=(
-                "The run sonication button is a placeholder. Sonication control is not yet implemented."
-                f" Here the solution that would have been run is {self.cur_solution_on_hardware.id}."
-                " The fake \"run\" will start after you close this dialog and end after three seconds."
-            ),
-            windowTitle="Not implemented"
-        )
+        self.run_progress = 0
+        self.sonication_run_complete = False
 
-        def end_run():
-            """Placeholder function that represents a sonication ending"""
-            self.running = False
-            self.run_progress = 100
-            self.sonication_run_complete = True
+        def poll():
+            self.run_hardware_status = self.cur_lifu_interface.get_status()
+            # ---- TODO ----
+            # The following functions mock the run, as the status is never updated to finished.
+            self.run_progress = 0.9*self.run_progress+11 # 11 because deq converges to 99 because of integer division if adding 10
+            self.sonication_run_complete = self.run_progress >= 99
+            # Replace above with functions that look something like this
+            # self.run_progress = self.cur_lifu_interface.get_progress_percent_as_int()
+            # self.sonication_run_complete = self.cur_lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
+            # --------------
+            if self.sonication_run_complete:
+                self.timer.stop()
+                self.running = False
 
         self.timer = qt.QTimer()
-        self.timer.timeout.connect(end_run) # Assumes that the sonication algorithm can be connected to a function
-        self.timer.setSingleShot(True)
-        self.timer.start(3000)
-
-        # Dummy code to test updating run progress.
-        # TODO: This value should be set based on progress updates provided by the sonication algorithm
-        self.run_progress = 50
+        self.timer.timeout.connect(poll)
+        self.timer.start(500)
 
     def abort(self) -> None:
         # Assumes that the sonication control algorithm will have a callback function to abort run, 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -210,12 +210,11 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
         # Buttons
+        self.ui.connectLIFUDevicePushButton.clicked.connect(self.onconnectLIFUDevicePushButtonClicked)
         self.ui.sendSonicationSolutionToDevicePushButton.clicked.connect(self.onSendSonicationSolutionToDevicePushButtonClicked)
         self.ui.runPushButton.clicked.connect(self.onRunClicked)
         self.ui.abortPushButton.clicked.connect(self.onAbortClicked)
         self.ui.manuallyGetDeviceStatusPushButton.clicked.connect(self.onManuallyGetDeviceStatusPushButtonClicked)
-        self.updateRunEnabled()
-        self.updateAbortEnabled()
         self.logic.call_on_running_changed(self.onRunningChanged)
         self.logic.call_on_sonication_complete(self.onRunCompleted)
         self.logic.call_on_run_progress_updated(self.updateRunProgressBar)
@@ -238,6 +237,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # After setup, update the module state from the data parameter node
         self.onDataParameterNodeModified()
         self.updateWorkflowControls()
+
+        # Update the state of any buttons that may not yet have been updated
+        self.updateAllButtonsEnabled()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -291,9 +293,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
     def onDataParameterNodeModified(self, caller=None, event=None) -> None:
-        self.updateSendSonicationSolutionToDevicePushButtonEnabled()
-        self.updateRunEnabled()
-        self.updateRunProgressBar()
+        self.updateAllButtonsEnabled()
         if (solution_parameter_pack := get_openlifu_data_parameter_node().loaded_solution) is None:
             self._cur_solution_id = None
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
@@ -301,12 +301,38 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._cur_solution_id = solution_parameter_pack.solution.solution.id
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
+    def updateConnectLIFUDevicePushButtonEnabled(self):
+        if self.logic.running:
+            enabled = False
+            tooltip = "Cannot reset connection while a sonication is running."
+        else:
+            enabled = True
+            tooltip = "Connect or reconnect to the connected hardware."
+
+        self.ui.connectLIFUDevicePushButton.setEnabled(enabled)
+        self.ui.connectLIFUDevicePushButton.setToolTip(tooltip)
+
+    @display_errors
+    def updateManuallyGetDeviceStatusPushButtonEnabled(self, checked=False):
+        if self.logic.cur_lifu_interface is None:
+            enabled = False
+            tooltip = "To get the device status you must first initiate a LIFU device connection."
+        else:
+            enabled = True
+            tooltip = "Get the current state of the hardware device."
+
+        self.ui.manuallyGetDeviceStatusPushButton.setEnabled(enabled)
+        self.ui.manuallyGetDeviceStatusPushButton.setToolTip(tooltip)
+
     def updateSendSonicationSolutionToDevicePushButtonEnabled(self):
         solution = get_openlifu_data_parameter_node().loaded_solution
 
         if solution is None:
             enabled = False
             tooltip = "To run a sonication, first generate and approve a solution in the sonication planning module."
+        elif self.logic.cur_lifu_interface is None:
+            enabled = False
+            tooltip = "To send a sonication solution to the device, you must first initiate a LIFU device connection."
         elif not solution.is_approved():
             enabled = False
             tooltip = "Cannot send to device because the currently active solution is not approved. Approve it in the sonication planning module."
@@ -341,6 +367,13 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateAbortEnabled(self):
         self.ui.abortPushButton.setEnabled(self.logic.running)
 
+    def updateAllButtonsEnabled(self):
+        self.updateConnectLIFUDevicePushButtonEnabled()
+        self.updateManuallyGetDeviceStatusPushButtonEnabled()
+        self.updateSendSonicationSolutionToDevicePushButtonEnabled()
+        self.updateRunEnabled()
+        self.updateAbortEnabled()
+
     @display_errors
     def onRunCompleted(self, new_sonication_run_complete_state: bool):
         """If the soniction_run_complete variable changes from False to True, then open the RunComplete 
@@ -352,50 +385,61 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             if returncode:
                 self.logic.create_openlifu_run(run_parameters)
 
+    def onconnectLIFUDevicePushButtonClicked(self, checked=False):
+        self.logic.cur_lifu_interface = None  # reset
+
+        if self.ui.testModeCheckBox.isChecked():
+            slicer.util.infoDisplay(text="LIFUInterface connected in test_mode")
+            interface = openlifu_lz().io.LIFUInterface(test_mode=True)
+            interface.txdevice.enum_tx7332_devices(2)
+            if interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
+                raise RuntimeError("Interface not ready")
+
+            self.logic.cur_lifu_interface = interface
+
+        else:
+            try:
+                interface = openlifu_lz().io.LIFUInterface()
+                interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
+                self.logic.cur_lifu_interface = interface
+                    
+            except Exception as e:
+                print("Exception thrown:", e)
+                import traceback
+                traceback.print_exc()
+                return
+
+            slicer.util.infoDisplay(text="LIFUInterface connected")
+
+        self.updateManuallyGetDeviceStatusPushButtonEnabled()
+        self.updateSendSonicationSolutionToDevicePushButtonEnabled()
+
+        # From now on, you can only reset the connection
+        self.ui.connectLIFUDevicePushButton.setText("Reset Connection")
+
     @display_errors
     def onSendSonicationSolutionToDevicePushButtonClicked(self, checked=False):
 
         try:
-            interface = openlifu_lz().io.LIFUInterface(test_mode=True)
-            interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
-            interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution)
-
-            self.logic.cur_lifu_interface = interface
-
-            if interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
+            self.logic.cur_lifu_interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution)
+            if self.logic.cur_lifu_interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
                 raise RuntimeError("Interface not ready")
+            self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
+            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.SUCCESSFUL_SEND)
                 
         except Exception as e:
             print("Exception thrown:", e)
             import traceback
             traceback.print_exc()
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.FAILED_SEND, self.logic.cur_lifu_interface.get_status())
-            self.logic.cur_lifu_interface = None
-            return
-        
-        self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
-        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.SUCCESSFUL_SEND)
 
         self.updateWorkflowControls()
 
     def onManuallyGetDeviceStatusPushButtonClicked(self, checked=False):
-
-        try:
-            interface = openlifu_lz().io.LIFUInterface(test_mode=True)
-            interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
-            self.logic.cur_lifu_interface = interface
-                
-        except Exception as e:
-            print("Could not initialize LIFUInterface because an exception was thrown:", e)
-            import traceback
-            traceback.print_exc()
-            self.logic.cur_lifu_interface = None
-            slicer.util.infoDisplay(text=f"Operation failed.", windowTitle="Device Status")
-            return
-
         slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status().name}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
+        self.updateConnectLIFUDevicePushButtonEnabled()
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
         self.updateAbortEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -390,13 +390,14 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.logic.cur_lifu_interface = None  # reset
 
         if self.ui.testModeCheckBox.isChecked():
-            slicer.util.infoDisplay(text="LIFUInterface connected in test_mode")
             interface = openlifu_lz().io.LIFUInterface(test_mode=True)
             interface.txdevice.enum_tx7332_devices(2)
             if interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
                 raise RuntimeError("Interface not ready")
 
             self.logic.cur_lifu_interface = interface
+
+            slicer.util.infoDisplay(text="LIFUInterface connected in test_mode")
 
         else:
             try:
@@ -412,8 +413,8 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
             slicer.util.infoDisplay(text="LIFUInterface connected")
 
-        self.updateManuallyGetDeviceStatusPushButtonEnabled()
-        self.updateSendSonicationSolutionToDevicePushButtonEnabled()
+        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
+        self.updateAllButtonsEnabled()
 
         # From now on, you can only reset the connection
         self.ui.connectLIFUDevicePushButton.setText("Reset Connection")

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -633,20 +633,25 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         if get_openlifu_data_parameter_node().loaded_solution is None:
             raise RuntimeError("No solution loaded; cannot run sonication.")
 
-        self.running = True
         self.run_progress = 0
         self.sonication_run_complete = False
 
+        # ---- Start the run ----
+        self.running = True
+        self.cur_lifu_interface.start_sonication()
+        # -----------------------
+
         def poll():
             self.run_hardware_status = self.cur_lifu_interface.get_status()
-            # ---- TODO ----
-            # The following functions mock the run, as the status is never updated to finished.
-            self.run_progress = 0.9*self.run_progress+11 # 11 because deq converges to 99 because of integer division if adding 10
-            self.sonication_run_complete = self.run_progress >= 99
-            # Replace above with functions that look something like this
-            # self.run_progress = self.cur_lifu_interface.get_progress_percent_as_int()
-            # self.sonication_run_complete = self.cur_lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
-            # --------------
+
+            # In non-test mode we simulate the run bars
+            if self.cur_lifu_interface._test_mode:
+                self.run_progress = 0.9*self.run_progress+11 # 11 because deq converges to 99 because of integer division if adding 10
+                self.sonication_run_complete = self.run_progress >= 99
+            else:
+                # self.run_progress = self.cur_lifu_interface.get_progress_percent_as_int() TODO: figure out
+                self.sonication_run_complete = self.cur_lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
+
             if self.sonication_run_complete:
                 self.timer.stop()
                 self.running = False
@@ -659,8 +664,12 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         # Assumes that the sonication control algorithm will have a callback function to abort run, 
         # that callback can be called here. 
         self.timer.stop()
-        self.running = False
         self.sonication_run_complete = False
+
+        # ---- Stop the run ----
+        self.running = False
+        self.cur_lifu_interface.stop_sonication()
+        # -----------------------
 
     def create_openlifu_run(self, run_parameters: Dict) -> SlicerOpenLIFURun:
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -383,14 +383,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onRunClicked(self):
         if not slicer.util.getModuleLogic('OpenLIFUData').validate_solution():
             raise RuntimeError("Invalid solution; not running sonication.")
-        solution = get_openlifu_data_parameter_node().loaded_solution
-
-        if solution is None:
-            raise RuntimeError("No solution loaded; cannot run sonication.")
-
         self.ui.runProgressBar.value = 0
-        self.logic.run(solution) 
 
+        self.logic.run() 
         self.updateWorkflowControls()
         
     def onAbortClicked(self):
@@ -526,13 +521,17 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         for f in self._on_run_progress_updated_callbacks:
             f(self._run_progress)
 
-    def run(self, solution:SlicerOpenLIFUSolution):
+    def run(self):
         " Returns True when the sonication control algorithm is done"
+
+        if get_openlifu_data_parameter_node().loaded_solution is None:
+            raise RuntimeError("No solution loaded; cannot run sonication.")
+
         self.running = True
         slicer.util.infoDisplay(
             text=(
                 "The run sonication button is a placeholder. Sonication control is not yet implemented."
-                f" Here the solution that would have been run is {solution.solution.solution.id}."
+                f" Here the solution that would have been run is {get_openlifu_data_parameter_node().loaded_solution.solution.solution.id}."
                 " The fake \"run\" will start after you close this dialog and end after three seconds."
             ),
             windowTitle="Not implemented"

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -1,5 +1,6 @@
 from typing import Optional, Callable, Dict, List, TYPE_CHECKING
 from enum import Enum
+import re
 
 import qt
 import vtk
@@ -626,6 +627,20 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._run_hardware_status = run_hardware_status_value
         for f in self._on_run_hardware_status_updated_callbacks:
             f(self._run_hardware_status)
+            
+    def update_run_progress_from_lifuinterface(self, descriptor, message):
+        """ Parses the status message from LIFUInterface. """
+
+        if descriptor != "TX":  
+            return  # Ignore non-transmitter messages
+
+        # Parse progress
+        
+        match = re.search(r'PULSE:\[(\d+)/100\]', message)  # TODO: format subject to change
+        if not match:
+            return
+        progress = int(match.group(1))
+        self.run_progress = progress
 
     def run(self):
         " Returns True when the sonication control algorithm is done"
@@ -641,6 +656,8 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self.cur_lifu_interface.start_sonication()
         # -----------------------
 
+        self.cur_lifu_interface.signal_data_received.connect(self.update_run_progress_from_lifuinterface)
+
         def poll():
             self.run_hardware_status = self.cur_lifu_interface.get_status()
 
@@ -649,12 +666,15 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
                 self.run_progress = 0.9*self.run_progress+11 # 11 because deq converges to 99 because of integer division if adding 10
                 self.sonication_run_complete = self.run_progress >= 99
             else:
-                # self.run_progress = self.cur_lifu_interface.get_progress_percent_as_int() TODO: figure out
                 self.sonication_run_complete = self.cur_lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
 
             if self.sonication_run_complete:
                 self.timer.stop()
                 self.running = False
+                self.cur_lifu_interface.stop_sonication()
+
+                # disconnect signals
+                self.cur_lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
 
         self.timer = qt.QTimer()
         self.timer.timeout.connect(poll)
@@ -670,6 +690,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self.running = False
         self.cur_lifu_interface.stop_sonication()
         # -----------------------
+
+        # disconnect signals
+        self.cur_lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
 
     def create_openlifu_run(self, run_parameters: Dict) -> SlicerOpenLIFURun:
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -213,6 +213,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.sendSonicationSolutionToDevicePushButton.clicked.connect(self.onSendSonicationSolutionToDevicePushButtonClicked)
         self.ui.runPushButton.clicked.connect(self.onRunClicked)
         self.ui.abortPushButton.clicked.connect(self.onAbortClicked)
+        self.ui.manuallyGetDeviceStatusPushButton.clicked.connect(self.onManuallyGetDeviceStatusPushButtonClicked)
         self.updateRunEnabled()
         self.updateAbortEnabled()
         self.logic.call_on_running_changed(self.onRunningChanged)
@@ -376,6 +377,23 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateWidgetSolutionHardwareState(SolutionHardwareState.SUCCESSFUL_SEND)
 
         self.updateWorkflowControls()
+
+    def onManuallyGetDeviceStatusPushButtonClicked(self, checked=False):
+
+        try:
+            interface = openlifu_lz().io.LIFUInterface(test_mode=True)
+            interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
+            self.logic.cur_lifu_interface = interface
+                
+        except Exception as e:
+            print("Could not initialize LIFUInterface because an exception was thrown:", e)
+            import traceback
+            traceback.print_exc()
+            self.logic.cur_lifu_interface = None
+            self.ui.manuallyGetDeviceStatusLabel.setProperty("text", "Operation failed.")
+            return
+
+        self.ui.manuallyGetDeviceStatusLabel.setProperty("text", f"{self.logic.cur_lifu_interface.get_status()}")
 
     def onRunningChanged(self, new_running_state:bool):
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -211,7 +211,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
         # Buttons
-        self.ui.connectLIFUDevicePushButton.clicked.connect(self.onconnectLIFUDevicePushButtonClicked)
+        self.ui.testModePushButton.clicked.connect(self.onTestModePushButtonClicked)
         self.ui.sendSonicationSolutionToDevicePushButton.clicked.connect(self.onSendSonicationSolutionToDevicePushButtonClicked)
         self.ui.runPushButton.clicked.connect(self.onRunClicked)
         self.ui.abortPushButton.clicked.connect(self.onAbortClicked)
@@ -302,25 +302,31 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._cur_solution_id = solution_parameter_pack.solution.solution.id
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
-    def updateConnectLIFUDevicePushButtonEnabled(self):
+    def updateTestModePushButtonEnabled(self):
+        if self.logic.lifu_interface._test_mode:
+            text = "Toggle Test Mode Off"
+        else:
+            text = "Toggle Test Mode On"
+
         if self.logic.running:
             enabled = False
-            tooltip = "Cannot reset connection while a sonication is running."
+            tooltip = "Cannot toggle on/off test mode while a sonication is running."
         else:
             enabled = True
-            tooltip = "Connect or reconnect to the connected hardware."
+            tooltip = "Toggle on/off test mode on the connected hardware."
 
-        self.ui.connectLIFUDevicePushButton.setEnabled(enabled)
-        self.ui.connectLIFUDevicePushButton.setToolTip(tooltip)
+        self.ui.testModePushButton.setText(text)
+        self.ui.testModePushButton.setEnabled(enabled)
+        self.ui.testModePushButton.setToolTip(tooltip)
 
     @display_errors
     def updateManuallyGetDeviceStatusPushButtonEnabled(self, checked=False):
-        if self.logic.cur_lifu_interface is None:
+        if not self.logic.get_lifu_device_connected():
             enabled = False
-            tooltip = "To get the device status you must first initiate a LIFU device connection."
+            tooltip = "The LIFU device must be connected to get its status."
         else:
             enabled = True
-            tooltip = "Get the current state of the hardware device."
+            tooltip = "Get the current state of the LIFU device."
 
         self.ui.manuallyGetDeviceStatusPushButton.setEnabled(enabled)
         self.ui.manuallyGetDeviceStatusPushButton.setToolTip(tooltip)
@@ -331,9 +337,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         if solution is None:
             enabled = False
             tooltip = "To run a sonication, first generate and approve a solution in the sonication planning module."
-        elif self.logic.cur_lifu_interface is None:
+        elif not self.logic.get_lifu_device_connected():
             enabled = False
-            tooltip = "To send a sonication solution to the device, you must first initiate a LIFU device connection."
+            tooltip = "To send a sonication solution to the device, you must first connect a LIFU device."
         elif not solution.is_approved():
             enabled = False
             tooltip = "Cannot send to device because the currently active solution is not approved. Approve it in the sonication planning module."
@@ -369,7 +375,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.abortPushButton.setEnabled(self.logic.running)
 
     def updateAllButtonsEnabled(self):
-        self.updateConnectLIFUDevicePushButtonEnabled()
+        self.updateTestModePushButtonEnabled()
         self.updateManuallyGetDeviceStatusPushButtonEnabled()
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
@@ -386,45 +392,29 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             if returncode:
                 self.logic.create_openlifu_run(run_parameters)
 
-    def onconnectLIFUDevicePushButtonClicked(self, checked=False):
-        self.logic.cur_lifu_interface = None  # reset
 
-        if self.ui.testModeCheckBox.isChecked():
-            interface = openlifu_lz().io.LIFUInterface(test_mode=True)
-            interface.txdevice.enum_tx7332_devices(2)
-            if interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
-                raise RuntimeError("Interface not ready")
 
-            self.logic.cur_lifu_interface = interface
 
-            slicer.util.infoDisplay(text="LIFUInterface connected in test_mode")
 
+    @display_errors
+    def onTestModePushButtonClicked(self, checked=False):
+        new_test_mode_state = not self.logic.lifu_interface._test_mode
+        self.logic.toggle_test_mode(new_test_mode_state)
+
+        if new_test_mode_state:
+            slicer.util.infoDisplay(text="LIFUInterface test_mode enabled")
         else:
-            try:
-                interface = openlifu_lz().io.LIFUInterface()
-                interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
-                self.logic.cur_lifu_interface = interface
-                    
-            except Exception as e:
-                print("Exception thrown:", e)
-                import traceback
-                traceback.print_exc()
-                return
-
-            slicer.util.infoDisplay(text="LIFUInterface connected")
+            slicer.util.infoDisplay(text="LIFUInterface test_mode disabled")
 
         self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
         self.updateAllButtonsEnabled()
-
-        # From now on, you can only reset the connection
-        self.ui.connectLIFUDevicePushButton.setText("Reset Connection")
 
     @display_errors
     def onSendSonicationSolutionToDevicePushButtonClicked(self, checked=False):
 
         try:
-            self.logic.cur_lifu_interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution)
-            if self.logic.cur_lifu_interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
+            self.logic.lifu_interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution)
+            if self.logic.lifu_interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
                 raise RuntimeError("Interface not ready")
             self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
             self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.SUCCESSFUL_SEND)
@@ -433,15 +423,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             print("Exception thrown:", e)
             import traceback
             traceback.print_exc()
-            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.FAILED_SEND, self.logic.cur_lifu_interface.get_status())
+            self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.FAILED_SEND, self.logic.lifu_interface.get_status())
 
         self.updateWorkflowControls()
 
     def onManuallyGetDeviceStatusPushButtonClicked(self, checked=False):
-        slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status().name}", windowTitle="Device Status")
+        slicer.util.infoDisplay(text=f"{self.logic.lifu_interface.get_status().name}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
-        self.updateConnectLIFUDevicePushButtonEnabled()
+        self.updateTestModePushButtonEnabled()
         self.updateSendSonicationSolutionToDevicePushButtonEnabled()
         self.updateRunEnabled()
         self.updateAbortEnabled()
@@ -550,11 +540,18 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._on_run_hardware_status_updated_callbacks = []
         """List of functions to call when `run_hardware_status` property is changed."""
 
-        self.cur_lifu_interface: Optional[openlifu.io.LIFUInterface] = None
+        # ---- LIFU Interface Connection ----
+
+        self.lifu_interface: Optional[openlifu.io.LIFUInterface] = openlifu_lz().io.LIFUInterface(run_async=True)
         """The active LIFUInterface object to the ultrasound hardware."""
 
         self.cur_solution_on_hardware: Optional[openlifu.plan.Solution] = None
         """The active Solution object last sent to the ultrasound hardware."""
+
+        #self.lifu_interface.start_monitoring() # TODO
+
+    def __del__(self):
+        self.lifu_interface.stop_monitoring()
 
     def getParameterNode(self):
         return OpenLIFUSonicationControlParameterNode(super().getParameterNode())
@@ -654,28 +651,28 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
         # ---- Start the run ----
         self.running = True
-        self.cur_lifu_interface.start_sonication()
+        self.lifu_interface.start_sonication()
         # -----------------------
 
-        self.cur_lifu_interface.signal_data_received.connect(self.update_run_progress_from_lifuinterface)
+        self.lifu_interface.signal_data_received.connect(self.update_run_progress_from_lifuinterface)
 
         def poll():
-            self.run_hardware_status = self.cur_lifu_interface.get_status()
+            self.run_hardware_status = self.lifu_interface.get_status()
 
             # In non-test mode we simulate the run bars
-            if self.cur_lifu_interface._test_mode:
+            if self.lifu_interface._test_mode:
                 self.run_progress = 0.9*self.run_progress+11 # 11 because deq converges to 99 because of integer division if adding 10
                 self.sonication_run_complete = self.run_progress >= 99
             else:
-                self.sonication_run_complete = self.cur_lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
+                self.sonication_run_complete = self.lifu_interface.get_status() == openlifu_lz().io.LIFUInterfaceStatus.STATUS_FINISHED
 
             if self.sonication_run_complete:
                 self.timer.stop()
                 self.running = False
-                self.cur_lifu_interface.stop_sonication()
+                self.lifu_interface.stop_sonication()
 
                 # disconnect signals
-                self.cur_lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
+                self.lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
 
         self.timer = qt.QTimer()
         self.timer.timeout.connect(poll)
@@ -689,11 +686,11 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
         # ---- Stop the run ----
         self.running = False
-        self.cur_lifu_interface.stop_sonication()
+        self.lifu_interface.stop_sonication()
         # -----------------------
 
         # disconnect signals
-        self.cur_lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
+        self.lifu_interface.signal_data_received.disconnect(self.update_run_progress_from_lifuinterface)
 
     def create_openlifu_run(self, run_parameters: Dict) -> SlicerOpenLIFURun:
 
@@ -727,3 +724,13 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         slicer.util.getModuleLogic('OpenLIFUData').set_run(run)
         
         return run
+
+    def toggle_test_mode(self, enabled : bool):
+        self.lifu_interface.stop_monitoring() # TODO: LIFUInterface may change so this is not needed. See https://github.com/OpenwaterHealth/OpenLIFU-python/pull/249#issuecomment-2730446411
+        self.lifu_interface.toggle_test_mode(enabled)
+        #self.lifu_interface.start_monitoring() # TODO
+
+    def get_lifu_device_connected(self) -> bool:
+        tx_connected = self.lifu_interface.txdevice.is_connected()
+        hv_connected = self.lifu_interface.hvcontroller.is_connected()
+        return tx_connected and hv_connected

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -54,6 +54,10 @@ class OpenLIFUSonicationControl(ScriptedLoadableModule):
             "and development."
         )
 
+class DeviceConnectedState(Enum):
+    NOT_CONNECTED=0
+    CONNECTED=1
+
 class SolutionOnHardwareState(Enum):
     SUCCESSFUL_SEND=0
     FAILED_SEND=1
@@ -172,6 +176,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
+        self._cur_device_connected_state : DeviceConnectedState = DeviceConnectedState.NOT_CONNECTED
         self._cur_solution_on_hardware_state : SolutionOnHardwareState = SolutionOnHardwareState.NOT_SENT
         self._cur_solution_id: str | None = None
         self._parameterNode = None
@@ -220,9 +225,12 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.logic.call_on_sonication_complete(self.onRunCompleted)
         self.logic.call_on_run_progress_updated(self.updateRunProgressBar)
         self.logic.call_on_run_hardware_status_updated(self.updateRunHardwareStatusLabel)
+        self.logic.call_on_lifu_device_connected(self.onDeviceConnected)
+        self.logic.call_on_lifu_device_disconnected(self.onDeviceDisconnected)
 
         # Initialize UI
         self.updateRunProgressBar()
+        self.updateDeviceConnectedStateFromDevice()
         self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
 
         # Add an observer on the Data module's parameter node
@@ -392,9 +400,27 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             if returncode:
                 self.logic.create_openlifu_run(run_parameters)
 
+    @display_errors
+    def onDeviceConnected(self):
+        slicer.util.infoDisplay(text="Ultrasound device connected")
 
+        # Even though this call explicitly tells us whether "Connected" or
+        # "Disconnected", we still update from the actual hardware for the best
+        # possible synchronization
+        self.updateDeviceConnectedStateFromDevice()
+        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
+        self.updateAllButtonsEnabled()
 
+    @display_errors
+    def onDeviceDisconnected(self):
+        slicer.util.infoDisplay(text="Ultrasound device disconnected")
 
+        # Even though this call explicitly tells us whether "Connected" or
+        # "Disconnected", we still update from the actual hardware for the best
+        # possible synchronization
+        self.updateDeviceConnectedStateFromDevice()
+        self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
+        self.updateAllButtonsEnabled()
 
     @display_errors
     def onTestModePushButtonClicked(self, checked=False):
@@ -406,6 +432,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         else:
             slicer.util.infoDisplay(text="LIFUInterface test_mode disabled")
 
+        self.updateDeviceConnectedStateFromDevice()
         self.updateWidgetSolutionOnHardwareState(SolutionOnHardwareState.NOT_SENT)
         self.updateAllButtonsEnabled()
 
@@ -474,6 +501,20 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         else: # not running
             self.ui.runHardwareStatusLabel.setProperty("text", "Run not in progress.")
 
+    def updateDeviceConnectedStateFromDevice(self):
+        if self.logic.get_lifu_device_connected():
+            self.updateDeviceConnectedState(DeviceConnectedState.CONNECTED)
+        else:
+            self.updateDeviceConnectedState(DeviceConnectedState.NOT_CONNECTED)
+
+    def updateDeviceConnectedState(self, connected_state: DeviceConnectedState):
+        self._cur_solution_on_hardware_state = connected_state
+        if connected_state == DeviceConnectedState.CONNECTED:
+            self.ui.connectedStateLabel.setProperty("text", "🟢 LIFU Device (connected)")
+        elif connected_state == DeviceConnectedState.NOT_CONNECTED:
+            self.ui.connectedStateLabel.setProperty("text", "🔴 LIFU Device (not connected)")
+        self.updateAllButtonsEnabled()
+
     def updateWidgetSolutionOnHardwareState(self, solution_state: SolutionOnHardwareState, hardware_state: "openlifu.io.LIFUInterfaceStatus | None" = None):
         self._cur_solution_on_hardware_state = solution_state
         if solution_state == SolutionOnHardwareState.SUCCESSFUL_SEND:
@@ -540,6 +581,12 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._on_run_hardware_status_updated_callbacks = []
         """List of functions to call when `run_hardware_status` property is changed."""
 
+        self._on_lifu_device_connected_callbacks = []
+        """List of functions to call when the LIFU interface is connected."""
+
+        self._on_lifu_device_disconnected_callbacks = []
+        """List of functions to call when the LIFU interface is disconnected."""
+
         # ---- LIFU Interface Connection ----
 
         self.lifu_interface: Optional[openlifu.io.LIFUInterface] = openlifu_lz().io.LIFUInterface(run_async=True)
@@ -548,6 +595,8 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self.cur_solution_on_hardware: Optional[openlifu.plan.Solution] = None
         """The active Solution object last sent to the ultrasound hardware."""
 
+        self.lifu_interface.signal_connect.connect(self.on_lifu_device_connected)
+        self.lifu_interface.signal_disconnect.connect(self.on_lifu_device_disconnected)
         #self.lifu_interface.start_monitoring() # TODO
 
     def __del__(self):
@@ -581,6 +630,14 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         of the running openlifu harware device.
         """
         self._on_run_hardware_status_updated_callbacks.append(f)
+
+    def call_on_lifu_device_connected(self, f) -> None:
+        """Set a function to be called whenever the LIFU device is connected. """
+        self._on_lifu_device_connected_callbacks.append(f)
+
+    def call_on_lifu_device_disconnected(self, f) -> None:
+        """Set a function to be called whenever the LIFU device is disconnected. """
+        self._on_lifu_device_disconnected_callbacks.append(f)
 
     @property
     def running(self) -> bool:
@@ -625,6 +682,14 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._run_hardware_status = run_hardware_status_value
         for f in self._on_run_hardware_status_updated_callbacks:
             f(self._run_hardware_status)
+
+    def on_lifu_device_connected(self):
+        for f in self._on_lifu_device_connected_callbacks:
+            f()
+
+    def on_lifu_device_disconnected(self):
+        for f in self._on_lifu_device_disconnected_callbacks:
+            f()
             
     def update_run_progress_from_lifuinterface(self, descriptor, message):
         """ Parses the status message from LIFUInterface. """

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -707,11 +707,17 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         for f in self._on_run_hardware_status_updated_callbacks:
             f(self._run_hardware_status)
 
-    def on_lifu_device_connected(self):
+    def on_lifu_device_connected(self, *args, **kwargs):
+        print("on_lifu_device_connected called in sonication control module. The arguments given in were:") # TODO: Remove when hardware device works without issues
+        print("Positional arguments:", args) # TODO: Remove when hardware device works without issues
+        print("Keyword arguments:", kwargs) # TODO: Remove when hardware device works without issues
         for f in self._on_lifu_device_connected_callbacks:
             f()
 
-    def on_lifu_device_disconnected(self):
+    def on_lifu_device_disconnected(self, *args, **kwargs):
+        print("on_lifu_device_disconnected called in sonication control module. The arguments given in were:") # TODO: Remove when hardware device works without issues
+        print("Positional arguments:", args) # TODO: Remove when hardware device works without issues
+        print("Keyword arguments:", kwargs) # TODO: Remove when hardware device works without issues
         for f in self._on_lifu_device_disconnected_callbacks:
             f()
             

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -171,7 +171,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
-        self._cur_solution_hardware_state = SolutionHardwareState.NOT_SENT
+        self._cur_solution_hardware_state : SolutionHardwareState = SolutionHardwareState.NOT_SENT
         self._cur_solution_id: str | None = None
         self._parameterNode = None
         self._parameterNodeGuiTag = None
@@ -358,7 +358,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             interface.txdevice.enum_tx7332_devices(2) # TODO: see why can't use kwarg
             interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution)
 
-            self.logic._lifu_interface = interface
+            self.logic.cur_lifu_interface = interface
 
             if interface.get_status() != openlifu_lz().io.LIFUInterfaceStatus.STATUS_READY:
                 raise RuntimeError("Interface not ready")
@@ -367,10 +367,11 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             print("Exception thrown:", e)
             import traceback
             traceback.print_exc()
-            self.logic._lifu_interface = None
+            self.logic.cur_lifu_interface = None
             self.updateWidgetSolutionHardwareState(SolutionHardwareState.FAILED_SEND)
             return
-
+        
+        self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
         self.updateWidgetSolutionHardwareState(SolutionHardwareState.SUCCESSFUL_SEND)
 
         self.updateWorkflowControls()
@@ -463,8 +464,11 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._on_run_progress_updated_callbacks: List[Callable[[int],None]] = []
         """List of functions to call when `run_progress` property is changed."""
 
-        self._lifu_interface: "Optional[openlifu.io.LIFUInterface]" = None
+        self.cur_lifu_interface: Optional[openlifu.io.LIFUInterface] = None
         """The active LIFUInterface object to the ultrasound hardware."""
+
+        self.cur_solution_on_hardware: Optional[openlifu.plan.Solution] = None
+        """The active Solution object last sent to the ultrasound hardware."""
 
     def getParameterNode(self):
         return OpenLIFUSonicationControlParameterNode(super().getParameterNode())
@@ -531,7 +535,7 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         slicer.util.infoDisplay(
             text=(
                 "The run sonication button is a placeholder. Sonication control is not yet implemented."
-                f" Here the solution that would have been run is {get_openlifu_data_parameter_node().loaded_solution.solution.solution.id}."
+                f" Here the solution that would have been run is {self.cur_solution_on_hardware.id}."
                 " The fake \"run\" will start after you close this dialog and end after three seconds."
             ),
             windowTitle="Not implemented"

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -7,10 +7,40 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>337</height>
+    <height>357</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="connectLIFUDevicePushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Connect LIFU Device</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="testModeCheckBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Test Mode</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">
      <property name="toolTip">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -14,7 +14,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="connectLIFUDevicePushButton">
+      <widget class="QPushButton" name="reinitializeLIFUInterfacePushButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -22,7 +22,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Connect LIFU Device</string>
+        <string>Reinitialize LIFUInterface</string>
        </property>
       </widget>
      </item>

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -10,7 +10,7 @@
     <height>311</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QPushButton" name="sendSonicationSolutionToDevicePushButton">
      <property name="text">
@@ -64,13 +64,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QProgressBar" name="runProgressBar">
-     <property name="value">
-      <number>24</number>
-     </property>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -82,6 +75,45 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QFrame" name="runStatusFrame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="runStatusFrameTitle">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Run Progress:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="runProgressBar">
+        <property name="value">
+         <number>24</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="runHardwareStatusLabel">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QWidget" name="workflowControlsPlaceholder" native="true">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -25,6 +25,38 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="connectedStateFrame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="connectedStateFrameTitle">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Connection Status:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="connectedStateLabel">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">
      <property name="toolTip">
       <string>This button retrieves the current status of the hardware device and prints the status below.</string>

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -12,6 +12,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">
+     <property name="toolTip">
+      <string>This button retrieves the current status of the hardware device and prints the status below.</string>
+     </property>
+     <property name="text">
+      <string>Get Device Status</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="sendSonicationSolutionToDevicePushButton">
      <property name="text">
       <string>Send Sonication Solution To Device</string>
@@ -75,16 +85,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">
-     <property name="toolTip">
-      <string>This button retrieves the current status of the hardware device and prints the status below.</string>
-     </property>
-     <property name="text">
-      <string>Get Device Status</string>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QFrame" name="runStatusFrame">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -87,13 +87,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="manuallyGetDeviceStatusLabel">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QFrame" name="runStatusFrame">
      <property name="frameShape">
       <enum>QFrame::Box</enum>

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -7,39 +7,22 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>357</height>
+    <height>450</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="connectLIFUDevicePushButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Connect LIFU Device</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="testModeCheckBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Test Mode</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QPushButton" name="testModePushButton">
+     <property name="text">
+      <string>Toggle Test Mode On</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -12,17 +12,34 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QPushButton" name="testModePushButton">
-     <property name="text">
-      <string>Toggle Test Mode On</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-     <property name="default">
-      <bool>false</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="connectLIFUDevicePushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Connect LIFU Device</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="testModeCheckBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Test Mode</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QFrame" name="connectedStateFrame">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -12,34 +12,17 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="reinitializeLIFUInterfacePushButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Reinitialize LIFUInterface</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="testModeCheckBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Test Mode</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QPushButton" name="reinitializeLIFUInterfacePushButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Reinitialize LIFUInterface in test_mode</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QFrame" name="connectedStateFrame">

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>311</height>
+    <height>337</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -75,6 +75,23 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="manuallyGetDeviceStatusPushButton">
+     <property name="toolTip">
+      <string>This button retrieves the current status of the hardware device and prints the status below.</string>
+     </property>
+     <property name="text">
+      <string>Get Device Status</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="manuallyGetDeviceStatusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QFrame" name="runStatusFrame">


### PR DESCRIPTION
Closes #140

## Summary

This pull request removes the LIFUInterface placeholders (e.g. `run()`) and integrates the hardware interface into the application, alongside a developer-oriented toggle switch between a `test_mode` interface and the real device. 

## Key Changes

- **Hardware Interface Integration (`LIFUInterface`)**
  - Handles starting and stopping sonication (`start_sonication`, `stop_sonication`).
  - Device signals are parsed and update the GUI (e.g., run progress and connectedness).

- **Test Mode Switching**
  - When switching modes, the interface is reinitialized, and the event loop holding the asynchronous `start_monitoring` is reset. When in test mode, it uses a more informative mock of start_monitoring, but this can be replaced.

## Additional Notes

- The run-status parsing logic is still subject to change pending finalization from the hardware team.

---

## For review

This will need a few stages of review. Kitware's team should do an initial pass over the code (stage 1), and then the hardware team should do a pass over the code (stage 2), and then the hardware team should actually test a release of the app (stage 3)

### Stage 1 

First, the application-level code should be reviewed for anything obvious before sending to @georgevigelette . The GUI parts of this need trivial testing; the software-hardware-bridge parts matter the most.

1. Try computing and approving a sonication solution and sending it to the device, connected in test_mode, and then hitting run.
2. Look at the code where signals from the LIFUInterface are connected to slots in the OpenLIFUSonicationControlLogic. 
3. Look at how the event loop `self.monitoring_loop` is set up and switches out the `start_monitoring` task depending on whether LIFUInterface is initialized in `test_mode`. Note that the task needs to be switched out only if we are toggling on/off test_mode, which shouldn't happen in the app.
4. It may be wise to look at all of the things the hardware team would look at in Stage 2, but it's extra work.

### Stage 2

After revisions, if any, the code should be looked over by the hardware team.

1. Look at the code under `---- LIFU Interface Connection ----`.  In this part, an initial LIFUInterface is initialized, and `start_monitoring` is scheduled in the event loop.
2. Look at `OpenLIFUSonicationControlLogic.run(self)`. That's the part where `run_sonication` is called, data received signals are connected, and the device is polled for completion status.
3. Look at `OpenLIFUSonicationControlLogic.reinitialize_lifu_interface(self, test_mode=False)`. This part reinitializes the LIFUInterface in `test_mode`. While this won't be used by the customer, its correctness is very important for the rest of our development.
5. Check that the run progress signal was parsed correctly (in `OpenLIFUSonicationControlLogic.update_run_progress_from_lifuinterface(self, descriptor, message)`.

### Stage 3

After revisions by both teams, the hardware team should install a release of the OpenLIFU-app and attempt non-test_mode runs on real hardware and report any issues.