### PR TITLE
Enable scaling of photoscan-volume transform node

### DIFF
--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -162,10 +162,3 @@ class SlicerOpenLIFUPhotoscan:
         self.model_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
         if self.facial_landmarks_fiducial_node:
             self.facial_landmarks_fiducial_node.GetDisplayNode().SetViewNodeIDs([node.GetID() for node in viewNodes] if viewNodes else ())
-        
-    def set_transform_node(self, transform_node: vtkMRMLTransformNode):
-        
-        self.model_node.SetAndObserveTransformNodeID(transform_node.GetID())
-        
-        if self.facial_landmarks_fiducial_node:
-            self.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(transform_node.GetID())   

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -846,7 +846,6 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
             # For now, disable the approval and initialization button while in manual editing mode
             self.ui.initializeTPRegistration.enabled = False
             self.ui.approveTransducerPhotoscanTransform.enabled = False
-
         else:
             self.ui.ICPPlaceholderLabel_2.text = ""
             self.transducer_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
@@ -895,10 +894,8 @@ class TransducerTrackingWizard(qt.QWizard):
 
         self.setOption(qt.QWizard.NoBackButtonOnStartPage)
         self.setWizardStyle(qt.QWizard.ClassicStyle)
-
         # Connect the currentIdChanged signal
         self.currentIdChanged.connect(self.setPageSpecificNodeDisplaySettings)
-
         # Connect signals for finish and cancel
         self.button(qt.QWizard.FinishButton).clicked.connect(self.onFinish)
         self.button(qt.QWizard.CancelButton).clicked.connect(self.onCancel)
@@ -911,13 +908,13 @@ class TransducerTrackingWizard(qt.QWizard):
             # Display the photoscan. This sets the visibility on the model and fiducial node
             # Reset the view node everytime the photoscan is displayed
             self.photoscan.model_node.GetDisplayNode().SetVisibility(True)
-            self.photoscan.model_node.SetAndObserveTransformNodeID(None)
+            self.photoscan.model_node.SetAndObserveTransformNodeID(None) # Should be viewed in native space
 
             # Disable editing of the fiducial node position
             if self.photoscanMarkupPage.facial_landmarks_fiducial_node:
                 self.photoscanMarkupPage.facial_landmarks_fiducial_node.SetLocked(True)
                 self.photoscanMarkupPage.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(True)
-                self.photoscanMarkupPage.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(None)
+                self.photoscanMarkupPage.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(None) # Should be viewed in native space
 
             # If the user clicks 'Back' from the skin segmentation markup page
             self.skin_mesh_node.GetDisplayNode().SetVisibility(False)
@@ -962,6 +959,7 @@ class TransducerTrackingWizard(qt.QWizard):
             # Display the photoscan and transducer and hide the skin mesh
             self.skin_mesh_node.GetDisplayNode().SetVisibility(False)
             self.skinSegmentationMarkupPage.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(False)
+            self.photoscanMarkupPage.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(False)
             self.photoscan.model_node.GetDisplayNode().SetVisibility(True)
             self.transducer_surface.GetDisplayNode().SetVisibility(True)
         
