### PR TITLE
Implement module specific guided mode behaviors

### DIFF
--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -317,6 +317,9 @@
      <property name="collapsed">
       <bool>true</bool>
      </property>
+     <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+      <bool>true</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <widget class="QPushButton" name="loadProtocolButton">

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -103,7 +103,13 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUDatabaseLogic()
 
+        # ---- Inject guided mode workflow controls ----
+
+        self.inject_workflow_controls_into_placeholder()
+
         # === Connections and UI setup =======
+
+        self.logic.call_on_db_changed(self.onDatabaseChanged)
 
         self.ui.databaseLoadButton.clicked.connect(self.onLoadDatabaseClicked)
         self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).connect(
@@ -118,10 +124,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
         # Call the routine to update from data parameter node
         self.onDataParameterNodeModified()
-
-        # ---- Inject guided mode workflow controls ----
-
-        self.inject_workflow_controls_into_placeholder()
+        self.updateWorkflowControls()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -131,6 +134,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         """Called each time the user opens this module."""
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
+        self.updateWorkflowControls()
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
@@ -213,6 +217,17 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
     def onParameterNodeModified(self, caller, event) -> None:
         pass
+
+    def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
+        self.updateWorkflowControls()
+
+    def updateWorkflowControls(self):
+        if self.logic.db is None:
+            self.workflow_controls.can_proceed = False
+            self.workflow_controls.status_text = "Connect a database to proceed."
+        else:
+            self.workflow_controls.can_proceed = True
+            self.workflow_controls.status_text = "Database connected, proceed to the next step."
 
 # OpenLIFUDatabaseLogic
 #

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -216,7 +216,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
             self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.onParameterNodeModified)
 
     def onParameterNodeModified(self, caller, event) -> None:
-        pass
+        self.updateWorkflowControls()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
         self.updateWorkflowControls()

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -212,6 +212,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onParameterNodeModified(self, caller, event) -> None:
         self.updateGuidedModeButton()
+        self.logic.workflow.enforceGuidedModeVisibility(self._parameterNode.guided_mode)
 
 #
 # OpenLIFUHomeLogic

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @dataclass
 class AlgorithmInput:
     name : str
+    label : qt.QLabel
     combo_box : qt.QComboBox
     most_recent_selection : Any = None
 
@@ -44,10 +45,10 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
             if input_name not in ["Protocol", "Transducer", "Volume", "Target", "Photoscan"]:
                 raise ValueError("Invalid algorithm input specified.")
             else:
-                self.inputs_dict[input_name] = AlgorithmInput(input_name, qt.QComboBox(self))
+                self.inputs_dict[input_name] = AlgorithmInput(input_name, qt.QLabel(f"{input_name}", self), qt.QComboBox(self))
                 
         for input in self.inputs_dict.values():
-            layout.addRow(f"{input.name}:", input.combo_box)
+            layout.addRow(input.label, input.combo_box)
 
     def add_protocol_to_combobox(self, protocol : SlicerOpenLIFUProtocol) -> None:
         self.inputs_dict["Protocol"].combo_box.addItem("{} (ID: {})".format(protocol.protocol.name,protocol.protocol.id), protocol)
@@ -68,6 +69,22 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
         for input in ["Protocol", "Transducer", "Volume"]:
             if input in self.inputs_dict:
                 self.inputs_dict[input].combo_box.setToolTip(text)
+
+    def enforceGuidedModeVisibility(self, enforced: bool):
+        """Enforce visibility of widgets when in guided mode. This function is
+        defined for this Widget because when guided mode is activated, we want
+        to let the parent widget *choose* which sub-widgets to hide. In this
+        specific case, it is simple, but some widgets may be more picky"""
+
+        # In this case we just want to hide these three combo box widgets
+        for widget_key in ["Protocol", "Transducer", "Volume"]:
+            if widget_key in self.inputs_dict:
+                if enforced:
+                    self.inputs_dict[widget_key].label.hide()
+                    self.inputs_dict[widget_key].combo_box.hide()
+                else:
+                    self.inputs_dict[widget_key].label.show()
+                    self.inputs_dict[widget_key].combo_box.show()
 
     def _clear_input_options(self):
         """Clear out input options, remembering what was most recently selected in order to be able to set that again later"""

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -79,12 +79,8 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
         # In this case we just want to hide these three combo box widgets
         for widget_key in ["Protocol", "Transducer", "Volume"]:
             if widget_key in self.inputs_dict:
