### PR TITLE
Fix errors with referenced python-requirements.txt (#206)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@f941ba743dee632a87d328491a383a5cccb6c951
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@d78e5edef8fb03b59871b24adc19338ef5f41355
 bcrypt

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -414,7 +414,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         max_len = max(
             len(getattr(analysis_openlifu, f.name))
             for f in fields(analysis_openlifu)
-            if get_origin(f.type) is list
+            if get_origin(f.type) is list or str(f.type) == "list[float]"
         )
 
         self.focusAnalysisTableModel.setHorizontalHeaderLabels(['Metric'] + [f"Focus {i+1}" for  i in range(max_len)])
@@ -431,7 +431,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             args = get_args(field.type)
 
             # lists of floats go into the focusAnalysisTableModel
-            if origin is list and args == (float,):
+            if origin is list and args == (float,) or str(field.type) == "list[float]":
                 values = getattr(analysis_openlifu,field.name)
                 value_strs = [
                     str(values[i]) if i<len(values) else ""
@@ -443,7 +443,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 )))
 
             # individual floats go into the globalAnalysisTableModel
-            elif origin is Union and len(args)==2 and float in args and type(None) in args:
+            elif origin is Union and len(args)==2 and float in args and type(None) in args or str(field.type) == "float | None":
                 value = getattr(analysis_openlifu,field.name)
                 value_str = str(value) if value is not None else ""
                 self.globalAnalysisTableModel.appendRow(list(map(
@@ -482,7 +482,7 @@ def compute_solution_openlifu(
         target=fiducial_to_openlifu_point_in_transducer_coords(target_node, transducer, name = 'sonication target'),
         session=session.session.session if session is not None else None,
     )
-    return solution, simulation_result_aggregated["p_min"], simulation_result_aggregated["ita"], scaled_solution_analysis
+    return solution, simulation_result_aggregated["p_min"], simulation_result_aggregated["intensity"], scaled_solution_analysis
 
 
 #


### PR DESCRIPTION
## Summary

Please check that the code below which expands on type checking-related conditions. For notes on why those decisions were made, see [OpenLIFU-python PR#244](https://github.com/OpenwaterHealth/OpenLIFU-python/pull/244#event-16717329794).

If you'd like to test additional stuff consider loading the example solution and computing a sonication solution in the sonication planner module, but I've already done this and it works.

## In detail

- This commit fixes a few issues with the version of OpenLIFU-python referenced in `python-requirements.txt`. In particular, the hash of openlifu included changes in naming conventions of `ita`->`intensity` as well as issues related to the solution analysis table being dynamically generated based on the types of fields. The python-requirements.txt was updated to the latest version, which includes additional fixes in OpenLIFU-python related to the solution analysis result data type.

- For related issues in OpenLIFU-python, see [OpenLIFU-python #242](https://github.com/OpenwaterHealth/OpenLIFU-python/issues/242) and [OpenLIFU-python PR#241](https://github.com/OpenwaterHealth/OpenLIFU-python/pull/241)

Changes in this PR also work toward #98 , as it fixes parsing issues introduced when integrating with solution analysis-related code merged in the updated python-requirements.txt.