### PR TITLE
Add complete transducer tracking UI workflow

### DIFF
--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -128,14 +128,11 @@ class SlicerOpenLIFUPhotoscan:
     def toggle_approval(self) -> None:
         self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
     
-    def toggle_model_display(self, visibility_on: bool = False, viewNodes: List[vtkMRMLViewNode] = []):
-        """ If a viewNode is not specified, the model is displayed in all views by default"""
+    def toggle_model_display(self, visibility_on: bool = False):
+
         self.model_node.GetDisplayNode().SetVisibility(visibility_on)
-        self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
-        
         if self.tracking_fiducial_node:
             self.tracking_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
-            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
                         
     def create_tracking_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
         """Nodes are created by default at the origin"""
@@ -150,4 +147,9 @@ class SlicerOpenLIFUPhotoscan:
         
         return self.tracking_fiducial_node
 
+    def set_view_nodes(self,viewNodes: List[vtkMRMLViewNode] = []):
+        """ If a viewNode is not specified, the model is displayed in all views by default"""
+        self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
+        if self.tracking_fiducial_node:
+            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -149,7 +149,7 @@ class SlicerOpenLIFUPhotoscan:
 
     def set_view_nodes(self,viewNodes: List[vtkMRMLViewNode] = []):
         """ If a viewNode is not specified, the model is displayed in all views by default"""
-        self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
+        self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
         if self.tracking_fiducial_node:
-            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
+            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
         

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -32,9 +32,13 @@ class SlicerOpenLIFUPhotoscan:
     texture_node : vtkMRMLVectorVolumeNode
     """Texture volume node"""
 
