### PR TITLE
Fix photocollections not being removed on session unload

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2217,6 +2217,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         if not photocollection_reference_number in loaded_photocollections:
             raise IndexError(f"No photocollection with reference_number {photocollection_reference_number} appears to be loaded; cannot remove it.")
 
+        loaded_photocollections.remove(photocollection_reference_number)
+
     def remove_photoscan(self, photoscan_id:str, clean_up_scene:bool = True) -> None:
         """Remove a photoscan from the list of loaded photoscans, clearing away its data from the scene.
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -287,7 +287,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.checkCanPreviewPhotoscan()
 
     def onStartPhotoscanGenerationButtonClicked(self):
-        reference_numbers = get_openlifu_data_parameter_node().loaded_photocollections
+        reference_numbers = get_openlifu_data_parameter_node().session_photocollections
         if len(reference_numbers) > 1:
             dialog = PhotoscanFromPhotocollectionDialog(reference_numbers)
             if dialog.exec_() == qt.QDialog.Accepted:
@@ -525,7 +525,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         if get_openlifu_data_parameter_node().loaded_session is None:
             self.ui.startPhotoscanGenerationButton.setEnabled(False)
             self.ui.startPhotoscanGenerationButton.setToolTip("Generating a photoscan requires an active session.")
-        elif len(get_openlifu_data_parameter_node().loaded_photocollections) == 0:
+        elif len(get_openlifu_data_parameter_node().session_photocollections) == 0:
             self.ui.startPhotoscanGenerationButton.setEnabled(False)
             self.ui.startPhotoscanGenerationButton.setToolTip("Generating a photoscan requires at least one photocollection.")
         else:


### PR DESCRIPTION
This introduces a minor fix that removes loaded photocollections when `remove_photocollection` is called