### PR TITLE
Make targets renamable

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1583,10 +1583,12 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
     def load_session(self, subject_id, session_id) -> None:
 
-        # Make sure to the preplanning module is loaded in -- it watches for some events
-        # that would cause virtual fit approval to be revoked. We could be about to load a
-        # session with virtual fit approval already applied so this is important.
+        # Certain modules need to have their widgets already set up, if they were not, before loading a session.
+        # This is because those module widgets set up observers on certain kinds of nodes as those nodes are added to the scene.
+        # If the widgets don't exist when a session is loaded, they will not get a chance to add their observers.
         slicer.util.getModule("OpenLIFUPrePlanning").widgetRepresentation()
+        slicer.util.getModule("OpenLIFUTransducerTracker").widgetRepresentation()
+        slicer.util.getModule("OpenLIFUSonicationPlanner").widgetRepresentation()
 
         # === Ensure it's okay to load a session ===
 

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/transducer_tracking_results.py
   OpenLIFULib/skinseg.py
   OpenLIFULib/transducer_tracking_wizard_utils.py
+  OpenLIFULib/events.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/events.py
+++ b/OpenLIFULib/OpenLIFULib/events.py
@@ -1,0 +1,12 @@
+"""Custom vtk events for use throughout the application."""
+from enum import IntEnum, unique
+import vtk
+
+OPENLIFU_STARTING_VTK_EVENT_ID = vtk.vtkCommand.UserEvent + 5000
+
+@unique
+class SlicerOpenLIFUEvents(IntEnum):
+    """Custom vtk events for SlicerOpenLIFU."""
+
+    TARGET_NAME_MODIFIED_EVENT = OPENLIFU_STARTING_VTK_EVENT_ID + 1
+    """Invoked by an openlifu target fiducial node when its name is modified via SlicerOpenLIFU."""

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -106,7 +106,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.setup(self)
 
-        self.node_observations : Dict[str:List[int]] = defaultdict(list)
+        # Mapping from mrml node ID to a list of vtkCommand tags that can later be used to remove the observation
+        self.node_observations : Dict[str,List[int]] = defaultdict(list)
 
         # Load widget from .ui file (created by Qt Designer).
         # Additional widgets can be instantiated manually and added to self.layout.

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -25,6 +25,7 @@ from OpenLIFULib import (
     SlicerOpenLIFUSolutionAnalysis,
 )
 from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem, get_openlifu_data_parameter_node
+from OpenLIFULib.events import SlicerOpenLIFUEvents
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -274,6 +275,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         """Add observers so that point-list changes in this fiducial node are tracked by the module."""
         self.addObserver(node,slicer.vtkMRMLMarkupsNode.PointAddedEvent,self.onPointAddedOrRemoved)
         self.addObserver(node,slicer.vtkMRMLMarkupsNode.PointRemovedEvent,self.onPointAddedOrRemoved)
+        self.addObserver(node,SlicerOpenLIFUEvents.TARGET_NAME_MODIFIED_EVENT,self.onTargetNameModified)
 
     def unwatch_fiducial_node(self, node:vtkMRMLMarkupsFiducialNode):
         """Un-does watch_fiducial_node; see watch_fiducial_node."""
@@ -281,6 +283,9 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.removeObserver(node,slicer.vtkMRMLMarkupsNode.PointRemovedEvent,self.onPointAddedOrRemoved)
 
     def onPointAddedOrRemoved(self, caller, event):
+        self.updateInputOptions()
+
+    def onTargetNameModified(self, caller, event):
         self.updateInputOptions()
 
     def onComputeSolutionClicked(self):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -50,7 +50,7 @@ from OpenLIFULib.transducer_tracking_wizard_utils import (
 from OpenLIFULib.virtual_fit_results import get_best_virtual_fit_result_node
 from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
-
+from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.skinseg import generate_skin_mesh
 
 if TYPE_CHECKING:
@@ -979,6 +979,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         """Add observers so that point-list changes in this fiducial node are tracked by the module."""
         self.addObserver(node,slicer.vtkMRMLMarkupsNode.PointAddedEvent,self.onPointAddedOrRemoved)
         self.addObserver(node,slicer.vtkMRMLMarkupsNode.PointRemovedEvent,self.onPointAddedOrRemoved)
+        self.addObserver(node,SlicerOpenLIFUEvents.TARGET_NAME_MODIFIED_EVENT,self.onTargetNameModified)
 
     def unwatch_fiducial_node(self, node:vtkMRMLMarkupsFiducialNode):
         """Un-does watch_fiducial_node; see watch_fiducial_node."""
@@ -986,6 +987,9 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.removeObserver(node,slicer.vtkMRMLMarkupsNode.PointRemovedEvent,self.onPointAddedOrRemoved)
 
     def onPointAddedOrRemoved(self, caller, event):
+        self.updateInputOptions()
+
+    def onTargetNameModified(self, caller, event):
         self.updateInputOptions()
 
     def updateInputOptions(self):


### PR DESCRIPTION
This makes it possible to set a target name by clicking on it

![Peek 2025-04-02 20-43](https://github.com/user-attachments/assets/ace2a4ce-fb23-43d8-9d44-bf359fff9aca)

A challenge here was to update the target dropdowns in three different modules: preplanning, transducer tracking, and sonication planning. There is no specific rename event that is invoked by fiducial nodes, so we'd have to watch for arbitrary PointModified events. But PointModified events are continuously invoked as points get dragged and dropped, and updating the input widgets across several modules continuously is ridiculous.

So the solution here was to invoke a custom vtk event when targets are renamed via SlicerOpenLIFU. This actually seemed generally useful for customizing inter-module communication in SlicerOpenLIFU, so I put the event definition into a new OpenLIFULib.events. It could come in handy!

Things to check for the review:
- The updates to the dropdowns in the transducer tracking module are done appropriately
- Optionally, you can build it and try it out. Rename a target, or create a new target and rename it, and then see that
  - the name updates in on the node and in the display
  - the name updates in the targets dropdown in the preplanning module, the TT module, and the sonication planning module