### PR TITLE
Fix Initialization of transform nodes and saving results to scene/session

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1733,8 +1733,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             replace=True, # If there happen to already be some virtual fit result nodes that clash, loading a session will silently overwrite them.
         )
 
-        for (transducer_to_photoscan_node, photoscan_to_volume_node) in newly_added_tt_result_nodes:
-            newly_loaded_transducer.move_node_into_transducer_sh_folder(transducer_to_photoscan_node)
+        for (transducer_to_volume_node, photoscan_to_volume_node) in newly_added_tt_result_nodes:
+            newly_loaded_transducer.move_node_into_transducer_sh_folder(transducer_to_volume_node)
             newly_loaded_transducer.move_node_into_transducer_sh_folder(photoscan_to_volume_node)
 
         # === Toggle slice visibility and center slices on first target ===

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@3340c3ab43525fbb7a09a93eddf9c458f1735c63
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0cda305c0e07ca292092703964008b3ae5f89aa5
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -136,6 +136,9 @@ class SlicerOpenLIFUPhotoscan:
     def is_approved(self) -> bool:
         return self.photoscan.photoscan.photoscan_approved
                        
+    def get_id(self) -> 'str':
+        return self.photoscan.photoscan.id
+    
     def toggle_approval(self) -> None:
         self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
     
@@ -150,6 +153,9 @@ class SlicerOpenLIFUPhotoscan:
 
         photoscan_id = self.photoscan.photoscan.id
         self.facial_landmarks_fiducial_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode",f"{photoscan_id}-faciallandmarks" )
+        # Ensure that visibility is turned off
+        self.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(False)
+
         self.facial_landmarks_fiducial_node.SetMaximumNumberOfControlPoints(3)
         self.facial_landmarks_fiducial_node.SetMarkupLabelFormat("%N")
         self.facial_landmarks_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -14,7 +14,7 @@ from OpenLIFULib.targets import (
     openlifu_point_to_fiducial,
     fiducial_to_openlifu_point,
 )
-from OpenLIFULib.transform_conversion import transform_node_to_openlifu
+from OpenLIFULib.transform_conversion import transducer_transform_node_to_openlifu
 from OpenLIFULib.virtual_fit_results import get_virtual_fit_results_in_openlifu_session_format
 from OpenLIFULib.transducer_tracking_results import get_transducer_tracking_results_in_openlifu_session_format
 
@@ -188,7 +188,7 @@ class SlicerOpenLIFUSession:
         transducer = get_openlifu_data_parameter_node().loaded_transducers[self.get_transducer_id()]
         transducer_openlifu = transducer.transducer.transducer
         transducer_transform_node : vtkMRMLTransformNode = transducer.transform_node