-    tracking_fiducial_node : vtkMRMLMarkupsFiducialNode = None
+    facial_landmarks_fiducial_node : vtkMRMLMarkupsFiducialNode = None
     """Fiducial node containing the control points required for photoscan-volume registration when
-     running transducer tracking. The control points mark the left ear, right ear and nasion."""
+     running transducer facial_landmarks. The control points mark the left ear, right ear and nasion."""
+    
+    view_node: vtkMRMLViewNode = None
+    """ View node associated with the preview of this photoscan. Each photoscan has its own viewnode
+    so we can restore the same camera position when the photoscan is previewed."""
 
     @staticmethod
     def _create_nodes(model_data, texture_data, node_name_prefix: str):
@@ -97,8 +101,10 @@ class SlicerOpenLIFUPhotoscan:
         """Clear associated mrml nodes from the scene."""
         slicer.mrmlScene.RemoveNode(self.model_node)
         slicer.mrmlScene.RemoveNode(self.texture_node)
-        if self.tracking_fiducial_node:
-            slicer.mrmlScene.RemoveNode(self.tracking_fiducial_node)
+        if self.facial_landmarks_fiducial_node:
+            slicer.mrmlScene.RemoveNode(self.facial_landmarks_fiducial_node)
+        if self.view_node:
+            slicer.mrmlScene.RemoveNode(self.view_node)
 
     def apply_texture_to_model(self):
         """Apply the texture image to the model node"""
@@ -136,31 +142,31 @@ class SlicerOpenLIFUPhotoscan:
     def toggle_model_display(self, visibility_on: bool = False):
 
         self.model_node.GetDisplayNode().SetVisibility(visibility_on)
-        if self.tracking_fiducial_node:
-            self.tracking_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
+        if self.facial_landmarks_fiducial_node:
+            self.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
                         
-    def create_tracking_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
+    def create_facial_landmarks_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
         """Nodes are created by default at the origin"""
 
         photoscan_id = self.photoscan.photoscan.id
-        self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"{photoscan_id}-faciallandmarks" )
-        self.tracking_fiducial_node.SetMaximumNumberOfControlPoints(3)
-        self.tracking_fiducial_node.SetMarkupLabelFormat("%N")
-        self.tracking_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
-        self.tracking_fiducial_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")
-        self.tracking_fiducial_node.AddControlPoint(nasion_coordinates[0],nasion_coordinates[0],nasion_coordinates[0],"Nasion")
+        self.facial_landmarks_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"{photoscan_id}-faciallandmarks" )
+        self.facial_landmarks_fiducial_node.SetMaximumNumberOfControlPoints(3)
+        self.facial_landmarks_fiducial_node.SetMarkupLabelFormat("%N")
+        self.facial_landmarks_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
+        self.facial_landmarks_fiducial_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")
+        self.facial_landmarks_fiducial_node.AddControlPoint(nasion_coordinates[0],nasion_coordinates[0],nasion_coordinates[0],"Nasion")
         
-        return self.tracking_fiducial_node
+        return self.facial_landmarks_fiducial_node
 
     def set_view_nodes(self,viewNodes: List[vtkMRMLViewNode] = []):
         """ If a viewNode is not specified, the model is displayed in all views by default"""
         self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
-        if self.tracking_fiducial_node:
-            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
+        if self.facial_landmarks_fiducial_node:
+            self.facial_landmarks_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
         
     def set_transform_node(self, transform_node: vtkMRMLTransformNode):
         
         self.model_node.SetAndObserveTransformNodeID(transform_node.GetID())
         
-        if self.tracking_fiducial_node:
-            self.tracking_fiducial_node.SetAndObserveTransformNodeID(transform_node.GetID())   
+        if self.facial_landmarks_fiducial_node:
+            self.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(transform_node.GetID())   

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -138,7 +138,7 @@ class SlicerOpenLIFUPhotoscan:
         """Nodes are created by default at the origin"""
 
         photoscan_id = self.photoscan.photoscan.id
-        self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"Photoscan-{photoscan_id}-TrackingFiducials" )
+        self.tracking_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"{photoscan_id}-faciallandmarks" )
         self.tracking_fiducial_node.SetMaximumNumberOfControlPoints(3)
         self.tracking_fiducial_node.SetMarkupLabelFormat("%N")
         self.tracking_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -2,7 +2,12 @@ from typing import TYPE_CHECKING, List
 import vtk
 from pathlib import Path
 import slicer
-from slicer import vtkMRMLVectorVolumeNode, vtkMRMLModelNode, vtkMRMLViewNode, vtkMRMLMarkupsFiducialNode
+from slicer import (
+    vtkMRMLVectorVolumeNode,
+    vtkMRMLModelNode,
+    vtkMRMLViewNode,
+    vtkMRMLMarkupsFiducialNode,
+    vtkMRMLTransformNode)
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPhotoscanWrapper,
@@ -153,3 +158,9 @@ class SlicerOpenLIFUPhotoscan:
         if self.tracking_fiducial_node:
             self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
         
+    def set_transform_node(self, transform_node: vtkMRMLTransformNode):
+        
+        self.model_node.SetAndObserveTransformNodeID(transform_node.GetID())
+        
+        if self.tracking_fiducial_node:
+            self.tracking_fiducial_node.SetAndObserveTransformNodeID(transform_node.GetID())   

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List
 import vtk
 from pathlib import Path
 import slicer
@@ -128,14 +128,14 @@ class SlicerOpenLIFUPhotoscan:
     def toggle_approval(self) -> None:
         self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
     
-    def toggle_model_display(self, visibility_on: bool = False, viewNode: vtkMRMLViewNode = None):
+    def toggle_model_display(self, visibility_on: bool = False, viewNodes: List[vtkMRMLViewNode] = []):
         """ If a viewNode is not specified, the model is displayed in all views by default"""
         self.model_node.GetDisplayNode().SetVisibility(visibility_on)
-        self.model_node.GetDisplayNode().SetViewNodeIDs([viewNode.GetID()] if viewNode else [])
+        self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
         
         if self.tracking_fiducial_node:
             self.tracking_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
-            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([viewNode.GetID()] if viewNode else [])
+            self.tracking_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes])
                         
     def create_tracking_fiducial_node(self, right_ear_coordinates = [0,0,0], left_ear_coordinates = [0,0,0], nasion_coordinates = [0,0,0]):
         """Nodes are created by default at the origin"""

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -129,8 +129,6 @@ class SlicerOpenLIFUTransducer:
         new_transform_vtk = numpy_to_vtk_4x4(new_transform)
         self.transform_node.SetMatrixTransformToParent(new_transform_vtk)
 
-
-
     def clear_nodes(self) -> None:
         """Clear associated mrml nodes from the scene. Do this when removing a transducer."""
         

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -113,9 +113,9 @@ def get_transducer_tracking_results_in_openlifu_session_format(session_id:str, u
         photoscan_id = transducer_photoscan_node.GetAttribute("TT:photoscanID")
         transducer_tracking_results_openlifu.append(
             openlifu_lz().db.session.TransducerTrackingResult(
-                    photoscan_id,
-                    transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
-                    transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
+                    photoscan_id = photoscan_id,
+                    transducer_to_photoscan_transform = transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
+                    photoscan_to_volume_transform = transform_node_to_openlifu(transform_node=transducer_photoscan_node, transducer_units=units),
                     transducer_to_photoscan_tracking_approved = transducer_photoscan_node.GetAttribute("TT:approvalStatus") == "1",
                     photoscan_to_volume_tracking_approved = photoscan_volume_node.GetAttribute("TT:approvalStatus") == "1",
                     )

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -87,10 +87,13 @@ def get_threeD_transducer_tracking_view_node():
 
     return viewNode
 
-def set_viewnodes_in_scene(view_node: vtkMRMLViewNode):
+def set_viewnodes_in_scene(wizard_view_nodes: List[vtkMRMLViewNode]):
 
     # IDs of all the view nodes in the main Window. This excludes the photoscan's view node
-    views_mainwindow = [node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') if node.GetID() != view_node.GetID()]
+    views_mainwindow = [
+        node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') 
+        for wizard_view_node in wizard_view_nodes
+        if node.GetID() != wizard_view_node.GetID()]
     
     # Set the view nodes for all displayable nodes.
     # If GetViewNodeIDs() is (), the node is displayed in all views so we need to exclude the photoscan view

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -97,7 +97,7 @@ def hide_displayable_nodes_from_view(wizard_view_nodes: List[vtkMRMLViewNode]):
     # IDs of all the view nodes in the main Window. This excludes the photoscan's view node
     all_view_nodes = slicer.util.getNodesByClass('vtkMRMLViewNode')
     views_mainwindow = [node.GetID() for node in all_view_nodes if node not in wizard_view_nodes]
-    
+
     # Set the view nodes for all displayable nodes.
     # If GetViewNodeIDs() is (), the node is displayed in all views so we need to exclude the photoscan view
     for displayable_node in list(slicer.util.getNodesByClass('vtkMRMLDisplayableNode')):

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -58,11 +58,36 @@ def create_threeD_photoscan_view_node(photoscan_id: str):
 
     return viewNode
 
-def display_photoscan_in_viewnode(photoscan: SlicerOpenLIFUPhotoscan, view_node: vtkMRMLViewNode, reset_camera_view: bool = False) -> None:
-    """ Displays the photoscan model node and associated fiducial nodes (if created) within the specified view node, while ensuring
-    that all other displayable nodes in the scene are not included in the view node. When a display node is created, by default, no viewIDs are set.
-    When GetViewNodeIDs is null, the node is displayed in all views. Therefore, to restrict non-photoscan nodes from being displayed in the photoscan preview widget, 
-    we need to set the viewNodeIDs of any displayed nodes to IDs of all viewNodes in the scene, excluding the photoscan viewnode."""
+def get_threeD_transducer_tracking_view_node():
+    """Creates view node for performing transducer tracking
+    """
+
+    # Layout name is used to create and identify the underlying view node 
+    layoutName = "TransducerTracking"
+    layoutLabel = "Volume Co-ordinate Space"
+    layoutColor = [0.97, 0.54, 0.12] # Orange background
+    # ownerNode manages this view instead of the layout manager (it can be any node in the scene)
+    viewOwnerNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode")
+
+    viewNode = slicer.util.getFirstNodeByClassByName('vtkMRMLViewNode','view-transducertracking')
+    if not viewNode:
+        viewLogic = slicer.vtkMRMLViewLogic()
+        viewLogic.SetMRMLScene(slicer.mrmlScene)
+        viewNode = viewLogic.AddViewNode(layoutName)
+        viewNode.SetLayoutLabel(layoutLabel)
+        viewNode.SetLayoutColor(layoutColor)
+        viewNode.SetName(f'view-transducertracking')
+        viewNode.SetAndObserveParentLayoutNodeID(viewOwnerNode.GetID())
+
+    # Customize view node. 
+    viewNode.SetBackgroundColor(0.98, 0.9,0.77) # shades of orange
+    viewNode.SetBackgroundColor2(0.98,0.58,0.4)
+    viewNode.SetBoxVisible(False) # Turn off bounding box visibility
+    viewNode.SetAxisLabelsVisible(False) # Turn off axis labels visibility
+
+    return viewNode
+
+def set_viewnodes_in_scene(view_node: vtkMRMLViewNode):
 
     # IDs of all the view nodes in the main Window. This excludes the photoscan's view node
     views_mainwindow = [node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') if node.GetID() != view_node.GetID()]
@@ -84,22 +109,16 @@ def display_photoscan_in_viewnode(photoscan: SlicerOpenLIFUPhotoscan, view_node:
             for view_nodeID in views_mainwindow:
                 slice_node.AddThreeDViewID(view_nodeID)
 
-    # Display the photoscan 
-    photoscan.toggle_model_display(visibility_on = True, viewNode = view_node) # Specify a view node for display
+def reset_view_node_camera(view_node: vtkMRMLViewNode):
 
-    # Center and fit displayed photoscan in 3D view.
-    # This should only happen when the user is viewing the photoscan for the first time. 
-    # If the user has previously interacted with the 3Dview widget, then
-    # maintain the previous camera/focal point. 
-    if reset_camera_view:
-        layoutManager = slicer.app.layoutManager()
-        for threeDViewIndex in range(layoutManager.threeDViewCount):
-            view = layoutManager.threeDWidget(threeDViewIndex).threeDView()
-            if view.mrmlViewNode().GetID() == view_node.GetID():
-                photoscanViewIndex = threeDViewIndex
-        
-        threeDWidget = layoutManager.threeDWidget(photoscanViewIndex)
-        threeDView = threeDWidget.threeDView() 
-        threeDView.rotateToViewAxis(3)  # look from anterior direction
-        threeDView.resetFocalPoint()  # reset the 3D view cube size and center it
-        threeDView.resetCamera()  # reset camera zoom
+    layoutManager = slicer.app.layoutManager()
+    for threeDViewIndex in range(layoutManager.threeDViewCount):
+        view = layoutManager.threeDWidget(threeDViewIndex).threeDView()
+        if view.mrmlViewNode().GetID() == view_node.GetID():
+            specifiedViewIndex = threeDViewIndex
+    
+    threeDWidget = layoutManager.threeDWidget(specifiedViewIndex)
+    threeDView = threeDWidget.threeDView() 
+    threeDView.rotateToViewAxis(3)  # look from anterior direction
+    threeDView.resetFocalPoint()  # reset the 3D view cube size and center it
+    threeDView.resetCamera()  # reset camera zoom

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -95,10 +95,8 @@ def get_threeD_transducer_tracking_view_node():
 def hide_displayable_nodes_from_view(wizard_view_nodes: List[vtkMRMLViewNode]):
 
     # IDs of all the view nodes in the main Window. This excludes the photoscan's view node
-    views_mainwindow = [
-        node.GetID() for node in slicer.util.getNodesByClass('vtkMRMLViewNode') 
-        for wizard_view_node in wizard_view_nodes
-        if node.GetID() != wizard_view_node.GetID()]
+    all_view_nodes = slicer.util.getNodesByClass('vtkMRMLViewNode')
+    views_mainwindow = [node.GetID() for node in all_view_nodes if node not in wizard_view_nodes]
     
     # Set the view nodes for all displayable nodes.
     # If GetViewNodeIDs() is (), the node is displayed in all views so we need to exclude the photoscan view

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -15,16 +15,21 @@ def initialize_wizard_ui(wizard: qt.QWizard):
     
     return slicer.util.childWidgetVariables(uiWidget)
 
-def set_threeD_view_node(wizard_page: qt.QWizardPage, threeD_view_node: vtkMRMLViewNode):
-
-    # This widget gets destroyed with the dialog so needs to be created each time
+def set_threeD_view_widget(ui):
+     
     viewWidget = slicer.qMRMLThreeDWidget()
     viewWidget.setMRMLScene(slicer.mrmlScene)
-    viewWidget.setMRMLViewNode(threeD_view_node)
     viewWidget.setMinimumHeight(200)
-    
+
     # Add the threeD view widget to specified ui
-    replace_widget(wizard_page.ui.viewWidgetPlaceholder, viewWidget, wizard_page.ui)
+    # In the layout, the UI should have the same name
+    replace_widget(ui.viewWidgetPlaceholder, viewWidget, ui)
+
+    return viewWidget
+
+def set_threeD_view_node(view_widget, threeD_view_node: vtkMRMLViewNode):
+
+    view_widget.setMRMLViewNode(threeD_view_node)
 
 def create_threeD_photoscan_view_node(photoscan_id: str):
     """Creates view node for displaying the photoscan model. Before transducer tracking registration,
