### PR TITLE
Hide old widget before replacement (#236)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -150,6 +150,7 @@ def replace_widget(old_widget: qt.QWidget, new_widget: qt.QWidget, ui_object=Non
     # deletion is requested, and the deletion must be requested before the attributes are dropped -- once the attributes are dropped
     # there is a possibility of the widgets getting auto-deleted just because there is no remaining reference to them.
     old_widget.deleteLater()
+    old_widget.hide()  # TODO: Find reason for replaced widgets having dangling reference. See https://github.com/OpenwaterHealth/OpenLIFU-app/pull/18
 
     if ui_object is not None:
         for attr_name in ui_attrs_to_delete:


### PR DESCRIPTION
Contributes to #236 

When the widget replacement occurs, there appears to be a residual reference to the widget causing a purple color to remain after the widget is replaced. Hiding it removes this issue, but it is not a permanent fix. See [OpenLIFU-app PR#18](https://github.com/OpenwaterHealth/OpenLIFU-app/pull/18)