### PR TITLE
Fix premature import openlifu failure (#215)

### DIFF
--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -237,6 +237,16 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUProtocolConfigLogic()
 
+        # Initialize the member in setup() because it relies on openlifu_lz(),
+        # which has GUI elements attached to trigger a yes/no dialog.
+        self.logic.EMPTY_PROTOCOL = openlifu_lz().plan.Protocol(
+            name = "",
+            id = "",
+            description = "",
+            pulse = openlifu_lz().bf.Pulse(frequency=0.00, duration=0.00),
+            focal_pattern = openlifu_lz().bf.focal_patterns.SinglePoint()
+        )
+
         # === Connections and UI setup =======
 
         # These connections ensure that we update parameter node when scene is closed
@@ -774,13 +784,9 @@ class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic):
         "Focal patten options": None,
     }
 
-    EMPTY_PROTOCOL = openlifu_lz().plan.Protocol(
-        name = "",
-        id = "",
-        description = "",
-        pulse = openlifu_lz().bf.Pulse(frequency=0.00, duration=0.00),
-        focal_pattern = openlifu_lz().bf.focal_patterns.SinglePoint()
-    )
+    # Initialize in setup() because it relies on openlifu_lz(),
+    # which has GUI elements attached to trigger a yes/no dialog.
+    EMPTY_PROTOCOL = None
 
     def __init__(self) -> None:
         """Called when the logic class is instantiated. Can be used for initializing member variables."""


### PR DESCRIPTION
Previously, `EMPTY_PROTOCOL` was initialized at the class level using `openlifu_lz()`, which attempts to import `openlifu`. If the Python dependencies were not yet installed, this resulted in a `ModuleNotFoundError`, preventing module loading.

**Traceback (Relevant Part):**

```
Traceback (most recent call last):
  File "Applicaton/s app/duleents/lib/Python/Lib/python3.9/imp.py", Line 169, in load source module = _exec(spec, sys-modules [namel)
  File "«frozen importlib._bootstrap»",
  File "<frozen importlib._bootstrap_external>",
  File "«frozen importlib._bootstrap›", in _call_with_frames_removed
  File "/Applications/Slicer.app/Contents/Extensions-33241/SlicerOpenLIFU/lib/Slicer-5.8/qt-scripted-modules/OpenLIFUProtocolConfig.py", Line 757, in <module> class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic) :
  File "/Applications/Slicer.app/Contents/Extensions-33241/SlicerOpenLIFU/lib/Slicer-5.8/qt-scripted-modules/OpenLIFUProtocolConfig.py", line 777, in OpenLIFUProtocolConfigLogic EMPTY_PROTOCOL = openlifu_lz(). plan.Protocol(
  File "/Applications/Slicer.app/Contents/Extensions-33241/SlicerOpenLIFU/lib/Slicer-5.8/qt-scripted-modules/OpenLIFULib/lazyimport.py", line 59, in openlifu_lz import openlifu
ModuleNotFoundError: No module named 'openlifu'
```

**Fix:**
- Initialize `EMPTY_PROTOCOL` to `None` at the class level.
- Add a comment explaining that initialization must be delayed.
- Set `EMPTY_PROTOCOL` in the module setup phase after Slicer’s UI is ready.

This ensures that the missing dependency check and prompt for installation happen at the appropriate time.