### PR TITLE
Enable requesting photoscans from the photogrammetry software

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -281,7 +281,6 @@ class AddNewPhotocollectionDialog(qt.QDialog):
         temp_dir = tempfile.gettempdir()
         self.temp_photocollection_path = os.path.join(temp_dir, self.reference_number)
         os.makedirs(self.temp_photocollection_path, exist_ok=True)
-        print(f"Made temp dir: {self.temp_photocollection_path}")
 
         self.setup()
 
@@ -343,7 +342,6 @@ class AddNewPhotocollectionDialog(qt.QDialog):
                 ["adb", "pull", f"{android_dir}/{filename}", dest_path]
             )
             self.pulled_files.append(dest_path)
-            print(f"Pulled {filename} to {self.temp_photocollection_path}")  # TODO: remove
 
         self.accept()
 

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -264,22 +264,22 @@ class AddNewVolumeDialog(qt.QDialog):
 
         return (returncode, volume_filepath,volume_name, volume_id)
 
-class AddNewPhotostackDialog(qt.QDialog):
-    """ Add new photostack dialog """
+class AddNewPhotocollectionDialog(qt.QDialog):
+    """ Add new photocollection dialog """
 
     MINIMUM_NUMBER_OF_PHOTOS_FOR_PHOTOSCAN=20
 
     def __init__(self, parent="mainWindow"):
         super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
-        self.setWindowTitle("Add New Photostack")
+        self.setWindowTitle("Add New Photocollection")
         self.setWindowModality(qt.Qt.WindowModal)
 
         self.reference_number = 'qwerty' # TODO: should be "".join(random.choices(string.ascii_letters + string.digits, k=8))
 
         temp_dir = tempfile.gettempdir()
-        self.temp_photostack_path = os.path.join(temp_dir, self.reference_number)
-        os.makedirs(self.temp_photostack_path, exist_ok=True)
-        print(f"Made temp dir: {self.temp_photostack_path}")
+        self.temp_photocollection_path = os.path.join(temp_dir, self.reference_number)
+        os.makedirs(self.temp_photocollection_path, exist_ok=True)
+        print(f"Made temp dir: {self.temp_photocollection_path}")
 
         self.setup()
 
@@ -290,11 +290,11 @@ class AddNewPhotostackDialog(qt.QDialog):
         formLayout = qt.QFormLayout()
         self.setLayout(formLayout)
 
-        self.directionLabel1 = qt.QLabel(f"Please create a 3D Open Water photostack with the following reference number: {self.reference_number}")
+        self.directionLabel1 = qt.QLabel(f"Please create a 3D Open Water photocollection with the following reference number: {self.reference_number}")
         formLayout.addRow(self.directionLabel1)
 
-        self.photostackName = qt.QLineEdit()
-        formLayout.addRow(_("Photostack Name:"), self.photostackName)
+        self.photocollectionName = qt.QLineEdit()
+        formLayout.addRow(_("Photocollection Name:"), self.photocollectionName)
 
         self.directionLabel2 = qt.QLabel(f"Click \"OK\" when the Android device has finished and is plugged into the computer.")
         formLayout.addRow(self.directionLabel2)