-                if enforced:
-                    self.inputs_dict[widget_key].label.hide()
-                    self.inputs_dict[widget_key].combo_box.hide()
-                else:
-                    self.inputs_dict[widget_key].label.show()
-                    self.inputs_dict[widget_key].combo_box.show()
+                self.inputs_dict[widget_key].label.visibility = enforced
+                self.inputs_dict[widget_key].combo_box.visibility = enforced
 
     def _clear_input_options(self):
         """Clear out input options, remembering what was most recently selected in order to be able to set that again later"""

--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -235,6 +235,41 @@ class Workflow:
         for workflow_controls in self.workflow_controls.values():
             workflow_controls.update()
 
+    def enforceGuidedModeVisibility(self, enforced: bool = False):
+
+        # ---- Locate widgets ----
+
+        # First, find all widgets that have the dynamic property set in the .ui
+        # file
+        hide_in_guided_mode_widgets = []
+        for moduleName in self.modules:
+            module = slicer.util.getModule(moduleName)
+            widgetRepresentation = module.widgetRepresentation()
+            all_widgets = slicer.util.findChildren(widgetRepresentation)
+            for widget in all_widgets:
+                hide_in_guided_mode = widget.property("slicer.openlifu.hide-in-guided-mode")
+                # If the widget does not have the specified property,
+                # QWidget.property("property-name") returns QVariant()—an
+                # invalid QVariant equivalent to None in Python.
+                if hide_in_guided_mode is not None:
+                    hide_in_guided_mode_widgets.append(widget)
+
+        # Second, find all widgets that we want to call the function to hide in
+        # guided mode, usually more complex widgets
+        complex_widgets = []
+        # TODO
+            
+        # ---- Hide ----
+
+        for widget in hide_in_guided_mode_widgets:
+            widget.hide() if enforced else widget.show()
+
+        for widget in complex_widgets:
+            widget.enforceGuidedModeVisibility(enforced)
+
+        return
+
+
 class GuidedWorkflowMixin:
     """A mixin class to add guided mode workflow related methods to a ScriptedLoadableModuleWidget"""
 

--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -276,7 +276,3 @@ class GuidedWorkflowMixin:
         self.workflow_controls = home_module_logic.workflow.workflow_controls[self.moduleName]
         replace_widget(self.ui.workflowControlsPlaceholder, self.workflow_controls, self.ui)
 
-    def enforceGuidedModeVisibility(self):
-        raise NotImplementedError("This method is to be implemented in issue #128")
-
-

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -701,7 +701,10 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         new_account_dlg.exec_()
 
     def updateWorkflowControls(self):
-        if self._cur_login_state in [LoginState.NOT_LOGGED_IN, LoginState.UNSUCCESSFUL_LOGIN]:
+        if not self._parameterNode.user_account_mode:
+            self.workflow_controls.can_proceed = True
+            self.workflow_controls.status_text = "User account mode disabled, proceed to the next step."
+        elif self._cur_login_state in [LoginState.NOT_LOGGED_IN, LoginState.UNSUCCESSFUL_LOGIN]:
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "Log in to proceed."
         else:

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -22,6 +22,9 @@
      <property name="default">
       <bool>false</bool>
      </property>
+     <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Closes #128 

## Summary

This PR adds guided mode support to all modules in the Guided mode workflow by first implementing `can_proceed` and `status_text` in a coarse way. The routine is set to make this more fine as we wish.

Then, separately, guided mode hides things in two ways:
1. Static case: The dynamic property `slicer.openlifu.hide-in-guided-mode` can be set in the `.ui` file for anything to be hidden in guided mode.
2. Dynamic case: When more custom logic is required to determine what will be hidden, `enforceGuidedModeVisibility()` needs to be implemented. `Workflow.enforceGuidedModeVisibility()` will then propagate that call.

The visibility logic is centralized in the `Workflow` class. The mixin previously responsible for `enforceGuidedModeVisibility()` was removed.

## For review

Test the complete workflow in guided mode and make sure things you don't like seeing are hidden. **Note, because you will likely be testing this in SlicerOpenLIFU, before turning on Guided Mode, activate user account mode. If you don't activate user account mode, guided mode will say you can skip logging in, but this is not the experience intended in the custom app.**