### PR TITLE
Fix bugs in transducer tracking wizard

### DIFF
--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -152,7 +152,6 @@ class SlicerOpenLIFUPhotoscan:
         
         # Ensure that visibility is turned off
         self.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(False)
-        self.facial_landmarks_fiducial_node.SetMaximumNumberOfControlPoints(3)
         self.facial_landmarks_fiducial_node.SetMarkupLabelFormat("%N")
 
         return self.facial_landmarks_fiducial_node

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -485,6 +485,9 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.updateTransformApprovalStatusLabel()
         self.setupTransformNode()
 
+        # Reset scaling transform node
+        self.ui.scalingTransformMRMLSliderWidget.value = 1
+
         # Enable approval and registration fine-tuning buttons
         self.ui.runPhotoscanVolumeRegistration.enabled = True
         self.ui.approvePhotoscanVolumeTransform.enabled = True
@@ -628,6 +631,7 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
             target = self.wizard().target)
         self.updateTransformApprovalStatusLabel()
         self.setupTransformNode()
+        self.ui.initializeTPRegistration.setText("Re-initialize transducer-photoscan transform")
 
         # Enable approval and registration fine-tuning buttons
         self.ui.runTransducerPhotoscanRegistration.enabled = True


### PR DESCRIPTION
Closes #253 
Closes #243 

- When re-initializing the photoscan-volume node, the scaling factor should also get reset to 1.
- After clicking 'Initialize ... transform', the button text should change to "Re-initialize ...transform"
- In the facial landmakrs markup pages (photoscan and skin segmntation), if a control point is deleted (this is currently possible by right-clicking a control point in the 3D view or pressing the delete button on your keyboard), then the deletion is blocked. After the fix in this PR, the order of the control points in the markups widget list should not change. When a point is deleted, the wizard forcefully adds the control point back at the end of the list. I now include a check which enforces a specific order of control points.