@@ -982,7 +980,7 @@ class TransducerTrackingWizard(qt.QWizard):
         self._logic.update_volume_facial_landmarks_from_node(volume_or_skin_mesh = self.skin_mesh_node,
             fiducial_node =  self.skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
         
-        # Add the transducer tracking result noes to the scene
+        # Add the transducer tracking result nodes to the slicer scene
         self.photoscanVolumeTrackingPage.scaledTransformNode.HardenTransform() 
         self._logic.add_transducer_tracking_result(
             transform_node=self.photoscanVolumeTrackingPage.scaledTransformNode,
@@ -1050,9 +1048,7 @@ class TransducerTrackingWizard(qt.QWizard):
         photoscan_id = self.photoscan.get_id()
         if self.photoscan.view_node is None:
             self.photoscan.view_node = create_threeD_photoscan_view_node(photoscan_id = photoscan_id)
-        
         self.volume_view_node = get_threeD_transducer_tracking_view_node()
-        
         wizard_view_nodes = [self.photoscan.view_node, self.volume_view_node]
 
         # Set view nodes for the skin mesh, transducer and photoscan

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -377,12 +377,13 @@ class SkinSegmentationMarkupPage(qt.QWizardPage):
             node.GetDisplayNode().SetVisibility(False) 
             # Clear the volume meta data attribute
             node.SetAttribute('OpenLIFUData.volume_id', None) 
-            node.GetDisplayNode().SetColor(0,1,1)
 
         else: # Initialize a new node
             node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode","photoscan-wizard-faciallandmarks")
             node.GetDisplayNode().SetVisibility(False) # Ensure that visibility is turned off
             node.SetMarkupLabelFormat("%N")
+            node.GetDisplayNode().SetColor(0,0,1)
+            node.GetDisplayNode().SetSelectedColor(0,0,1)
             for landmark_name in self.temp_markup_fiducials:
                 node.AddControlPoint(0,0,0,f"Click to Place {landmark_name}")
                 index = list(self.temp_markup_fiducials.keys()).index(landmark_name)
@@ -981,19 +982,21 @@ class TransducerTrackingWizard(qt.QWizard):
             fiducial_node =  self.skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
         
         # Add the transducer tracking result nodes to the slicer scene
-        self.photoscanVolumeTrackingPage.scaledTransformNode.HardenTransform() 
-        self._logic.add_transducer_tracking_result(
-            transform_node=self.photoscanVolumeTrackingPage.scaledTransformNode,
-            transform_type= TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME,
-            approval_status=self.photoscanVolumeTrackingPage.transform_approved,
-            photoscan=self.photoscan,
-            transducer=self.transducer)
-        self._logic.add_transducer_tracking_result(
-            transform_node=self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node,
-            transform_type= TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME,
-            approval_status=self.transducerPhotoscanTrackingPage.transform_approved,
-            photoscan=self.photoscan,
-            transducer=self.transducer)
+        if self.photoscanVolumeTrackingPage.scaledTransformNode:
+            self.photoscanVolumeTrackingPage.scaledTransformNode.HardenTransform() 
+            self._logic.add_transducer_tracking_result(
+                transform_node=self.photoscanVolumeTrackingPage.scaledTransformNode,
+                transform_type= TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME,
+                approval_status=self.photoscanVolumeTrackingPage.transform_approved,
+                photoscan=self.photoscan,
+                transducer=self.transducer)
+        if self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node:
+            self._logic.add_transducer_tracking_result(
+                transform_node=self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node,
+                transform_type= TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME,
+                approval_status=self.transducerPhotoscanTrackingPage.transform_approved,
+                photoscan=self.photoscan,
+                transducer=self.transducer)
 
         self.clearWizardNodes() #remove the wizard-level node
 
@@ -1832,8 +1835,8 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
             # Ensure that visibility is turned off
             volume_facial_landmarks_node.GetDisplayNode().SetVisibility(False)
             volume_facial_landmarks_node.SetMarkupLabelFormat("%N")
-            volume_facial_landmarks_node.GetDisplayNode().SetSelectedColor(0,1,1)
-            volume_facial_landmarks_node.GetDisplayNode().SetColor(0,1,1)
+            volume_facial_landmarks_node.GetDisplayNode().SetSelectedColor(0,0,1)
+            volume_facial_landmarks_node.GetDisplayNode().SetColor(0,0,1)
             # Set the ID of corresponding volume as a node attribute 
             volume_facial_landmarks_node.SetAttribute('OpenLIFUData.volume_id', volume_tracking_fiducial_id)
                 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -594,8 +594,8 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.ui.scalingTransformMRMLSliderWidget.minimum = 0.8
         self.ui.scalingTransformMRMLSliderWidget.maximum = 1.2
         self.ui.scalingTransformMRMLSliderWidget.value = 1
-        self.ui.scalingTransformMRMLSliderWidget.decimals = 2
-        self.ui.scalingTransformMRMLSliderWidget.singleStep = 0.01
+        self.ui.scalingTransformMRMLSliderWidget.decimals = 3
+        self.ui.scalingTransformMRMLSliderWidget.singleStep = 0.002
         self.ui.scalingTransformMRMLSliderWidget.pageStep = 1.0
         self.ui.scalingTransformMRMLSliderWidget.setToolTip(_('Adjust the scale of the photosan mesh."'))
         self.ui.scalingTransformMRMLSliderWidget.connect("valueChanged(double)", self.updateScaledTransformNode)

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -96,7 +96,7 @@
           </sizepolicy>
          </property>
          <property name="contextMenuPolicy">
-          <enum>Qt::PreventContextMenu</enum>
+          <enum>Qt::NoContextMenu</enum>
          </property>
          <property name="nodeSelectorVisible">
           <bool>false</bool>
@@ -194,6 +194,38 @@
             <property name="text">
              <string>Run ICP-based registration fine-tuning</string>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="scalingTransformWidget" native="true">
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="scalingLabel">
+               <property name="text">
+                <string>Scale:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="qMRMLSliderWidget" name="scalingTransformMRMLSliderWidget">
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+               <property name="minimum">
+                <double>-0.800000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1.200000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="quantity">
+                <string notr="true"/>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
@@ -335,6 +367,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -350,6 +387,11 @@
    <class>qSlicerSimpleMarkupsWidget</class>
    <extends>qSlicerWidget</extends>
    <header>qSlicerSimpleMarkupsWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Closes #219 
Closes #220 

- The photoscan-volume registration step now includes a slider that can be used during manual interactive registration to scale the photoscan mesh. Scaling factor range = [0.8,1.2]
- The transform nodes used for tt are local to the wizard and separate to the ones added to the scene at the end. These nodes are cleared when the user cancels the wizard before the end.
- On 'Finish', the transducer tracking results are added to the scene by cloning the wizard-level transform nodes. 
- This PR also includes minor bug fixes to the photoscan and skin-segmentation markup steps 