@@ -312,7 +312,7 @@ class AddNewPhotostackDialog(qt.QDialog):
         We need to make sure that the android file system has the files
         associated with the reference id in the right location.
         """
-        photostack_name = self.photostackName.text
+        photocollection_name = self.photocollectionName.text
         
         # The path /sdcard/DCIM/Camera/ is the standard internal storage path
         # from the Android device’s perspective when accessed via adb, not the
@@ -330,26 +330,26 @@ class AddNewPhotostackDialog(qt.QDialog):
         files = [f for f in result.stdout.strip().split('\n') if f]
 
         if not files or len(files) < self.MINIMUM_NUMBER_OF_PHOTOS_FOR_PHOTOSCAN:
-            slicer.util.errorDisplay(f"Not enough photos were found in the photostack.", parent = self)
+            slicer.util.errorDisplay(f"Not enough photos were found in the photocollection.", parent = self)
             return
         
         for file in files:
             filename = os.path.basename(file)
             subprocess.run(
-                ["adb", "pull", f"{android_dir}/{filename}", os.path.join(self.temp_photostack_path, filename)]
+                ["adb", "pull", f"{android_dir}/{filename}", os.path.join(self.temp_photocollection_path, filename)]
             )
-            print(f"Pulled {filename} to {self.temp_photostack_path}")  # TODO: remove
+            print(f"Pulled {filename} to {self.temp_photocollection_path}")  # TODO: remove
 
         self.accept()
 
     def customexec_(self):
 
         returncode = self.exec_()
-        photostack_dict = {
-            "name": self.photostackName.text,
-            "photostack_reference_number" : self.reference_number,
+        photocollection_dict = {
+            "name": self.photocollectionName.text,
+            "photocollection_reference_number" : self.reference_number,
         }
-        return (returncode, photostack_dict, self.temp_photostack_path)
+        return (returncode, photocollection_dict, self.temp_photocollection_path)
 
 class AddNewPhotoscanDialog(qt.QDialog):
     """ Add new photoscan dialog """
@@ -667,8 +667,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.newSessionButton.clicked.connect(self.onCreateNewSessionClicked)
         self.update_subjectLevelButtons_enabled()
 
-        # Add new photostack to session
-        self.ui.addPhotostackToSessionButton.clicked.connect(self.onAddPhotostackToSessionClicked)
+        # Add new photocollection to session
+        self.ui.addPhotocollectionToSessionButton.clicked.connect(self.onAddPhotocollectionToSessionClicked)
         self.update_sessionLevelButtons_enabled()
 
         # Add new photoscan to session
@@ -808,18 +808,18 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.newSessionButton.toolTip = 'Requires a loaded database and subject to be selected'
     
     def update_sessionLevelButtons_enabled(self):
-        """ Update whether the add photoscan and photostack buttons are enabled
+        """ Update whether the add photoscan and photocollection buttons are enabled
         based on whether a database has been loaded and a session has been
         selected in the tree view"""
 
         if self.logic.db and self.itemIsSession(self.ui.subjectSessionView.currentIndex()):
-            self.ui.addPhotostackToSessionButton.setEnabled(True)
-            self.ui.addPhotostackToSessionButton.toolTip = 'Add new photostack to selected session'
+            self.ui.addPhotocollectionToSessionButton.setEnabled(True)
+            self.ui.addPhotocollectionToSessionButton.toolTip = 'Add new photocollection to selected session'
             self.ui.addPhotoscanToSessionButton.setEnabled(True)
             self.ui.addPhotoscanToSessionButton.toolTip = 'Add new photoscan to selected session'
         else:
-            self.ui.addPhotostackToSessionButton.setEnabled(False)
-            self.ui.addPhotostackToSessionButton.toolTip = 'Requires a loaded database and session to be selected'
+            self.ui.addPhotocollectionToSessionButton.setEnabled(False)
+            self.ui.addPhotocollectionToSessionButton.toolTip = 'Requires a loaded database and session to be selected'
             self.ui.addPhotoscanToSessionButton.setEnabled(False)
             self.ui.addPhotoscanToSessionButton.toolTip = 'Requires a loaded database and session to be selected'
 
@@ -911,9 +911,9 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.logic.load_session(subject_id, session_parameters['id'])
 
     @display_errors
-    def onAddPhotostackToSessionClicked(self, checked:bool):
-        photostackdlg = AddNewPhotostackDialog()
-        returncode, photostack_dict, photostack_filepath = photostackdlg.customexec_()
+    def onAddPhotocollectionToSessionClicked(self, checked:bool):
+        photocollectiondlg = AddNewPhotocollectionDialog()
+        returncode, photocollection_dict, photocollection_filepath = photocollectiondlg.customexec_()
         if not returncode:
             return False
 