-        self.session.session.array_transform = transform_node_to_openlifu(transducer_transform_node, transducer_openlifu.units)
+        self.session.session.array_transform = transducer_transform_node_to_openlifu(transducer_transform_node, transducer_openlifu.units)
 
         # Update virtual fit results
         self.session.session.virtual_fit_results = get_virtual_fit_results_in_openlifu_session_format(
@@ -199,7 +199,7 @@ class SlicerOpenLIFUSession:
         #Update transducer tracking results
         self.session.session.transducer_tracking_results = get_transducer_tracking_results_in_openlifu_session_format(
             session_id=self.get_session_id(),
-            units = transducer_openlifu.units,
+            transducer_units = transducer_openlifu.units,
         )
 
         return self.session.session

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -213,7 +213,7 @@ class SlicerOpenLIFUSession:
             photoscan_id for photoscan_id in self.get_affiliated_photoscan_ids()
             for tt_result in session_openlifu.transducer_tracking_results
             if photoscan_id == tt_result.photoscan_id 
-            and tt_result.transducer_to_photoscan_tracking_approved 
+            and tt_result.transducer_to_volume_tracking_approved 
             and tt_result.photoscan_to_volume_tracking_approved 
         ]
 

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -11,7 +11,7 @@ from slicer import (
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.parameter_node_utils import SlicerOpenLIFUTransducerWrapper
 from OpenLIFULib.coordinate_system_utils import numpy_to_vtk_4x4
-from OpenLIFULib.transform_conversion import create_openlifu2slicer_matrix, transform_node_from_openlifu
+from OpenLIFULib.transform_conversion import create_openlifu2slicer_matrix, transducer_transform_node_from_openlifu
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime, but it is done here for IDE and static analysis purposes
@@ -59,7 +59,7 @@ class SlicerOpenLIFUTransducer:
         if transducer_matrix_units is None:
             transducer_matrix_units = transducer.units
 
-        transform_node = transform_node_from_openlifu(
+        transform_node = transducer_transform_node_from_openlifu(
             openlifu_transform_matrix = transducer_matrix,
             transform_units = transducer_matrix_units,
             transducer = transducer,

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -321,7 +321,6 @@ def get_photoscan_ids_with_results(session_id: str, approved_only = False) -> Li
     else:
         return [t.GetAttribute("TT:photoscanID") for (t,_) in tt_results]
 
-
 def set_transducer_tracking_approval_for_node(approval_state: bool, transform_node: vtkMRMLTransformNode) -> None:
     """Set approval state on the given transducer tracking transform node.
 
@@ -330,10 +329,15 @@ def set_transducer_tracking_approval_for_node(approval_state: bool, transform_no
         transform_node: vtkMRMLTransformNode
     """
     if (transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}") != "1" 
-        or transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") != "1"
+        and transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") != "1"
     ):
         raise ValueError("The specified transform node is a not a transducer tracking result node")
     transform_node.SetAttribute("TT:approvalStatus", "1" if approval_state else "0")
+
+def get_approval_from_transducer_tracking_result_node(node : vtkMRMLTransformNode) -> bool:
+    if node.GetAttribute("TT:approvalStatus") is None:
+        raise RuntimeError("Node does not have a transducer tracking approval status.")
+    return node.GetAttribute("TT:approvalStatus") == "1"
 
 def get_photoscan_id_from_transducer_tracking_result(result: Union[vtkMRMLTransformNode, Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]]) -> str:
     """Returns the photoscan ID associated with a transducer tracking transform node. 

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -106,6 +106,8 @@ def hide_displayable_nodes_from_view(wizard_view_nodes: List[vtkMRMLViewNode]):
             vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(displayable_node)
             if vrDisplayNode and vrDisplayNode.GetVisibility() and not vrDisplayNode.GetViewNodeIDs():
                     vrDisplayNode.SetViewNodeIDs(views_mainwindow)
+        elif displayable_node.IsA('vtkMRMLTransformNode') and displayable_node.GetDisplayNode() is not None:
+            displayable_node.GetDisplayNode().SetEditorVisibility(False)
         elif displayable_node.GetDisplayVisibility() and not displayable_node.GetDisplayNode().GetViewNodeIDs():
             displayable_node.GetDisplayNode().SetViewNodeIDs(views_mainwindow)
     

--- a/OpenLIFULib/OpenLIFULib/transform_conversion.py
+++ b/OpenLIFULib/OpenLIFULib/transform_conversion.py
@@ -27,7 +27,7 @@ def create_openlifu2slicer_matrix(units : str) -> np.ndarray:
         get_xxx2ras_matrix('LPS') * get_xx2mm_scale_factor(units)
     )
 
-def transform_node_to_openlifu(transform_node:vtkMRMLTransformNode, transducer_units:str) -> "ArrayTransform":
+def transducer_transform_node_to_openlifu(transform_node:vtkMRMLTransformNode, transducer_units:str) -> "ArrayTransform":
     """Convert a transducer transform vtkMRMLTransformNode from Slicer to openlifu format.
 
     The vtkMRMLTransformNode has a matrix is assumed to convert from the transducer LPS space in the given `transducer_units`
@@ -47,7 +47,7 @@ def transform_node_to_openlifu(transform_node:vtkMRMLTransformNode, transducer_u
         units = transducer_units,
     )
 
-def transform_node_from_openlifu(
+def transducer_transform_node_from_openlifu(
         openlifu_transform_matrix:np.ndarray,
         transducer : "Transducer",
         transform_units:str = None,

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -1,7 +1,7 @@
 import slicer
 from slicer import vtkMRMLTransformNode
 from typing import Optional, Iterable, List, Tuple, Dict, TYPE_CHECKING, Union
-from OpenLIFULib.transform_conversion import transform_node_to_openlifu, transform_node_from_openlifu
+from OpenLIFULib.transform_conversion import transducer_transform_node_to_openlifu, transducer_transform_node_from_openlifu
 from OpenLIFULib.lazyimport import openlifu_lz
 
 if TYPE_CHECKING:
@@ -153,7 +153,7 @@ def get_virtual_fit_results_in_openlifu_session_format(session_id:str, units:str
         virtual_fit_results_openlifu[target_id] = (
             approved,
             [
-                transform_node_to_openlifu(transform_node=t, transducer_units=units)
+                transducer_transform_node_to_openlifu(transform_node=t, transducer_units=units)
                 for t in vf_nodes_for_target
             ],
         )
@@ -184,7 +184,7 @@ def add_virtual_fit_results_from_openlifu_session_format(
     nodes_that_have_been_added = []
     for target_id, (is_approved, array_transforms) in vf_results_openlifu.items():
         for i, array_transform in enumerate(array_transforms):
-            virtual_fit_result_transform = transform_node_from_openlifu(
+            virtual_fit_result_transform = transducer_transform_node_from_openlifu(
                 openlifu_transform_matrix = array_transform.matrix,
                 transform_units = array_transform.units,
                 transducer = transducer,

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -35,7 +35,7 @@ from OpenLIFULib.virtual_fit_results import (
 )
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
-from OpenLIFULib.transform_conversion import transform_node_from_openlifu
+from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 
 if TYPE_CHECKING:
     from OpenLIFUData.OpenLIFUData import OpenLIFUDataLogic
@@ -582,7 +582,7 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
 
         for i,vf_transform in zip(range(10), vf_transforms): # We only add the top 10 virtual fit nodes, to not put so many transforms into the scene.
             node = add_virtual_fit_result(
-                transform_node = transform_node_from_openlifu(vf_transform, transducer.transducer.transducer, "mm"),
+                transform_node = transducer_transform_node_from_openlifu(vf_transform, transducer.transducer.transducer, "mm"),
                 target_id = target_id,
                 session_id = session_id,
                 approval_status = False,

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -47,7 +47,7 @@ from OpenLIFULib.transducer_tracking_wizard_utils import (
 )
 
 from OpenLIFULib.virtual_fit_results import get_best_virtual_fit_result_node
-from OpenLIFULib.coordinate_system_utils import numpy_to_vtk_4x4
+from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 
 from OpenLIFULib.skinseg import generate_skin_mesh
@@ -1385,13 +1385,15 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
         
         if best_virtual_fit_result_node is None:
             # Initialize transform with identity matrix
-            initial_transform = numpy_to_vtk_4x4(np.eye(4))
+            transducer_to_volume_result = transducer_transform_node_from_openlifu(
+                openlifu_transform_matrix = np.eye(4) ,
+                transducer = transducer.transducer.transducer,
+                transform_units = transducer.transducer.transducer.units)
         else:
-            initial_transform = vtk.vtkMatrix4x4()
-            best_virtual_fit_result_node.GetMatrixTransformToParent(initial_transform)
-            
-        transducer_to_volume_result = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
-        transducer_to_volume_result.SetMatrixTransformToParent(initial_transform)
+            virtual_fit_transform = vtk.vtkMatrix4x4()
+            best_virtual_fit_result_node.GetMatrixTransformToParent(virtual_fit_transform)
+            transducer_to_volume_result = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+            transducer_to_volume_result.SetMatrixTransformToParent(virtual_fit_transform)
 
         transducer_to_volume_result = add_transducer_tracking_result(
             transducer_to_volume_result,

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -555,12 +555,17 @@ class TransducerTrackingWizard(qt.QWizard):
             transform_type = TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME)
         if tt_result:
             self.transducer.set_current_transform_to_match_transform_node(tt_result)
+            
+        # Reset the transducer surface to observe the transducer transform
+        self.transducer_surface.SetAndObserveTransformNodeID(self.transducer.transform_node.GetID())
 
         self.accept()  # Closes the wizard
 
     def onCancel(self):
         """Handle Cancel button click."""
         self.resetViewNodes()
+        # Reset the transducer surface to observe the transducer transform
+        self.transducer_surface.SetAndObserveTransformNodeID(self.transducer.transform_node.GetID())
         self.reject()  # Closes the wizard
     
     def setupViewNodes(self):
@@ -1383,7 +1388,7 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
             initial_transform = numpy_to_vtk_4x4(np.eye(4))
         else:
             initial_transform = vtk.vtkMatrix4x4()
-            best_virtual_fit_result_node.GetMatrixTransformFromParent(initial_transform)
+            best_virtual_fit_result_node.GetMatrixTransformToParent(initial_transform)
             
         transducer_to_volume_result = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
         transducer_to_volume_result.SetMatrixTransformToParent(initial_transform)

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>398</width>
-    <height>289</height>
+    <width>774</width>
+    <height>666</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -79,6 +79,12 @@
        </item>
        <item>
         <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>
          </property>
@@ -113,6 +119,12 @@
        </item>
        <item>
         <widget class="qSlicerSimpleMarkupsWidget" name="skinSegMarkupsWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>
          </property>
@@ -139,37 +151,62 @@
      <widget class="QWidget" name="PhotoscanVolumeTracking">
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QLabel" name="photoscanVolumeTransformApprovalStatusLabel">
-         <property name="text">
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
           <string/>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_11">
+          <item>
+           <widget class="QPushButton" name="initializePVRegistration">
+            <property name="text">
+             <string>Initialize photoscan-volume transform</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
+            <property name="text">
+             <string>Run ICP-based registration fine-tuning</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="ICPPlaceholderLabel">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
-         <property name="text">
-          <string>Run ICP registration</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
-         <property name="text">
-          <string>Approve photoscan-volume transform</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ICPPlaceholderLabel">
-         <property name="text">
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
           <string/>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
+            <property name="text">
+             <string>Approve photoscan-volume transform</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="photoscanVolumeTransformApprovalStatusLabel">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -190,34 +227,65 @@
      <widget class="QWidget" name="TransducerPhotoscanTracking">
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
-        <widget class="QLabel" name="transducerPhotoscanTransformApprovalStatusLabel">
-         <property name="text">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
           <string/>
          </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <item>
+           <widget class="QPushButton" name="initializeTPRegistration">
+            <property name="text">
+             <string>Initialize transducer-photoscan transform</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="runTransducerPhotoscanRegistration">
+            <property name="text">
+             <string>Run ICP-based registration fine-tuning</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="ICPPlaceholderLabel_2">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="runTransducerPhotoscanRegistration">
-         <property name="text">
-          <string>Run ICP registration</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
-         <property name="text">
-          <string>Approve transducer - photoscan transform</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ICPPlaceholderLabel_2">
-         <property name="text">
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
           <string/>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
+            <property name="text">
+             <string>Approve transducer - photoscan transform</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="transducerPhotoscanTransformApprovalStatusLabel">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
Closes #201 
Closes #202 
Addresses #203 
Closes #211

- In utils.transform_conversion, `transform_node_{to/from}_openlifu` has been renamed `transducer_transform_node_{to/from}_openlifu`
- In openlifu, we keep tracking of `transducer_to_volume` and `photoscan_to_volume` transforms. We don't save the `transducer_to_photoscan` transform. 
- Depends on openlifu update: https://github.com/OpenwaterHealth/OpenLIFU-python/pull/257

- [x] Before merging: Update python requirements

Changes to test:

- The photoscan to volume page now has the functionality to initialize/reinitialize the transform with fiducial-based regstration.
- When running ICP, the transform node handles should now be centered on the photoscan model. 
- The transducer to skin surface registration page has the functionality to initialize/reinitialize the transform with the virtual fit result. If there is no virtual fit result, the transform node is initialized with identity. 
- When 'Finish' is clicked at the end, the view nodes are all reset and the current transducer tranform is updated.
- When 'Cancel' is clicked at any point, the view nodes are all reset. If cancel is clicked on the last page, then the current transducer transform is not updated. 
- No bugs when switching back and forth between pages. The correct 3D nodes should be displayed in each view.
- Each time the user navigates to a new wizard page, the view gets reset i.e. the displayed nodes are centered in the view. 
- When in "manual ICP registration mode", the approval and initialize buttons are disabled
- The transform approve button is only enabled when there is a transform node initialized. If there is no transform node to approve,the status message is empty.  
- Toggling the approval button, toggles the "approvalStatus" attribute of the affiliated transform node.
- After generating both transducer tracking transforms, the session can be saved and the transform nodes are written to open lifu correctly. This can be tested by saving and then reloading the session. The session should read back in the correct transform nodes.