@@ -87,7 +92,7 @@ def get_threeD_transducer_tracking_view_node():
 
     return viewNode
 
-def set_viewnodes_in_scene(wizard_view_nodes: List[vtkMRMLViewNode]):
+def hide_displayable_nodes_from_view(wizard_view_nodes: List[vtkMRMLViewNode]):
 
     # IDs of all the view nodes in the main Window. This excludes the photoscan's view node
     views_mainwindow = [

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -1,27 +1,30 @@
 import slicer
 import qt
-from typing import Tuple
-from slicer import vtkMRMLViewNode
+from typing import Tuple, List
+from slicer import vtkMRMLViewNode, vtkMRMLModelNode
 from OpenLIFULib.util import replace_widget
 from OpenLIFULib import SlicerOpenLIFUPhotoscan
 
+def initialize_wizard_ui(wizard: qt.QWizard):
 
-def create_dialog_with_viewnode(dialog_title : str, view_node: vtkMRMLViewNode, ui_path: str) -> Tuple[slicer.qMRMLThreeDWidget, qt.QDialog]:
-    """ Creates the transducer tracking wizard dialog and replaces the place holder widget 
-     with a threeD view widget containing the specified view node.""" 
-      
+    vBoxLayout = qt.QVBoxLayout()
+    wizard.setLayout(vBoxLayout)
+    ui_path = slicer.modules.OpenLIFUTransducerTrackerWidget.resourcePath("UI/TransducerTrackingWizard.ui")
+    uiWidget = slicer.util.loadUI(ui_path)
+    vBoxLayout.addWidget(uiWidget)
+    
+    return slicer.util.childWidgetVariables(uiWidget)
+
+def set_threeD_view_node(wizard_page: qt.QWizardPage, threeD_view_node: vtkMRMLViewNode):
+
     # This widget gets destroyed with the dialog so needs to be created each time
     viewWidget = slicer.qMRMLThreeDWidget()
     viewWidget.setMRMLScene(slicer.mrmlScene)
-    viewWidget.setMRMLViewNode(view_node)
+    viewWidget.setMRMLViewNode(threeD_view_node)
+    viewWidget.setMinimumHeight(200)
     
-    # Create dialog for photoscan preview and add threeD view widget to dialog
-    dialog = slicer.util.loadUI(ui_path)
-    ui = slicer.util.childWidgetVariables(dialog)
-    dialog.setWindowTitle(dialog_title)
-    replace_widget(ui.photoscanPlaceholderWidget, viewWidget, ui)
-
-    return dialog 
+    # Add the threeD view widget to specified ui
+    replace_widget(wizard_page.ui.viewWidgetPlaceholder, viewWidget, wizard_page.ui)
 
 def create_threeD_photoscan_view_node(photoscan_id: str):
     """Creates view node for displaying the photoscan model. Before transducer tracking registration,

--- a/OpenLIFUTransducerTracker/CMakeLists.txt
+++ b/OpenLIFUTransducerTracker/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
-  Resources/UI/PhotoscanPreview.ui
+  Resources/UI/TransducerTrackingWizard.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -96,6 +96,9 @@ class PhotoscanMarkupPage(qt.QWizardPage):
         elif self.ui.placeLandmarksButton.text == "Done Placing Landmarks":
             tracking_node.SetLocked(True)
             self.ui.placeLandmarksButton.setText("Place/Edit Registration Landmarks")
+            
+            # Emit signal to update the enable/disable state of 'Next button'. 
+            self.completeChanged()
     
     def setupMarkupsWidget(self):
 
@@ -103,6 +106,10 @@ class PhotoscanMarkupPage(qt.QWizardPage):
         self.ui.photoscanMarkupsWidget.setCurrentNode(self.wizard().photoscan.tracking_fiducial_node)
         self.wizard().photoscan.tracking_fiducial_node.SetLocked(True)
         self.ui.photoscanMarkupsWidget.enabled = False
+
+    def isComplete(self):
+        """" Determines if the 'Next' button should be enabled"""
+        return self.wizard().photoscan.tracking_fiducial_node is not None
 
 class SkinSegmentationMarkupPage(qt.QWizardPage):
     def __init__(self, parent = None):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -403,6 +403,7 @@ class TransducerTrackingWizard(qt.QWizard):
         self.addPage(self.transducerPhotoscanTrackingPage)
 
         self.setOption(qt.QWizard.NoBackButtonOnStartPage)
+        self.setWizardStyle(qt.QWizard.ClassicStyle)
     
 class PhotoscanPreviewPage(qt.QWizardPage):
     def __init__(self, parent = None):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -642,6 +642,11 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Set view nodes for the skin mesh, transducer and photoscan
         skin_mesh_node.GetDisplayNode().SetViewNodeIDs([volume_view_node.GetID()])
         transducer_surface.GetDisplayNode().SetViewNodeIDs([volume_view_node.GetID()])
+        # For transducers, ensure that the parent folder visibility is turned on
+        shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+        parentFolderID = shNode.GetItemParent(shNode.GetItemByDataNode(transducer_surface))
+        shNode.SetItemDisplayVisibility(parentFolderID, True)
+
         photoscan.set_view_nodes(wizard_view_nodes)
 
         # Hide all displayable nodes in the scene from the wizard view ndoes

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -187,6 +187,12 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
         self.ui.dialogControls.setCurrentIndex(3)
+        
+        # Temp functionality. This will be determined based on the transform node
+        # if it already exists in the scene. 
+        self.transform_approved = False
+
+        self.ui.approvePhotoscanVolumeTransform.clicked.connect(self.onTransformApproveClicked)
     
     def initializePage(self):
         
@@ -202,13 +208,46 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
     
         reset_view_node_camera(view_node)
 
+        self.updateTransformApprovalStatusLabel()
+        self.updateTransformApproveButton()
+    
+    def updateTransformApprovalStatusLabel(self):
+        
+        status = "approved" if self.transform_approved else "not approved"
+        self.ui.photoscanVolumeTransformApprovalStatusLabel.text = (
+            f"The photoscan-volume transform is {status} for transducer tracking"
+        )
+
+    def updateTransformApproveButton(self):
+
+        if self.transform_approved:
+            self.ui.approvePhotoscanVolumeTransform.setText("Revoke approval")
+            self.ui.approvePhotoscanVolumeTransform.setToolTip(
+                    "Revoke approval that the current transducer tracking result is correct")
+        else:
+            self.ui.approvePhotoscanVolumeTransform.setText("Approve photoscan-volume transform")
+            self.ui.approvePhotoscanVolumeTransform.setToolTip("Approve the current transducer tracking result")
+
+    def onTransformApproveClicked(self):
+
+        self.transform_approved = not self.transform_approved
+        
+        # Update the wizard page
+        self.updateTransformApprovalStatusLabel()
+        self.updateTransformApproveButton()
+
 class TransducerPhotoscanTrackingPage(qt.QWizardPage):
     def __init__(self, parent = None):
         super().__init__()
         self.setTitle("Register transducer to photoscan")
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
-        self.ui.dialogControls.setCurrentIndex(3)
+        self.ui.dialogControls.setCurrentIndex(4)
+
+        # Temp functionality. This will be determined based on the transform node
+        # if it already exists in the scene. 
+        self.transform_approved = False
+        self.ui.approveTransducerPhotoscanTransform.clicked.connect(self.onTransformApproveClicked)
     
     def initializePage(self):
 
@@ -223,6 +262,34 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
         skinseg_facial_landmarks.GetDisplayNode().SetVisibility(False)
         
         reset_view_node_camera(view_node)
+    
+        self.updateTransformApprovalStatusLabel()
+        self.updateTransformApproveButton()
+    
+    def updateTransformApprovalStatusLabel(self):
+        
+        status = "approved" if self.transform_approved else "not approved"
+        self.ui.transducerPhotoscanTransformApprovalStatusLabel.text = (
+            f"The transducer-photoscan transform is {status} for transducer tracking"
+        )
+
+    def updateTransformApproveButton(self):
+
+        if self.transform_approved:
+            self.ui.approveTransducerPhotoscanTransform.setText("Revoke approval")
+            self.ui.approveTransducerPhotoscanTransform.setToolTip(
+                    "Revoke approval that the current transducer tracking result is correct")
+        else:
+            self.ui.approveTransducerPhotoscanTransform.setText("Approve transducer-photoscan transform")
+            self.ui.approveTransducerPhotoscanTransform.setToolTip("Approve the current transducer tracking result")
+
+    def onTransformApproveClicked(self):
+
+        self.transform_approved = not self.transform_approved
+        
+        # Update the wizard page
+        self.updateTransformApprovalStatusLabel()
+        self.updateTransformApproveButton()
 
 class TransducerTrackingWizard(qt.QWizard):
     def __init__(self, photoscan: SlicerOpenLIFUPhotoscan, 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 class PhotoscanMarkupPage(qt.QWizardPage):
     def __init__(self, parent = None):
         super().__init__()
-        self.setTitle("Photoscan markup")
+        self.setTitle("Place registration fiducials on photoscan")
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
         self.placingLandmarks = False
@@ -119,7 +119,7 @@ class PhotoscanMarkupPage(qt.QWizardPage):
 class SkinSegmentationMarkupPage(qt.QWizardPage):
     def __init__(self, parent = None):
         super().__init__()
-        self.setTitle("Skin segmentation markup")
+        self.setTitle("Place registration fiducials on skin surface")
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
         self.ui.dialogControls.setCurrentIndex(2)
@@ -139,7 +139,7 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
 class PhotoscanVolumeTrackingPage(qt.QWizardPage):
     def __init__(self, parent = None):
         super().__init__()
-        self.setTitle("Photoscan registration")
+        self.setTitle("Register photoscan to skin surface")
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
         self.ui.dialogControls.setCurrentIndex(3)
@@ -159,7 +159,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 class TransducerPhotoscanTrackingPage(qt.QWizardPage):
     def __init__(self, parent = None):
         super().__init__()
-        self.setTitle("Transducer registration")
+        self.setTitle("Register transducer to photoscan")
         self.ui = initialize_wizard_ui(self)
         self.viewWidget = set_threeD_view_widget(self.ui)
         self.ui.dialogControls.setCurrentIndex(3)
@@ -202,6 +202,8 @@ class TransducerTrackingWizard(qt.QWizard):
         self.addPage(self.skinSegmentationMarkupPage)
         self.addPage(self.photoscanVolumeTrackingPage)
         self.addPage(self.transducerPhotoscanTrackingPage)
+
+        self.setOption(qt.QWizard.NoBackButtonOnStartPage)
     
 class PhotoscanPreviewPage(qt.QWizardPage):
     def __init__(self, parent = None):
@@ -267,6 +269,10 @@ class PhotoscanPreviewWizard(qt.QWizard):
         self.setWindowTitle("Photoscan Preview")
         self.photoscanPreviewPage = PhotoscanPreviewPage(self)
         self.addPage(self.photoscanPreviewPage)
+
+        # Customize view
+        self.setOption(qt.QWizard.NoBackButtonOnStartPage)
+        self.setOption(qt.QWizard.NoCancelButton)
 
 #
 # OpenLIFUTransducerTracker

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -15,7 +15,7 @@ from slicer import (
     vtkMRMLViewNode,
     )
 
-from OpenLIFULib.util import replace_widget
+from OpenLIFULib.util import replace_widget, BusyCursor
 from OpenLIFULib import (
     openlifu_lz,
     get_openlifu_data_parameter_node,
@@ -793,29 +793,32 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.runTrackingButton.setToolTip("Please specify the required inputs")
 
     def onRunTrackingClicked(self):
-        activeData = self.algorithm_input_widget.get_current_data()
-        selected_photoscan_openlifu = activeData["Photoscan"]
-        loaded_slicer_photoscan = self.logic.load_openlifu_photoscan(selected_photoscan_openlifu)
 
-        selected_transducer = activeData["Transducer"]
-        transducer_registration_surface = selected_transducer.surface_model_node
+        with BusyCursor():
+            
+            activeData = self.algorithm_input_widget.get_current_data()
+            selected_photoscan_openlifu = activeData["Photoscan"]
+            loaded_slicer_photoscan = self.logic.load_openlifu_photoscan(selected_photoscan_openlifu)
 
-        volume = activeData["Volume"]
-        skin_mesh_node = self.logic.compute_skin_segmentation(volume)
+            selected_transducer = activeData["Transducer"]
+            transducer_registration_surface = selected_transducer.surface_model_node
 
-        photoscan_view_node, volume_view_node = self.setupWizardViewNodes(
-            loaded_slicer_photoscan,
-            photoscan_preview_only = False,
-            skin_mesh_node =skin_mesh_node,
-            transducer_surface = transducer_registration_surface,
-            )
-      
-        wizard = TransducerTrackingWizard(
-            photoscan = loaded_slicer_photoscan,
-            skin_mesh_node = skin_mesh_node,
-            transducer = selected_transducer,
-            photoscan_view_node= photoscan_view_node,
-            volume_view_node= volume_view_node)
+            volume = activeData["Volume"]
+            skin_mesh_node = self.logic.compute_skin_segmentation(volume)
+
+            photoscan_view_node, volume_view_node = self.setupWizardViewNodes(
+                loaded_slicer_photoscan,
+                photoscan_preview_only = False,
+                skin_mesh_node =skin_mesh_node,
+                transducer_surface = transducer_registration_surface,
+                )
+
+            wizard = TransducerTrackingWizard(
+                photoscan = loaded_slicer_photoscan,
+                skin_mesh_node = skin_mesh_node,
+                transducer = selected_transducer,
+                photoscan_view_node= photoscan_view_node,
+                volume_view_node= volume_view_node)
         
         wizard.exec_()
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -526,8 +526,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             current_page.ui.photoscanMarkupsWidget.setCurrentNode(photoscan.tracking_fiducial_node)
             photoscan.tracking_fiducial_node.SetLocked(True)
             current_page.ui.photoscanMarkupsWidget.enabled = False
-        else:
-            current_page.ui.photoscanMarkupsWidget.show()
 
         self.updatePhotoscanApprovalStatusLabel(current_page, photoscan.is_approved())
 
@@ -537,13 +535,12 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 tracking_fiducial_node = self.logic.initialize_photoscan_tracking_fiducials(photoscan)
                 # Set view nodes on fiducials
                 photoscan.toggle_model_display(visibility_on = True, viewNode = self.photoscanViewNode[photoscan_id]) # Specify a view node for display
+                markupsWidget.setMRMLScene(slicer.mrmlScene)
+                markupsWidget.setCurrentNode(tracking_fiducial_node)
+                markupsWidget.enabled = False
             else:
                 tracking_fiducial_node = photoscan.tracking_fiducial_node
             
-            markupsWidget.setMRMLScene(slicer.mrmlScene)
-            markupsWidget.setCurrentNode(tracking_fiducial_node)
-            markupsWidget.show()
-            markupsWidget.enabled = False
             if current_page.ui.placeLandmarksButton.text == "Place/Edit Registration Landmarks":
                 tracking_fiducial_node.SetLocked(False)
                 current_page.ui.placeLandmarksButton.setText("Done Placing Landmarks")

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -98,35 +98,6 @@
            </layout>
           </widget>
          </item>
-         <item>
-          <layout class="QFormLayout" name="formLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="skinSegmentationModelLabel">
-             <property name="text">
-              <string>Skin segmentation model:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="qMRMLNodeComboBox" name="skinSegmentationModelqMRMLNodeComboBox">
-             <property name="nodeTypes">
-              <stringlist>
-               <string>vtkMRMLModelNode</string>
-              </stringlist>
-             </property>
-             <property name="noneEnabled">
-              <bool>true</bool>
-             </property>
-             <property name="addEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="removeEnabled">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
        </widget>
       </item>
@@ -171,11 +142,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -183,22 +149,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>OpenLIFUTransducerTracking</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>skinSegmentationModelqMRMLNodeComboBox</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>261</x>
-     <y>117</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>328</x>
-     <y>64</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -1,44 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PhotoscanPreview</class>
- <widget class="QDialog" name="PhotoscanPreview">
+ <class>TransducerTrackingWizard</class>
+ <widget class="qMRMLWidget" name="TransducerTrackingWizard">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>580</width>
-    <height>751</height>
+    <width>400</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="photoscanApprovalStatusLabel">
-     <property name="text">
-      <string/>
-     </property>
+   <item alignment="Qt::AlignTop">
+    <widget class="QWidget" name="viewWidgetPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_6"/>
     </widget>
    </item>
-   <item>
-    <widget class="QWidget" name="photoscanPlaceholderWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>560</width>
-       <height>560</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2"/>
-    </widget>
-   </item>
-   <item>
+   <item alignment="Qt::AlignTop">
     <widget class="QStackedWidget" name="dialogControls">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -47,10 +28,17 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="photoscanApprovalStatusLabel">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QPushButton" name="photoscanApprovalButton">
          <property name="text">
@@ -58,23 +46,17 @@
          </property>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="photoscanMarkup">
       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="photoscanApprovalStatusLabel_2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QPushButton" name="placeLandmarksButton">
          <property name="text">
@@ -92,10 +74,35 @@
          </property>
         </widget>
        </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="skinSegmentationMarkup">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QPushButton" name="nextStepButton">
+        <widget class="QPushButton" name="placeLandmarksButtonSkinSeg">
          <property name="text">
-          <string>Next</string>
+          <string>Place/Edit Registration Landmarks</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="qSlicerSimpleMarkupsWidget" name="skinSegMarkupsWidget">
+         <property name="nodeSelectorVisible">
+          <bool>false</bool>
+         </property>
+         <property name="optionsVisible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="PhotoscanMRITracking">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
+         <property name="text">
+          <string>Approve Photoscan-MRI Transform</string>
          </property>
         </widget>
        </item>
@@ -106,6 +113,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>
    <extends>QWidget</extends>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -51,9 +51,9 @@
      <widget class="QWidget" name="photoscanMarkup">
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QLabel" name="photoscanApprovalStatusLabel_2">
+        <widget class="QLabel" name="photoscanApprovalStatusLabel_Markup">
          <property name="text">
-          <string>TextLabel</string>
+          <string/>
          </property>
         </widget>
        </item>
@@ -97,12 +97,23 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="PhotoscanMRITracking">
+     <widget class="QWidget" name="PhotoscanVolumeTracking">
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
         <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
          <property name="text">
-          <string>Approve Photoscan-MRI Transform</string>
+          <string>Approve Photoscan-Volume Transform</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="TransducerPhotoscanTracking">
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
+         <property name="text">
+          <string>Approve Transducer - Photoscan transform</string>
          </property>
         </widget>
        </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>398</width>
+    <height>289</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -100,9 +100,16 @@
      <widget class="QWidget" name="PhotoscanVolumeTracking">
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
+        <widget class="QLabel" name="photoscanVolumeTransformApprovalStatusLabel">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
          <property name="text">
-          <string>Approve Photoscan-Volume Transform</string>
+          <string>Approve photoscan-volume transform</string>
          </property>
         </widget>
        </item>
@@ -111,9 +118,16 @@
      <widget class="QWidget" name="TransducerPhotoscanTracking">
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
+        <widget class="QLabel" name="transducerPhotoscanTransformApprovalStatusLabel">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
          <property name="text">
-          <string>Approve Transducer - Photoscan transform</string>
+          <string>Approve transducer - photoscan transform</string>
          </property>
         </widget>
        </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -19,7 +19,7 @@
      <layout class="QVBoxLayout" name="verticalLayout_6"/>
     </widget>
    </item>
-   <item alignment="Qt::AlignTop">
+   <item>
     <widget class="QStackedWidget" name="dialogControls">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -45,6 +45,19 @@
           <string>Approve Photoscan</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -74,6 +87,19 @@
          </property>
         </widget>
        </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="skinSegmentationMarkup">
@@ -95,6 +121,19 @@
          </property>
         </widget>
        </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="PhotoscanVolumeTracking">
@@ -104,6 +143,16 @@
          <property name="text">
           <string/>
          </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
+         <property name="text">
+          <string>Run ICP registration</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -112,6 +161,29 @@
           <string>Approve photoscan-volume transform</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="ICPPlaceholderLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -125,11 +197,41 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="runTransducerPhotoscanRegistration">
+         <property name="text">
+          <string>Run ICP registration</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
          <property name="text">
           <string>Approve transducer - photoscan transform</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="ICPPlaceholderLabel_2">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Closes #199 
Closes #200 

Few things to address:

- [x] - Currently still need to specify a skin segmentation to proceed
- [x] - Able to click "next" in the TT wizard even without placing any landmarks
- [x] - Able to click "next" in the TT wizard while int he middle of placing landmarks, before clicking "Done placing landmarks"
- [x] To fix: If transducer folder is not displayed in the main scene i.e. eyeballs off, then transducer is not visualized in the wizard.
- [x] Remove transducer tracking view node from photoscan when the user exits wizard.  
- [x] When clearing a photocan, clear the associated view node from the scene
- [ ] Can I set when the back button is enabled/disabled? What behavior is associated with cleanupPage? #203 
- [ ] Which signal is used to indicate wizard finish vs cancel. #203 
- [x] When the session is cleared or the selected TT volume node is removed from the scene - the associated facial landmarks and skin segmentation should also be cleared from the scene. 