@@ -923,14 +923,14 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # TODO: add the stuff to the database when it's made in python
 
-        # self.logic.add_photostack_to_database(subject_id, session_id, photostack_dict)
+        # self.logic.add_photocollection_to_database(subject_id, session_id, photocollection_dict)
         # 
-        # # If the photostack is being added to a currently active session,
-        # # update the session and the transducer tracking module to reflect the added photostack.
+        # # If the photocollection is being added to a currently active session,
+        # # update the session and the transducer tracking module to reflect the added photocollection.
         # loaded_session = self._parameterNode.loaded_session
         # if loaded_session is not None and session_id == loaded_session.get_session_id():
-        #     self.logic.update_photostacks_affiliated_with_loaded_session()
-        #     # Update the transducer tracking drop down to reflect new photostacks 
+        #     self.logic.update_photocollections_affiliated_with_loaded_session()
+        #     # Update the transducer tracking drop down to reflect new photocollections 
         #     transducer_tracking_widget = slicer.util.getModule('OpenLIFUTransducerTracker').widgetRepresentation()
         #     transducer_tracking_widget.self().algorithm_input_widget.update()
 
@@ -1130,7 +1130,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self._parameterNode is None or self._parameterNode.loaded_session is None:
             for label in self.session_status_field_widgets:
                 label.setText("") # Doing this before setCurrentIndex(0) results in the desired scrolling behavior
-                # (Doing it after makes Qt maintain the possibly larger size of page 1 of the stacked widget, providing unnecessary scroll bars)
+                # (Doing it after makes Qt maintain the possibly larger size of page 1 of the collectioned widget, providing unnecessary scroll bars)
             self.ui.sessionStatusStackedWidget.setCurrentIndex(0)
             for button in [self.ui.unloadSessionButton, self.ui.saveSessionButton]:
                 button.setEnabled(False)

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -923,11 +923,11 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         currentIndex = self.ui.subjectSessionView.currentIndex()
         _, session_id = self.getSubjectSessionAtIndex(currentIndex)
         _, subject_id = self.getSubjectSessionAtIndex(currentIndex.parent())
-
+        self._parameterNode.loaded_photocollections.append(photocollection_dict["reference_number"]) # automatically load as well
         self.logic.add_photocollection_to_database(subject_id, session_id, photocollection_dict)
         
         # If the photocollection is being added to a currently active session,
-        # update the session and the transducer tracking module to reflect the added photocollection.
+        # update the session 
         loaded_session = self._parameterNode.loaded_session
         if loaded_session is not None and session_id == loaded_session.get_session_id():
             self.logic.update_photocollections_affiliated_with_loaded_session()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -275,7 +275,7 @@ class AddNewPhotocollectionDialog(qt.QDialog):
         self.setWindowTitle("Add New Photocollection")
         self.setWindowModality(qt.Qt.WindowModal)
 
-        self.reference_number = 'qwerty' # TODO: should be "".join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.reference_number = "".join(random.choices(string.digits, k=8))
         self.pulled_files = []
 
         temp_dir = tempfile.gettempdir()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -319,14 +319,21 @@ class AddNewPhotocollectionDialog(qt.QDialog):
         # The path /sdcard/DCIM/Camera/ is the standard internal storage path
         # from the Android device’s perspective when accessed via adb, not the
         # computer’s mounted file system like with Android File Transfer.
-        android_dir = "/sdcard/DCIM/Camera"
+        android_dir = Path("/sdcard/DCIM/Camera")
         result = subprocess.run(
-            ["adb", "shell", "ls", f"{android_dir}/{self.reference_number}_*.jpeg"],
+            ["adb", "shell", "ls", android_dir/f"{self.reference_number}_*.jpeg"],
             capture_output=True, text=True
-        )
-        
+        ) 
+
         if result.returncode != 0:
-            slicer.util.errorDisplay(f"Error finding files on Android device.", parent = self)
+            slicer.util.errorDisplay(
+              "Error finding files on Android device."
+              " Please make sure the device is connected,"
+              " you have installed android platform tools on this machine,"
+              " you have enabled developer mode on the device,"
+              " and you have enabled USB debugging on the device.",
+              parent = self
+            )
             return
         
         files = [f for f in result.stdout.strip().split('\n') if f]

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -30,7 +30,7 @@
       <item>
        <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit">
         <property name="filters">
-         <string>ctkPathLineEdit::Dirs</string>
+         <set>ctkPathLineEdit::Dirs</set>
         </property>
         <property name="SlicerParameterName" stdset="0">
          <string>databaseDirectory</string>
@@ -83,6 +83,13 @@
           <widget class="QPushButton" name="newSessionButton">
            <property name="text">
             <string>Create New Session</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="addPhotostackToSessionButton">
+           <property name="text">
+            <string>Add Photostack To Session</string>
            </property>
           </widget>
          </item>
@@ -154,8 +161,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>299</width>
-           <height>198</height>
+           <width>272</width>
+           <height>230</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -87,9 +87,9 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="addPhotostackToSessionButton">
+          <widget class="QPushButton" name="addPhotocollectionToSessionButton">
            <property name="text">
-            <string>Add Photostack To Session</string>
+            <string>Add Photocollection To Session</string>
            </property>
           </widget>
          </item>

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@15f8e491cd019f7fc21bba3c1464e53fba79328a
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@f941ba743dee632a87d328491a383a5cccb6c951
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -41,6 +41,10 @@ class SlicerOpenLIFUSession:
     in order to have the option of unloading them when unloading the session. In SlicerOpenLIFU, all
     fiducial markups in the scene are potential targets, not necessarily just the ones listed here."""
 
+    affiliated_photocollections : List[str] = []
+    """List containing photocollection_reference_numbers for any photocollections associated with the session. We keep track of any
+    photocollections associated with the session here so that they can be loaded into slicer during transducer tracking as required."""
+
     affiliated_photoscans : Dict[str,SlicerOpenLIFUPhotoscanWrapper] = {}
     """Dictionary containing photoscan_id: SlicerOpenLIFUPhotoscanWrapper for any photoscans associated with the session. We keep track of 
     any photoscans associated with the session here so that they can be loaded into slicer as a SlicerOpenLIFUPhotoscan during
