### PR TITLE
127 set up guided mode framework and UI

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -44,6 +44,7 @@ from OpenLIFULib.util import (
     ensure_list,
     add_slicer_log_handler_for_openlifu_object,
     BusyCursor,
+    replace_widget,
 )
 
 from OpenLIFULib.virtual_fit_results import (
@@ -57,6 +58,7 @@ from OpenLIFULib.transducer_tracking_results import (
 )
 
 from OpenLIFULib.events import SlicerOpenLIFUEvents
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -750,6 +752,15 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         self.updateLoadedObjectsView()
         self.updateSessionStatus()
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = "OpenLIFULogin",
+            next_module_name = "OpenLIFUPrePlanning",
+            include_session_controls = False,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
     def onSubjectSessionSelected(self):
         self.update_subjectLevelButtons_enabled()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -44,7 +44,6 @@ from OpenLIFULib.util import (
     ensure_list,
     add_slicer_log_handler_for_openlifu_object,
     BusyCursor,
-    replace_widget,
 )
 
 from OpenLIFULib.virtual_fit_results import (
@@ -58,7 +57,7 @@ from OpenLIFULib.transducer_tracking_results import (
 )
 
 from OpenLIFULib.events import SlicerOpenLIFUEvents
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -78,7 +77,7 @@ class OpenLIFUData(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Data")  # TODO: make this more human readable by adding spaces
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = []  # add here list of module names that this module requires
+        self.parent.dependencies = ["OpenLIFUHome"]  # add here list of module names that this module requires
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware), Brad Moore (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -627,7 +626,7 @@ def sessionInvalidatedDialogDisplay(message:str) -> bool:
 #
 
 
-class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -753,14 +752,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.updateLoadedObjectsView()
         self.updateSessionStatus()
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = "OpenLIFULogin",
-            next_module_name = "OpenLIFUPrePlanning",
-            include_session_controls = False,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
     def onSubjectSessionSelected(self):
         self.update_subjectLevelButtons_enabled()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -115,12 +115,12 @@ class CreateNewSessionDialog(qt.QDialog):
     """ Create new session dialog """
 
     def __init__(self, transducer_ids: List[str], protocol_ids: List[str], volume_ids: List[str], parent="mainWindow"):
-        super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
         """ Args:
                 transducer_ids: IDs of the transducers available in the loaded database
                 protocol_ids: IDs of the protocols available in the loaded database
                 volume_ids: IDs of the volumes available for the selected subject in the loaded database
         """
+        super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
 
         self.setWindowTitle("Create New Session")
         self.setWindowModality(qt.Qt.WindowModal)

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -416,6 +416,13 @@
      </property>
     </spacer>
    </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -241,7 +241,7 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
 
     def start_guided_mode(self):
         set_guided_mode_state(True)
-        slicer.util.selectModule("OpenLIFUData")
+        slicer.util.selectModule("OpenLIFULogin")
 
 #
 # OpenLIFUHomeTest

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -13,7 +13,7 @@ from OpenLIFULib.lazyimport import (
     check_and_install_python_requirements,
 )
 
-from OpenLIFULib.guided_mode_util import set_guided_mode_state
+from OpenLIFULib.guided_mode_util import set_guided_mode_state, Workflow
 
 #
 # OpenLIFUHome
@@ -232,6 +232,8 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
         """Called when the logic class is instantiated. Can be used for initializing member variables."""
         ScriptedLoadableModuleLogic.__init__(self)
 
+        self.workflow = Workflow()
+
     
     def getParameterNode(self):
         return OpenLIFUHomeParameterNode(super().getParameterNode())
@@ -242,6 +244,10 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
     def start_guided_mode(self):
         set_guided_mode_state(True)
         slicer.util.selectModule("OpenLIFULogin")
+    
+    def workflow_jump_ahead(self):
+        """Jump ahead in the guided workflow to the furthest step for which `can_proceed` is True."""
+        slicer.util.selectModule(self.workflow.furthest_module_to_which_can_proceed())
 
 #
 # OpenLIFUHomeTest

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -102,7 +102,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.guidedModePushButton.connect("clicked()", self.onGuidedModeClicked)
         self.updateInstallButtonText()
         self.updateGuidedModeButton()
-        
+
         # Switch modules
         self.ui.dataPushButton.clicked.connect(lambda : self.switchModule(self.ui.dataPushButton.text))
         self.ui.prePlanningPushButton.clicked.connect(lambda : self.switchModule(self.ui.prePlanningPushButton.text))
@@ -111,9 +111,9 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.transducerTrackingPushButton.clicked.connect(lambda : self.switchModule(self.ui.transducerTrackingPushButton.text))
         self.ui.protocolConfigPushButton.clicked.connect(lambda :
                                                          self.switchModule(self.ui.protocolConfigPushButton.text))
-    
 
-    def switchModule(self, moduleButtonText: str) -> None:  
+
+    def switchModule(self, moduleButtonText: str) -> None:
         moduleButtonText = moduleButtonText.replace(" ", "")
         moduleButtonText = moduleButtonText.replace("-", "")
 
@@ -124,7 +124,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if (moduleButtonText == "OpenLIFUProtocolConfiguration"):
             moduleButtonText = moduleButtonText[:-7]  # strip to -Config
-        
+
         slicer.util.selectModule(moduleButtonText)
 
 
@@ -173,7 +173,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # so that when the scene is saved and reloaded, these settings are restored.
 
         self.setParameterNode(self.logic.getParameterNode())
-       
+
     def setParameterNode(self, inputParameterNode: Optional[OpenLIFUHomeParameterNode]) -> None:
         """
         Set and observe parameter node.
@@ -209,10 +209,10 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.guidedModePushButton.setToolTip(
                     "Guided mode will take you step-by-step through the treatment workflow"
                 )
-    
+
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateGuidedModeButton()
-            
+
 #
 # OpenLIFUHomeLogic
 #
@@ -234,7 +234,7 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
 
         self.workflow = Workflow()
 
-    
+
     def getParameterNode(self):
         return OpenLIFUHomeParameterNode(super().getParameterNode())
 
@@ -243,11 +243,15 @@ class OpenLIFUHomeLogic(ScriptedLoadableModuleLogic):
 
     def start_guided_mode(self):
         set_guided_mode_state(True)
-        slicer.util.selectModule("OpenLIFULogin")
-    
+        self.workflow_go_to_start()
+
     def workflow_jump_ahead(self):
         """Jump ahead in the guided workflow to the furthest step for which `can_proceed` is True."""
         slicer.util.selectModule(self.workflow.furthest_module_to_which_can_proceed())
+
+    def workflow_go_to_start(self):
+        """Go to the starting module of the workflow"""
+        slicer.util.selectModule(self.workflow.starting_module())
 
 #
 # OpenLIFUHomeTest

--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -1,4 +1,11 @@
+from typing import Optional, TYPE_CHECKING
+import qt
 import slicer
+from OpenLIFULib.util import display_errors
+
+if TYPE_CHECKING:
+    from OpenLIFUData.OpenLIFUData import OpenLIFUDataLogic
+    from OpenLIFUHome.OpenLIFUHome import OpenLIFUHomeLogic
 
 def get_guided_mode_state() -> bool:
     """Get guided mode state from the OpenLIFU Home module's parameter node"""
@@ -9,3 +16,163 @@ def set_guided_mode_state(new_guided_mode_state: bool):
     """Set guided mode state in OpenLIFU Home module's parameter node"""
     openlifu_home_parameter_node = slicer.util.getModuleLogic('OpenLIFUHome').getParameterNode()
     openlifu_home_parameter_node.guided_mode = new_guided_mode_state
+
+class WorkflowControls(qt.QWidget):
+    """ Guided mode workflow controls widget
+
+    The widget can be used whether in or out of guided mode, but the guardrails are active only when in guided mode.
+    Guardrails here means that the "can_proceed" property controls whether the next button is enabled.
+
+    Example usage to test it out in the Slicer python console:
+        from OpenLIFULib.guided_mode_util import WorkflowControls
+        workflow_controls = WorkflowControls(
+            parent=None,
+            previous_module_name = "OpenLIFUData",
+            next_module_name = "OpenLIFUPrePlanning",
+            include_session_controls = True,
+        )
+        workflow_controls.show()
+
+        # then try things like this:
+        workflow_controls.status_text = "Blah blah"
+        workflow_controls.can_proceed = False
+    """
+
+    def __init__(
+            self,
+            parent:qt.QWidget,
+            previous_module_name:Optional[str],
+            next_module_name:Optional[str],
+            include_session_controls:bool=False,
+        ):
+        """Guided mode controls QWidget
+
+        Args:
+            parent: Parent QWidget
+            previous_module_name: Name of the slicer module that precedes the current one in the workflow. If None then there is no previous module,
+                and in that case there will not be a back button.
+            next_module_name: Name of the slicer module that is next in the workflow. If None then there is no next module, and in that case
+                there will not be a next button and the "save and close" button will instead be labeled "Finish"
+                (and will still have the effect of saving and closing). So if you set `next_module_name` to `None` then you probably
+                want to enable `include_session_controls`.
+            include_session_controls: Whether to include the buttons for saving and closing the session. The buttons do not set their enabled/disabled
+                state based on whether there is a session or whether there is a database, so only include session controls if you know that
+                in the guided workflow there will definitely be a database connection and an active session during the modules in the workflow
+                that this widget is being added to.
+        """
+        super().__init__(parent)
+
+        self._can_proceed:bool = True
+        self._status_text:str = ""
+
+        self.next_module_name = next_module_name
+        self.previous_module_name = previous_module_name
+
+        main_layout = qt.QVBoxLayout()
+        self.setLayout(main_layout)
+
+        main_group_box = qt.QGroupBox("Workflow Controls")
+        main_group_box_layout = qt.QVBoxLayout()
+        main_group_box.setLayout(main_group_box_layout)
+        main_layout.addWidget(main_group_box)
+
+        self.status_label = qt.QLabel("")
+        main_group_box_layout.addWidget(self.status_label)
+
+        button_row1_layout = qt.QHBoxLayout()
+        main_group_box_layout.addLayout(button_row1_layout)
+
+        if self.previous_module_name is not None:
+            self.back_button = qt.QPushButton("Back")
+            button_row1_layout.addWidget(self.back_button)
+            self.back_button.clicked.connect(self.on_back)
+
+        if self.next_module_name is not None:
+            self.next_button = qt.QPushButton("Next")
+            button_row1_layout.addWidget(self.next_button)
+            self.next_button.clicked.connect(self.on_next)
+
+
+        if include_session_controls:
+            button_row2_layout = qt.QHBoxLayout()
+            self.save_close_button = qt.QPushButton("Save and close" if self.next_module_name is not None else "Finish")
+            self.close_button = qt.QPushButton("Close without saving")
+            button_row2_layout.addWidget(self.save_close_button)
+            button_row2_layout.addWidget(self.close_button)
+            main_group_box_layout.addLayout(button_row2_layout)
+            self.save_close_button.clicked.connect(self.on_save_close)
+            self.close_button.clicked.connect(self.on_close)
+
+        self.update_back_button_enabledness()
+        self.update_next_button_enabledness()
+        self.update_status_label()
+
+    def on_next(self):
+        slicer.util.selectModule(self.next_module_name)
+
+    def on_back(self):
+        slicer.util.selectModule(self.previous_module_name)
+
+    @display_errors
+    def on_save_close(self, clicked:bool):
+        self.close_session(save=True)
+
+    @display_errors
+    def on_close(self, clicked:bool):
+        self.close_session(save=False)
+
+    def close_session(self, save:bool):
+        """Close the session, saving it or not depending on `save`"""
+        data_module_logic : OpenLIFUDataLogic = slicer.util.getModuleLogic('OpenLIFUData')
+        home_module_logic : OpenLIFUHomeLogic = slicer.util.getModuleLogic('OpenLIFUHome')
+        if save:
+            data_module_logic.save_session()
+        data_module_logic.clear_session(clean_up_scene=True)
+        home_module_logic.start_guided_mode()
+
+    def update_next_button_enabledness(self):
+        if not hasattr(self, "next_button"):
+            return
+        enabled = (
+            (
+                (self.next_module_name is not None)
+                and self.can_proceed
+            )
+            or not get_guided_mode_state()
+        )
+        self.next_button.setEnabled(enabled)
+        if enabled:
+            self.next_button.setToolTip(f"Go to the {self.next_module_name} module.")
+        else:
+            self.next_button.setToolTip(self.status_text)
+
+
+    def update_back_button_enabledness(self):
+        if not hasattr(self, "back_button"):
+            return
+        self.back_button.setEnabled(self.previous_module_name is not None)
+
+    def update_status_label(self):
+        self.status_label.setText(self.status_text)
+
+    @property
+    def can_proceed(self) -> bool:
+        """Whether the next step of the workflow should be available"""
+        return self._can_proceed
+
+    @can_proceed.setter
+    def can_proceed(self, new_val : bool):
+        self._can_proceed = new_val
+        self.update_next_button_enabledness()
+
+    @property
+    def status_text(self) -> str:
+        """Status text explaining what the next step is"""
+        return self._status_text
+
+    @status_text.setter
+    def status_text(self, new_val : str):
+        self._status_text = new_val
+        self.update_status_label()
+
+

--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -114,9 +114,9 @@ class WorkflowControls(qt.QWidget):
         self.update()
 
     def update(self):
-        self.update_back_button_enabledness()
-        self.update_next_button_enabledness()
         self.update_status_label()
+        self.update_back_button_enabledness()
+        self.update_next_button()
 
     def on_next(self):
         slicer.util.selectModule(self.next_module_name)
@@ -145,7 +145,8 @@ class WorkflowControls(qt.QWidget):
         data_module_logic.clear_session(clean_up_scene=True)
         home_module_logic.start_guided_mode()
 
-    def update_next_button_enabledness(self):
+    def update_next_button(self):
+        """Update next button enabledness and tooltip"""
         if not hasattr(self, "next_button"):
             return
         enabled = self.can_proceed or not get_guided_mode_state()
@@ -155,7 +156,6 @@ class WorkflowControls(qt.QWidget):
         else:
             self.next_button.setToolTip(self.status_text)
 
-
     def update_back_button_enabledness(self):
         if not hasattr(self, "back_button"):
             return
@@ -164,6 +164,7 @@ class WorkflowControls(qt.QWidget):
 
     def update_status_label(self):
         self.status_label.setText(self.status_text)
+        self.update_next_button() # Ensures the tooltip gets updated
 
     @property
     def can_proceed(self) -> bool:
@@ -173,7 +174,7 @@ class WorkflowControls(qt.QWidget):
     @can_proceed.setter
     def can_proceed(self, new_val : bool):
         self._can_proceed = new_val
-        self.update_next_button_enabledness()
+        self.update_next_button()
 
     @property
     def status_text(self) -> str:

--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -143,7 +143,7 @@ class WorkflowControls(qt.QWidget):
         if save:
             data_module_logic.save_session()
         data_module_logic.clear_session(clean_up_scene=True)
-        home_module_logic.start_guided_mode()
+        home_module_logic.workflow_go_to_start()
 
     def update_next_button(self):
         """Update next button enabledness and tooltip"""
@@ -218,6 +218,10 @@ class Workflow:
                 next_module_name = next_module,
                 include_session_controls = current_module not in ["OpenLIFULogin", "OpenLIFUData"],
             )
+
+    def starting_module(self) -> str:
+        """Get the name of the first module in the guided workflow."""
+        return self.modules[0]
 
     def furthest_module_to_which_can_proceed(self) -> str:
         """Get the name of the furthest module along the workflow to which we `can_proceed`."""

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -29,10 +29,9 @@ from OpenLIFULib import (
 
 from OpenLIFULib.util import (
     display_errors,
-    replace_widget,
 )
 
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -509,7 +508,7 @@ class ChangePasswordDialog(qt.QDialog):
 # OpenLIFULoginWidget
 #
 
-class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -580,14 +579,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Call the routine to update from data parameter node
         self.onDataParameterNodeModified()
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = None,
-            next_module_name = "OpenLIFUData",
-            include_session_controls = False,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -29,7 +29,10 @@ from OpenLIFULib import (
 
 from OpenLIFULib.util import (
     display_errors,
+    replace_widget,
 )
+
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -576,6 +579,15 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Call the routine to update from data parameter node
         self.onDataParameterNodeModified()
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = None,
+            next_module_name = "OpenLIFUData",
+            include_session_controls = False,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -92,6 +92,13 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -37,6 +37,7 @@ from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.events import SlicerOpenLIFUEvents
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     from OpenLIFUData.OpenLIFUData import OpenLIFUDataLogic
@@ -178,6 +179,15 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.ui.lockButton.clicked.connect(self.onLockClicked)
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
         self.ui.virtualfitButton.clicked.connect(self.onVirtualfitClicked)
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = "OpenLIFUData",
+            next_module_name = "OpenLIFUTransducerTracker",
+            include_session_controls = True,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -37,7 +37,7 @@ from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.events import SlicerOpenLIFUEvents
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     from OpenLIFUData.OpenLIFUData import OpenLIFUDataLogic
@@ -55,7 +55,7 @@ class OpenLIFUPrePlanning(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Pre-Planning")
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = []  # add here list of module names that this module requires
+        self.parent.dependencies = ["OpenLIFUHome"]  # add here list of module names that this module requires
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware), Brad Moore (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -90,7 +90,7 @@ class OpenLIFUPrePlanningParameterNode:
 #
 
 
-class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -180,14 +180,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
         self.ui.virtualfitButton.clicked.connect(self.onVirtualfitClicked)
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = "OpenLIFUData",
-            next_module_name = "OpenLIFUTransducerTracker",
-            include_session_controls = True,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -197,8 +197,7 @@
             <item>
              <widget class="QLabel" name="placeholderLabel">
               <property name="text">
-               <string>Placeholder for an
-OpenLIFUAlgorithmInputWidget</string>
+               <string>Placeholder for an OpenLIFUAlgorithmInputWidget</string>
               </property>
              </widget>
             </item>
@@ -237,6 +236,13 @@ OpenLIFUAlgorithmInputWidget</string>
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -18,8 +18,8 @@ from OpenLIFULib import (get_openlifu_data_parameter_node,
                          SlicerOpenLIFURun,
 )
 
-from OpenLIFULib.util import display_errors, replace_widget
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.util import display_errors
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -38,7 +38,7 @@ class OpenLIFUSonicationControl(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Sonication Control")  # TODO: make this more human readable by adding spaces
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = []  # add here list of module names that this module requires
+        self.parent.dependencies = ["OpenLIFUHome"]  # add here list of module names that this module requires
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Andrew Howe (Kitware) Peter Hollender (Openwater), Sam Horvath (Kitware), Brad Moore (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -161,7 +161,7 @@ class OnRunCompletedDialog(qt.QDialog):
 #
 
 
-class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -230,14 +230,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # After setup, update the module state from the data parameter node
         self.onDataParameterNodeModified()
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = "OpenLIFUSonicationPlanner",
-            next_module_name = None,
-            include_session_controls = True,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -18,7 +18,8 @@ from OpenLIFULib import (get_openlifu_data_parameter_node,
                          SlicerOpenLIFURun,
 )
 
-from OpenLIFULib.util import display_errors
+from OpenLIFULib.util import display_errors, replace_widget
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -228,6 +229,15 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # After setup, update the module state from the data parameter node
         self.onDataParameterNodeModified()
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = "OpenLIFUSonicationPlanner",
+            next_module_name = None,
+            include_session_controls = True,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -83,6 +83,13 @@
      </property>
     </spacer>
    </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -26,7 +26,7 @@ from OpenLIFULib import (
 )
 from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem, get_openlifu_data_parameter_node
 from OpenLIFULib.events import SlicerOpenLIFUEvents
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -48,7 +48,7 @@ class OpenLIFUSonicationPlanner(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Sonication Planning")
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = []  # add here list of module names that this module requires
+        self.parent.dependencies = ["OpenLIFUHome"]  # add here list of module names that this module requires
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware), Brad Moore (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -79,7 +79,7 @@ class OpenLIFUSonicationPlannerParameterNode:
 #
 
 
-class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -157,14 +157,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = "OpenLIFUTransducerTracker",
-            next_module_name = "OpenLIFUSonicationControl",
-            include_session_controls = True,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
 
     def cleanup(self) -> None:

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -26,6 +26,7 @@ from OpenLIFULib import (
 )
 from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem, get_openlifu_data_parameter_node
 from OpenLIFULib.events import SlicerOpenLIFUEvents
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -155,6 +156,15 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = "OpenLIFUTransducerTracker",
+            next_module_name = "OpenLIFUSonicationControl",
+            include_session_controls = True,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
 
     def cleanup(self) -> None:

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -17,8 +17,7 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Placeholder for an
-OpenLIFUAlgorithmInputWidget</string>
+         <string>Placeholder for an OpenLIFUAlgorithmInputWidget</string>
         </property>
        </widget>
       </item>
@@ -211,6 +210,13 @@ analysis.</string>
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -52,7 +52,7 @@ from OpenLIFULib.transform_conversion import transducer_transform_node_from_open
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.skinseg import generate_skin_mesh
-from OpenLIFULib.guided_mode_util import WorkflowControls
+from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 
 if TYPE_CHECKING:
     import openlifu
@@ -738,7 +738,7 @@ class OpenLIFUTransducerTracker(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("OpenLIFU Transducer Tracking")
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "OpenLIFU.OpenLIFU Modules")]
-        self.parent.dependencies = ['OpenLIFUData']  # add here list of module names that this module requires
+        self.parent.dependencies = ['OpenLIFUData',"OpenLIFUHome"]  # add here list of module names that this module requires
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware), Sadhana Ravikumar (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware)"]
         # short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -830,7 +830,7 @@ class PhotoscanFromPhotocollectionDialog(qt.QDialog):
 # OpenLIFUTransducerTrackerWidget
 #
     
-class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, GuidedWorkflowMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -903,14 +903,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updatePhotoscanGenerationButtons()
         self.updateApprovalStatusLabel()
 
-        # === Guided mode workflow controls ===
-        self.workflow_controls = WorkflowControls(
-            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
-            previous_module_name = "OpenLIFUPrePlanning",
-            next_module_name = "OpenLIFUSonicationPlanner",
-            include_session_controls = True,
-        )
-        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
+        self.inject_workflow_controls_into_placeholder()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -52,6 +52,7 @@ from OpenLIFULib.transform_conversion import transducer_transform_node_from_open
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.skinseg import generate_skin_mesh
+from OpenLIFULib.guided_mode_util import WorkflowControls
 
 if TYPE_CHECKING:
     import openlifu
@@ -901,6 +902,15 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         self.updatePhotoscanGenerationButtons()
         self.updateApprovalStatusLabel()
+
+        # === Guided mode workflow controls ===
+        self.workflow_controls = WorkflowControls(
+            parent = self.ui.workflowControlsPlaceholder.parentWidget(),
+            previous_module_name = "OpenLIFUPrePlanning",
+            next_module_name = "OpenLIFUSonicationPlanner",
+            include_session_controls = True,
+        )
+        replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -122,20 +122,27 @@
         </property>
        </widget>
       </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>21</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>21</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(128, 0, 128);</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This adds a guided mode framework.

The way it works is that each module that needs guided mode controls has a placeholder widget called `workflowControlsPlaceholder`. Each such module gets a mixin `GuidedWorkflowMixin` added to its inheritance chain. This provides it with a method `inject_workflow_controls_into_placeholder` that sticks the widget into place.

The workflow widgets look like this:

![image](https://github.com/user-attachments/assets/007b6953-2ca9-461f-ac85-f7ecb915a47d)

with some variability when different buttons need to be available at the start and end.

Memory-wise the workflow widgets are owned by the module widgets that they live in, but bookkeeping-wise they are tracked in a `Workflow` object that is in the OpenLIFUHome module logic. This object does the setup, linking the next and back buttons to one another and allowing you to define how the workflow is organized in one place.

The `GuidedWorkflowMixin` grants to each module widget an attribute `workflow_controls` which is the the widget in the screenshot above. Each module is responsible for controlling the widget's `can_proceed:bool` and `status_text:str` attributes. With the magic of properties, the widget updates automatically when those attributes are modified.