### PR TITLE
Introduce guided workflow for placing facial landmarks 

### DIFF
--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -158,6 +158,9 @@ class SlicerOpenLIFUPhotoscan:
         self.facial_landmarks_fiducial_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
         self.facial_landmarks_fiducial_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")
         self.facial_landmarks_fiducial_node.AddControlPoint(nasion_coordinates[0],nasion_coordinates[0],nasion_coordinates[0],"Nasion")
+        self.facial_landmarks_fiducial_node.UnsetNthControlPointPosition(0)
+        self.facial_landmarks_fiducial_node.UnsetNthControlPointPosition(1)
+        self.facial_landmarks_fiducial_node.UnsetNthControlPointPosition(2)
         
         return self.facial_landmarks_fiducial_node
 

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -138,13 +138,7 @@ class SlicerOpenLIFUPhotoscan:
     
     def toggle_approval(self) -> None:
         self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
-    
-    # def toggle_model_display(self, visibility_on: bool = False):
-
-    #     self.model_node.GetDisplayNode().SetVisibility(visibility_on)
-    #     # if self.facial_landmarks_fiducial_node:
-    #     #     self.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(visibility_on)
-                        
+                     
     def initialize_facial_landmarks_from_node(self, fiducial_node: vtkMRMLMarkupsFiducialNode):
         """ Clones the provided vtkMRMLMarkupsFiducialNode and assigns the clone to the photoscan attribute. The input fiducial node
         is expected to contain 3 control points, marking the Right Ear, Left Ear and Nasion on the photoscan mesh. This node

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -176,6 +176,14 @@ class PhotoscanMarkupPage(qt.QWizardPage):
         tableWidget = self.ui.photoscanMarkupsWidget.tableWidget()
         tableWidget.setSelectionMode(tableWidget.SingleSelection)
         tableWidget.setSelectionBehavior(tableWidget.SelectRows)
+        tableWidget.setContextMenuPolicy(qt.Qt.NoContextMenu) # Prevents context menu that allows point deletion/rearrangement.
+        # Make the row  names uneditable
+        for row in range(tableWidget.rowCount):
+            item = tableWidget.item(row, 0)
+            flags = item.flags()
+            flags &= ~qt.Qt.ItemIsEditable
+            item.setFlags(flags)
+
         tableWidget.itemClicked.connect(self.markupTableWidgetSelected)
         tableWidget.itemDoubleClicked.connect(self.unsetControlPoint)
 
@@ -397,6 +405,13 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
         tableWidget = self.ui.skinSegMarkupsWidget.tableWidget()
         tableWidget.setSelectionMode(tableWidget.SingleSelection)
         tableWidget.setSelectionBehavior(tableWidget.SelectRows)
+        tableWidget.setContextMenuPolicy(qt.Qt.NoContextMenu) # Prevents context menu that allows point deletion/rearrangement.
+        # Make the row  names uneditable
+        for row in range(tableWidget.rowCount):
+            item = tableWidget.item(row, 0)
+            flags = item.flags()
+            flags &= ~qt.Qt.ItemIsEditable
+            item.setFlags(flags)
         tableWidget.itemClicked.connect(self.markupTableWidgetSelected)
         tableWidget.itemDoubleClicked.connect(self.unsetControlPoint)
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -156,7 +156,7 @@ class PhotoscanMarkupPage(qt.QWizardPage):
             self.placingLandmarks = True
             self.ui.photoscanMarkupsWidget.enabled = True
             if self._checkAllLandmarksDefined():
-                self.ui.landmarkPlacementStatus.text = "-Landmark positions unlocked. Click on the mesh to adjust.\n" \
+                self.ui.landmarkPlacementStatus.text = "- Landmark positions unlocked. Click on the mesh to adjust.\n" \
                 "- To unset a landmark's position, double-click it in the list."
             else:
                 self.ui.landmarkPlacementStatus.text = "- Select the desired landmark (Right Ear, Left Ear, or Nasion) from the list.\n" \
@@ -301,6 +301,7 @@ class PhotoscanMarkupPage(qt.QWizardPage):
         self.facial_landmarks_fiducial_node.SetNthControlPointLabel(self._currentlyPlacingIndex, caller.GetName())
         
         self.exitPlaceFiducialMode() # Exit place mode after the point is placed
+        self.currently_placing_node.RemoveAllObservers()
         slicer.mrmlScene.RemoveNode(self.currently_placing_node) # Remove the temporary node
         self.temp_markup_fiducials[self.currently_placing_node.GetName()] = None
         if self._checkAllLandmarksDefined():
@@ -408,7 +409,7 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
             self.placingLandmarks = True
             self.ui.skinSegMarkupsWidget.enabled = True
             if self._checkAllLandmarksDefined():
-                self.ui.landmarkPlacementStatus_2.text = "-Landmark positions unlocked. Click on the mesh to adjust.\n" \
+                self.ui.landmarkPlacementStatus_2.text = "- Landmark positions unlocked. Click on the mesh to adjust.\n" \
                 "- To unset a landmark's position, double-click it in the list."
             else:
                 self.ui.landmarkPlacementStatus_2.text = "- Select the desired landmark (Right Ear, Left Ear, or Nasion) from the list.\n" \
@@ -530,10 +531,12 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
         self.facial_landmarks_fiducial_node.SetNthControlPointLabel(self._currentlyPlacingIndex, caller.GetName())
         
         self.exitPlaceFiducialMode() # Exit place mode after the point is placed
+        self.currently_placing_node.RemoveAllObservers()
         slicer.mrmlScene.RemoveNode(self.currently_placing_node) # Remove the temporary node
         self.temp_markup_fiducials[self.currently_placing_node.GetName()] = None
         if self._checkAllLandmarksDefined():
-            self.ui.landmarkPlacementStatus_2.text = "Landmark positions unlocked. Click on the mesh to adjust." # Update the status message
+            self.ui.landmarkPlacementStatus_2.text = "-Landmark positions unlocked. Click on the mesh to adjust.\n" \
+                "- To unset a landmark's position, double-click it in the list." # Update the status message
     
     @vtk.calldata_type(vtk.VTK_INT)
     def onPointRemoved(self, node, eventID, callData):
@@ -1000,10 +1003,14 @@ class TransducerTrackingWizard(qt.QWizard):
     def clearWizardNodes(self):
         # Ensure any temporary variables are cleared. Nodes in the scene are not updated
         for node in self.photoscanMarkupPage.temp_markup_fiducials.values():
+            if node:
+                node.RemoveAllObservers()
             slicer.mrmlScene.RemoveNode(node)
         slicer.mrmlScene.RemoveNode(self.photoscanMarkupPage.facial_landmarks_fiducial_node)
 
         for node in self.skinSegmentationMarkupPage.temp_markup_fiducials.values():
+            if node:
+                node.RemoveAllObservers()
             slicer.mrmlScene.RemoveNode(node)
         slicer.mrmlScene.RemoveNode(self.skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
         

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -144,6 +144,10 @@ class PhotoscanMarkupPage(qt.QWizardPage):
         self.ui.photoscanMarkupsWidget.setCurrentNode(self.wizard().photoscan.facial_landmarks_fiducial_node)
         
         tableWidget = self.ui.photoscanMarkupsWidget.tableWidget()
+
+        # for i in range(self.wizard().photoscan.facial_landmarks_fiducial_node.GetNumberOfControlPoints()):
+        #     if self.wizard().photoscan.facial_landmarks_fiducial_node.GetNthControlPointPositionStatus(i) == 0:
+        #         tableWidget.setItem(i,1,None)
         
         # If the selected landmark is 'unset', then the cursor is set to 'Place' mode.
         tableWidget.setSelectionMode(tableWidget.SingleSelection)
@@ -202,8 +206,7 @@ class PhotoscanMarkupPage(qt.QWizardPage):
 
         # Add observer to detect when a point is placed
         self._pointModifiedObserverTag = self.currently_placing_node.AddObserver(
-            slicer.vtkMRMLMarkupsNode.PointPositionDefinedEvent , self.onPointPlaced
-        )
+            slicer.vtkMRMLMarkupsNode.PointPositionDefinedEvent , self.onPointPlaced)
 
     def onPointPlaced(self, caller, event):
         
@@ -239,6 +242,12 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
         self.ui.dialogControls.setCurrentIndex(2)
 
         self.placingLandmarks = False
+        self._pointModifiedObserverTag = None
+        self.temp_markup_fiducials = {
+            'Right Ear': None,
+            'Left Ear': None,
+            'Nasion': None}
+        
         self.ui.placeLandmarksButtonSkinSeg.clicked.connect(self.onPlaceLandmarksClicked)
 
     def initializePage(self):
@@ -264,25 +273,122 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
             self.skinseg_facial_landmarks.SetLocked(False)
             self.ui.placeLandmarksButtonSkinSeg.setText("Done Placing Landmarks")
             self.placingLandmarks = True
-            # Emit signal to update the enable/disable state of 'Next button'. 
-            self.completeChanged()
+            if self.checkAllLandmarksDefined():
+                self.ui.landmarkPlacementStatus_2.text = "Landmark positions unlocked. Click on the mesh to adjust."
+            else:
+                self.ui.landmarkPlacementStatus_2.text = "To place a landmark (Right Ear, Left Ear, or Nasion), first select it from the list, " \
+                        "and then click on the corresponding location on the skin surface mesh."
+
         elif self.ui.placeLandmarksButtonSkinSeg.text == "Done Placing Landmarks":
             self.skinseg_facial_landmarks.SetLocked(True)
             self.ui.placeLandmarksButtonSkinSeg.setText("Place/Edit Registration Landmarks")
             self.placingLandmarks = False
-            # Emit signal to update the enable/disable state of 'Next button'. 
-            self.completeChanged()
+            self.exitPlaceFiducialMode()
+            self.ui.landmarkPlacementStatus_2.text = ""
+        
+        # Emit signal to update the enable/disable state of 'Next button'. 
+        self.completeChanged()
+
+    def initialize_temporary_skinseg_tracking_fiducial(self, node_name: str):
+
+        initialized_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", node_name)
+        initialized_node.GetDisplayNode().SetVisibility(False) # Ensure that visibility is turned off
+        initialized_node.SetMaximumNumberOfControlPoints(1)
+        initialized_node.SetMarkupLabelFormat("%N")
+        initialized_node.GetDisplayNode().SetViewNodeIDs([self.wizard().photoscan.view_node.GetID(), self.wizard().volume_view_node.GetID()])
+        initialized_node.GetDisplayNode().SetVisibility(True)
+
+        return initialized_node
     
     def setupMarkupsWidget(self):
 
         self.ui.skinSegMarkupsWidget.setMRMLScene(slicer.mrmlScene)
         self.ui.skinSegMarkupsWidget.setCurrentNode(self.skinseg_facial_landmarks)
-        self.ui.skinSegMarkupsWidget.enabled = False
+        tableWidget = self.ui.skinSegMarkupsWidget.tableWidget()
+        
+        # If the selected landmark is 'unset', then the cursor is set to 'Place' mode.
+        tableWidget.setSelectionMode(tableWidget.SingleSelection)
+        tableWidget.setSelectionBehavior(tableWidget.SelectRows)
+        tableWidget.itemClicked.connect(self.markupTableWidgetSelected)
+
+    def markupTableWidgetSelected(self, item):
+
+        if not self.placingLandmarks:
+            return
+        currentRow = item.row()
+        if currentRow == -1:
+            self._currentlyPlacingIndex = -1
+            self.exitPlaceFiducialMode()
+            return
+
+        selected_landmark_name = self.ui.skinSegMarkupsWidget.tableWidget().item(currentRow, 0).text()
+        # If the point has already been defined, exit place mode
+        if self.skinseg_facial_landmarks.GetNthControlPointPositionStatus(currentRow) != 0:
+            self.exitPlaceFiducialMode()
+            return
+
+        # Initialize temporary fiducial if it doesn't exist
+        if self.temp_markup_fiducials.get(selected_landmark_name) is None:
+            self.temp_markup_fiducials[selected_landmark_name] = self.initialize_temporary_skinseg_tracking_fiducial(node_name=selected_landmark_name)
+
+        self.currently_placing_node = self.temp_markup_fiducials[selected_landmark_name]
+        # Enter place mode if the node has no control points yet
+        if self.currently_placing_node.GetNumberOfControlPoints() == 0:
+            self.enterPlaceFiducialMode()
+            self._currentlyPlacingIndex = currentRow
+  
+    def enterPlaceFiducialMode(self):
+
+        markupLogic = slicer.modules.markups.logic()
+        markupLogic.SetActiveListID(self.currently_placing_node)
+        markupLogic.StartPlaceMode(0)
+
+        # Add observer to detect when a point is placed
+        self._pointModifiedObserverTag = self.currently_placing_node.AddObserver(
+            slicer.vtkMRMLMarkupsNode.PointPositionDefinedEvent , self.onPointPlaced)
+
+    def onPointPlaced(self, caller, event):
+        
+        # Check that a control point was actually added to the fiducial node
+        if caller.GetNumberOfControlPoints() < 1: 
+            return
+
+        # Update the control point associated with the skin segmentation
+        position = [0.0, 0.0, 0.0]
+        self.currently_placing_node.GetNthControlPointPosition(0,position)
+        self.skinseg_facial_landmarks.SetNthControlPointPosition(self._currentlyPlacingIndex, position)
+        
+        self.exitPlaceFiducialMode() # Exit place mode after the point is placed
+        slicer.mrmlScene.RemoveNode(self.currently_placing_node) # Remove the temporary node
+        self.temp_markup_fiducials[self.currently_placing_node.GetName()] = None
+        if self.checkAllLandmarksDefined():
+            self.ui.landmarkPlacementStatus_2.text = "Landmark positions unlocked. Click on the mesh to adjust." # Update the status message
+
+    def exitPlaceFiducialMode(self):
+        if self._pointModifiedObserverTag:
+            self.currently_placing_node.RemoveObserver(self._pointModifiedObserverTag)
+            self._pointModifiedObserverTag = None
+  
+        interactionNode = slicer.app.applicationLogic().GetInteractionNode()
+        interactionNode.SetCurrentInteractionMode(interactionNode.ViewTransform)
+
+    def checkAllLandmarksDefined(self):
+
+        if self.skinseg_facial_landmarks is None:
+            return False
+
+        # Check that all the landmarks are valid/set control point
+        all_points_defined = True
+        for i in range(self.skinseg_facial_landmarks.GetNumberOfControlPoints()):
+            if self.skinseg_facial_landmarks.GetNthControlPointPositionStatus(i) == 0:
+                all_points_defined = False
+        return all_points_defined
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
         landmarks_exist = self.skinseg_facial_landmarks is not None
-        return landmarks_exist and not self.placingLandmarks
+        all_points_defined = self.checkAllLandmarksDefined()
+        return landmarks_exist and all_points_defined and not self.placingLandmarks
 
 class PhotoscanVolumeTrackingPage(qt.QWizardPage):
     def __init__(self, parent = None):
@@ -404,7 +510,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             self.ui.ICPPlaceholderLabel.text = "This run button is a placeholder. The transducer tracking algorithm is under development. " \
             "Use the interaction handles to manually align the photoscan and volume mesh." \
             "You can click the run button again to remove the interaction handles."
-            self.ui.ICPPlaceholderLabel.setProperty(" .Sheet", "color: red;")
+            self.ui.ICPPlaceholderLabel.setProperty("styleSheet", "color: red;")
 
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
             self.runningRegistration = True
@@ -1441,6 +1547,9 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
         volume_facial_landmarks_node.AddControlPoint(right_ear_coordinates[0],right_ear_coordinates[0],right_ear_coordinates[0],"Right Ear")
         volume_facial_landmarks_node.AddControlPoint(left_ear_coordinates[0],left_ear_coordinates[0],left_ear_coordinates[0],"Left Ear")
         volume_facial_landmarks_node.AddControlPoint(nasion_coordinates[0],nasion_coordinates[0],nasion_coordinates[0],"Nasion")
+        volume_facial_landmarks_node.UnsetNthControlPointPosition(0)
+        volume_facial_landmarks_node.UnsetNthControlPointPosition(1)
+        volume_facial_landmarks_node.UnsetNthControlPointPosition(2)
 
         # Set the ID of corresponding volume as a node attribute 
         volume_facial_landmarks_node.SetAttribute('OpenLIFUData.volume_id', volume_tracking_fiducial_id)

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -127,6 +127,16 @@
         <widget class="QPushButton" name="placeLandmarksButtonSkinSeg">
          <property name="text">
           <string>Place/Edit Registration Landmarks</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="landmarkPlacementStatus_2">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>774</width>
-    <height>666</height>
+    <width>778</width>
+    <height>688</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -78,12 +78,25 @@
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="landmarkPlacementStatus">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::PreventContextMenu</enum>
          </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -96,7 +96,7 @@
           </sizepolicy>
          </property>
          <property name="contextMenuPolicy">
-          <enum>Qt::NoContextMenu</enum>
+          <enum>Qt::PreventContextMenu</enum>
          </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -28,7 +28,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="photoscanPreview">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -96,7 +96,7 @@
           </sizepolicy>
          </property>
          <property name="contextMenuPolicy">
-          <enum>Qt::PreventContextMenu</enum>
+          <enum>Qt::NoContextMenu</enum>
          </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>
@@ -147,6 +147,9 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::NoContextMenu</enum>
          </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>


### PR DESCRIPTION
Closes #196 
Partly Addresses #219. The fiducial markup nodes used within the wizard and independent of the nodes in the scene. The 'scene' nodes are only updated on Finish.  

- Introduces a guided workflow for annotating the photoscan and skin segmentation mesh
- When points are 'unset', the table shows 'Click to Place XX'. Once placed, the table lists the landmark name.
- When a point is double clicked in the table, the point is unset and the user can click to place again. The position gets reset to 0,0,0
- If the user clicks 'Cancel' at any point, even after moving landmarks, landmarks don't get created in the scene
- When user clicks Finish at the end, fiducial nodes are added to the scene and temp wizard nodes are cleared.
- Next is only enabled once all points are defined.
- Disabled the right click context menu on the markups widget but if the user does delete a control point (i.e. keyboard press or right clicking the control point), this action is blocked and the user is notified.
- If a previously computed facial landmarks node has been invalidated ie. the previously created landmark node in the scene does not have 3 control points, the user is notified before the wizard is started. 
- Control points in the list are indexed based on their names, not position in the list. The user is notified if a control point is selected that has an "invalid" name

Note: I noticed some errors when I get to the registration steps after previously running the wizard. I will fix that when updating the registration workflow as part of #220 