@@ -102,6 +106,9 @@ class SlicerOpenLIFUSession:
         """
         return get_openlifu_data_parameter_node().loaded_protocols[self.get_protocol_id()]
 
+    def get_affiliated_photocollection_reference_numbers(self):
+        return self.affiliated_photocollections
+
     def get_affiliated_photoscan_ids(self):
         return list(self.affiliated_photoscans.keys())
     
@@ -145,6 +152,11 @@ class SlicerOpenLIFUSession:
         target_nodes = [openlifu_point_to_fiducial(target) for target in session.targets]
 
         return SlicerOpenLIFUSession(SlicerOpenLIFUSessionWrapper(session), volume_node, target_nodes)
+
+    def set_affiliated_photocollections(self, affiliated_photocollections : List[str]):
+        
+        self.affiliated_photocollections = affiliated_photocollections
+
 
     def set_affiliated_photoscans(self, affiliated_photoscans : Dict[str, "openlifu.Photoscan"]):
         

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>272</height>
+    <height>421</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -19,19 +19,63 @@
        <string>operator</string>
       </stringlist>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QFrame" name="photoscanGeneratorFrame">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QLabel" name="photoscanGeneratorFrameTitle">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Photoscan Generation&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="margin">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="photoscanGeneratorButtons">
+           <item>
+            <widget class="QPushButton" name="addPhotostackToSessionButton">
+             <property name="toolTip">
+              <string>Load an openlifu protocol from json</string>
+             </property>
+             <property name="text">
+              <string>Add Photostack To Session</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="startPhotoscanGenerationButton">
+             <property name="text">
+              <string>Start Photoscan Generation</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QProgressBar" name="photoscanGeneratorProgressBar">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="value">
+            <number>24</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item>
        <widget class="QWidget" name="tempWidget" native="true">
         <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>421</height>
+    <height>459</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -29,6 +29,9 @@
          <enum>QFrame::Raised</enum>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="bottomMargin">
+          <number>14</number>
+         </property>
          <item>
           <widget class="QLabel" name="photoscanGeneratorFrameTitle">
            <property name="text">
@@ -69,7 +72,10 @@
             <bool>true</bool>
            </property>
            <property name="value">
-            <number>24</number>
+            <number>0</number>
+           </property>
+           <property name="textVisible">
+            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -45,12 +45,12 @@
          <item>
           <layout class="QHBoxLayout" name="photoscanGeneratorButtons">
            <item>
-            <widget class="QPushButton" name="addPhotostackToSessionButton">
+            <widget class="QPushButton" name="addPhotocollectionToSessionButton">
              <property name="toolTip">
               <string>Load an openlifu protocol from json</string>
              </property>
              <property name="text">
-              <string>Add Photostack To Session</string>
+              <string>Add Photocollection To Session</string>
              </property>
             </widget>
            </item>

--- a/README.md
+++ b/README.md
@@ -3,3 +3,42 @@
 3D Slicer Extension for Openwater's OpenLIFU project
 
 Build this extension by following [the usual procedure for Slicer extensions](https://slicer.readthedocs.io/en/latest/developer_guide/extensions.html#build-an-extension).
+
+## Pairing with 3D Open Water App
+
+### Install Android Platform Tools
+
+**macOS:**  
+
+```bash
+brew install android-platform-tools
+```
+
+**Linux:**  
+
+```bash
+sudo apt update
+sudo apt install android-tools-adb
+```
+
+**Windows (PowerShell):**  
+
+```powershell
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+irm get.scoop.sh | iex
+scoop install android-platform-tools
+```
+
+Or download from [Google's
+platform-tools](https://developer.android.com/tools/releases/platform-tools) and
+add it to your `PATH`.
+
+### Enable USB Debugging on Android
+
+1. On your Android device, go to **Settings → About phone**.
+2. Tap **Build number** 7 times until you see “You are now a developer!”.
+3. Go to **Settings → System → Developer options**.
+4. Enable **USB debugging**.
+5. When prompted, allow USB debugging access to your computer.  (Check "Always
+   allow" to avoid repeated prompts.)
+

--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ add it to your `PATH`.
 
 ### Enable USB Debugging on Android
 
-1. On your Android device, go to **Settings → About phone**.
-2. Tap **Build number** 7 times until you see “You are now a developer!”.
+1. On your Android device, go to **Settings → About phone → Software information**.
+2. Tap **Build number** 7 times until you see "You are now a developer!".
 3. Go to **Settings → System → Developer options**.
 4. Enable **USB debugging**.
 5. When prompted, allow USB debugging access to your computer.  (Check "Always
    allow" to avoid repeated prompts.)
-


### PR DESCRIPTION
Closes #150

## Summary

This PR fully implements the photocollections workflow, including:  
1. Adding the photocollections concept  
2. Prompting the user to enter a randomly generated reference number  
3. Retrieving the photocollection from 3D Open Water when the Android device is connected  
4. Inserting the photocollection into the database  

A draft "Start Photoscan Generation" button is added, which currently prints the reference number. A progress bar for this feature is also included in the GUI for completeness.

## For Review

1. Follow the `README.md` instructions to integrate the OpenLIFU app with 3D Open Water.  
2. Update the `openlifu` library in the app to the new version specified in `python-requirements.txt` to include photocollections.  
3. Ensure your `db_dvc/` matches the version in the relevant OpenLIFU-python commit that introduced photocollections.  

### Testing Workflow

Load a session, add a photocollection using "Add Photocollection To Session" in either the Data or Transducer Tracking module, follow the steps on the Android device, connect the Android device via usb, and confirm the database updates correctly.