### PR TITLE
Remove texture flip (#222)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -125,10 +125,7 @@ class SlicerOpenLIFUPhotoscan:
         self.model_node.CreateDefaultDisplayNodes() # By default, this turns model visibility on
         modelDisplayNode = self.model_node.GetDisplayNode()
         modelDisplayNode.SetBackfaceCulling(0)
-        textureImageFlipVert = vtk.vtkImageFlip()
-        textureImageFlipVert.SetFilteredAxis(1)
-        textureImageFlipVert.SetInputConnection(filter.GetOutputPort())
-        modelDisplayNode.SetTextureImageDataConnection(textureImageFlipVert.GetOutputPort())
+        modelDisplayNode.SetTextureImageDataConnection(filter.GetOutputPort())
 
         # Turn model visibility off
         modelDisplayNode.SetVisibility(False)


### PR DESCRIPTION
See https://github.com/OpenwaterHealth/OpenLIFU-python/pull/261#issuecomment-2769787977

The run_reconstruction function in openlifu is what we'll ultimately use, so the code that applies textures to models in SlicerOpenLIFU should be made compatible with the output of run_reconstruction.