### PR TITLE
Revert "Simplify algorithm input widget sub-widget hiding (#232)" (#241)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -79,12 +79,8 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
         # In this case we just want to hide these three combo box widgets
         for widget_key in ["Protocol", "Transducer", "Volume"]:
             if widget_key in self.inputs_dict:
-                if enforced:
-                    self.inputs_dict[widget_key].label.hide()
-                    self.inputs_dict[widget_key].combo_box.hide()
-                else:
-                    self.inputs_dict[widget_key].label.show()
-                    self.inputs_dict[widget_key].combo_box.show()
+                self.inputs_dict[widget_key].label.visible = enforced
+                self.inputs_dict[widget_key].combo_box.visible = enforced
 
     def _clear_input_options(self):
         """Clear out input options, remembering what was most recently selected in order to be able to set that again later"""

--- a/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
+++ b/OpenLIFULib/OpenLIFULib/algorithm_input_widget.py
@@ -79,8 +79,12 @@ class OpenLIFUAlgorithmInputWidget(qt.QWidget):
         # In this case we just want to hide these three combo box widgets
         for widget_key in ["Protocol", "Transducer", "Volume"]:
             if widget_key in self.inputs_dict:
-                self.inputs_dict[widget_key].label.visibility = enforced
-                self.inputs_dict[widget_key].combo_box.visibility = enforced
+                if enforced:
+                    self.inputs_dict[widget_key].label.hide()
+                    self.inputs_dict[widget_key].combo_box.hide()
+                else:
+                    self.inputs_dict[widget_key].label.show()
+                    self.inputs_dict[widget_key].combo_box.show()
 
     def _clear_input_options(self):
         """Clear out input options, remembering what was most recently selected in order to be able to set that again later"""


### PR DESCRIPTION
Closes #241

This reverts commit 5c7c514c0d8e1d60c4840c210d086d7c1fddc059.

Commit 5c7c514c0d8e1d60c4840c210d086d7c1fddc059 introduced the following error at runtime:

```python
AttributeError: 'visibility' does not exist on QLabel and creating new attributes on C++ objects is not allowed
```

This is caused by replacing .hide() / .show() calls with assignment to a non-existent .visibility attribute on Qt widgets. Since these are C++-backed objects, arbitrary attribute creation is not allowed.