### PR TITLE
Show login state in all modules

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -661,9 +661,12 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUDataLogic()
 
-        # User account banner widget replacement
+        # User account banner widget replacement. Note: the visibility is
+        # initialized to false because this widget will *always* exist before
+        # the login module parameter node.
         self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+        self.user_account_banner.visible = False
 
         # Manual object loading UI and the loaded objects view
         self.loadedObjectsItemModel = qt.QStandardItemModel()

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -43,8 +43,11 @@ from OpenLIFULib.util import (
     display_errors,
     create_noneditable_QStandardItem,
     ensure_list,
+    replace_widget,
     BusyCursor,
 )
+
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 
 from OpenLIFULib.virtual_fit_results import (
     clear_virtual_fit_results,
@@ -657,6 +660,10 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         # Create logic class. Logic implements all computations that should be possible to run
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUDataLogic()
+
+        # User account banner widget replacement
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
 
         # Manual object loading UI and the loaded objects view
         self.loadedObjectsItemModel = qt.QStandardItemModel()

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -12,6 +12,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_13">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="configureProtocolsPushButtonFrame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -5,7 +5,6 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFURun,
     SlicerOpenLIFUSolutionAnalysis,
-    SlicerOpenLIFUUser,
 )
 from OpenLIFULib.transducer import SlicerOpenLIFUTransducer
 from OpenLIFULib.photoscan import SlicerOpenLIFUPhotoscan
@@ -42,7 +41,6 @@ __all__ = [
     "SlicerOpenLIFURun",
     "SlicerOpenLIFUSolutionAnalysis",
     "SlicerOpenLIFUPhotoscan",
-    "SlicerOpenLIFUUser",
     "get_cur_db",
     "get_openlifu_database_parameter_node",
     "get_openlifu_data_parameter_node",

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -93,13 +93,6 @@ class SlicerOpenLIFUPhotoscanWrapper:
     def __init__(self, photoscan: "Optional[openlifu.Photoscan]" = None):
         self.photoscan = photoscan
 
-# For the same reason we have a thin wrapper around openlifu.User
-class SlicerOpenLIFUUser:
-    """Ultrathin wrapper of openlifu.User. This exists so that users can have parameter node
-    support while we still do lazy-loading of openlifu."""
-    def __init__(self, user: "Optional[openlifu.db.User]" = None):
-        self.user = user
-
 def SlicerOpenLIFUSerializerBaseMaker(
         serialized_type:type,
         default_args:Optional[list[Any]] = None,
@@ -282,25 +275,6 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         """
         json_string = parameterNode.GetParameter(name)    
         return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().photoscan.Photoscan.from_json(json_string))
-
-@parameterNodeSerializer
-class OpenLIFUUserSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUUser)):
-    def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value: SlicerOpenLIFUUser) -> None:
-        """
-        Writes the value to the parameterNode under the given name.
-        """
-        parameterNode.SetParameter(
-            name,
-            value.user.to_json(compact=True)
-        )
-
-    def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUUser:
-        """
-        Reads and returns the value with the given name from the parameterNode.
-        """
-        json_string = parameterNode.GetParameter(name)    
-        return SlicerOpenLIFUUser(openlifu_lz().db.User.from_json(json_string))
-
 
 @parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -42,26 +42,19 @@ class UserAccountBanner(qt.QWidget):
 
         layout = qt.QHBoxLayout(self)
 
-        self.active_user_label = qt.QLabel()
-        self.active_user_label.setAlignment(qt.Qt.AlignCenter)
-        font = self.active_user_label.font()
-        font.setPointSize(16)
-        self.active_user_label.setFont(font)
-        layout.addWidget(self.active_user_label)
+        self.active_user_label = qt.QLabel("Not signed in")
+        self.active_user_label.setAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
+        self.active_user_label.setFont(qt.QFont("", 14))
+        layout.addWidget(self.active_user_label, 1)  # stretch=1 as positional argument
 
         self.go_to_login_button = qt.QPushButton("👤")
-        self.go_to_login_button.setFixedSize(30, 30)
-        self.go_to_login_button.clicked.connect(lambda : slicer.util.selectModule("OpenLIFULogin"))
+        self.go_to_login_button.setToolTip("Switch user")
+        self.go_to_login_button.setFixedSize(28, 28)
+        self.go_to_login_button.clicked.connect(lambda: slicer.util.selectModule("OpenLIFULogin"))
         layout.addWidget(self.go_to_login_button)
-
-        # Add connection to change the label when a new account is logged in
-
-        get_openlifu_login_logic().call_on_active_user_changed(self.on_active_user_changed)
-
-
     
-    def on_active_user_changed(self, new_active_user: Optional["openlifu.db.User"]):
-        if new_active_user is None:
-            self.active_user_label.text = ""
+    def change_active_user(self, new_active_user: Optional["openlifu.db.User"]):
+        if new_active_user is None or new_active_user.id == "anonymous":
+            self.active_user_label.setText("Not signed in")
         else:
-            self.active_user_label.text = f"{new_active_user.name} ({new_active_user.id})"
+            self.active_user_label.setText(f"Signed in as {new_active_user.id}")

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -12,7 +12,7 @@ def get_current_user() -> "Optional[openlifu.db.User]":
     """Get the active openlifu user. If no user is logged in or user account
     mode is off, a default user is returned, with the intention of being the most
     restricted"""
-    return get_openlifu_login_logic().active_user.user
+    return get_openlifu_login_logic().active_user
 
 def get_user_account_mode_state() -> bool:
     """Get user account mode state from the OpenLIFU Login module's parameter node"""

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -1,5 +1,8 @@
 from typing import Optional, TYPE_CHECKING
 
+import qt
+import slicer
+
 from OpenLIFULib.util import (
         get_openlifu_login_parameter_node,
         get_openlifu_login_logic,
@@ -21,3 +24,44 @@ def get_user_account_mode_state() -> bool:
 def set_user_account_mode_state(new_user_account_mode_state: bool):
     """Set user account mode state in OpenLIFU Login module's parameter node"""
     get_openlifu_login_parameter_node().user_account_mode = new_user_account_mode_state
+
+class UserAccountBanner(qt.QWidget):
+    """ This is a lightweight widget that shows the current user account and
+    allows jumping to the login module widget. """
+
+    def __init__(
+            self,
+            parent:qt.QWidget,
+        ):
+        """User account shortcut QWidget
+
+        Args:
+            parent: Parent QWidget
+        """
+        super().__init__(parent)
+
+        layout = qt.QHBoxLayout(self)
+
+        self.active_user_label = qt.QLabel()
+        self.active_user_label.setAlignment(qt.Qt.AlignCenter)
+        font = self.active_user_label.font()
+        font.setPointSize(16)
+        self.active_user_label.setFont(font)
+        layout.addWidget(self.active_user_label)
+
+        self.go_to_login_button = qt.QPushButton("👤")
+        self.go_to_login_button.setFixedSize(30, 30)
+        self.go_to_login_button.clicked.connect(lambda : slicer.util.selectModule("OpenLIFULogin"))
+        layout.addWidget(self.go_to_login_button)
+
+        # Add connection to change the label when a new account is logged in
+
+        get_openlifu_login_logic().call_on_active_user_changed(self.on_active_user_changed)
+
+
+    
+    def on_active_user_changed(self, new_active_user: Optional["openlifu.db.User"]):
+        if new_active_user is None:
+            self.active_user_label.text = ""
+        else:
+            self.active_user_label.text = f"{new_active_user.name} ({new_active_user.id})"

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -833,6 +833,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self.updateUserAccountModeButton()
         self.updateAccountManagementButtons()
         self.enforceUserPermissions()
+        for widget in self._user_account_banners:
+            widget.visible = self._parameterNode.user_account_mode
 
     def enforceUserPermissions(self) -> None:
         

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -132,9 +132,12 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         # see https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/120
         slicer.util.getModule("OpenLIFUData").widgetRepresentation()
 
-        # User account banner widget replacement
+        # User account banner widget replacement. Note: the visibility is
+        # initialized to false because this widget will *always* exist before
+        # the login module parameter node.
         self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+        self.user_account_banner.visible = False
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -39,6 +39,7 @@ from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 
 if TYPE_CHECKING:
     from OpenLIFUData.OpenLIFUData import OpenLIFUDataLogic
@@ -130,6 +131,10 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         # Prevents possible creation of two OpenLIFUData widgets
         # see https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/120
         slicer.util.getModule("OpenLIFUData").widgetRepresentation()
+
+        # User account banner widget replacement
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -6,17 +6,30 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>410</height>
+    <width>387</width>
+    <height>592</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="ctkCollapsibleButton" name="targetsCollapsible" native="true">
-     <property name="text" stdset="0">
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_7">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="targetsCollapsible">
+     <property name="text">
       <string>Targets</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_5">

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -26,6 +26,7 @@ from OpenLIFULib import (
     SlicerOpenLIFUProtocol,
 )
 
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 from OpenLIFULib.util import (
     display_errors,
     replace_widget,
@@ -217,6 +218,9 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.logic = OpenLIFUProtocolConfigLogic()
 
         # === Instantiation of Placeholder Widgets ====
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+
         self.pulse_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().bf.Pulse, parent=self.ui.pulseDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Pulse")
         replace_widget(self.ui.pulseDefinitionWidgetPlaceholder, self.pulse_definition_widget, self.ui)
 

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -218,8 +218,13 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.logic = OpenLIFUProtocolConfigLogic()
 
         # === Instantiation of Placeholder Widgets ====
+
+        # User account banner widget replacement. Note: the visibility is
+        # initialized to false because this widget will *always* exist before
+        # the login module parameter node.
         self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+        self.user_account_banner.visible = False
 
         self.pulse_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().bf.Pulse, parent=self.ui.pulseDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Pulse")
         replace_widget(self.ui.pulseDefinitionWidgetPlaceholder, self.pulse_definition_widget, self.ui)

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -7,10 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>669</width>
-    <height>1262</height>
+    <height>1318</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="protocolConfigLayout">
+   <item>
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QFrame" name="returnToSubjectSessionManagementPushButtonFrame">
      <property name="frameShape">

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -21,8 +21,9 @@ from OpenLIFULib import (get_openlifu_data_parameter_node,
                          SlicerOpenLIFURun,
 )
 
-from OpenLIFULib.util import display_errors
+from OpenLIFULib.util import display_errors, replace_widget
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -206,6 +207,10 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Create logic class. Logic implements all computations that should be possible to run
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUSonicationControlLogic()
+
+        # User account banner widget replacement
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -208,9 +208,12 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         # in batch mode, without a graphical user interface.
         self.logic = OpenLIFUSonicationControlLogic()
 
-        # User account banner widget replacement
+        # User account banner widget replacement. Note: the visibility is
+        # initialized to false because this widget will *always* exist before
+        # the login module parameter node.
         self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+        self.user_account_banner.visible = False
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -7,10 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>450</height>
+    <height>502</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QPushButton" name="reinitializeLIFUInterfacePushButton">
      <property name="sizePolicy">

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -27,6 +27,7 @@ from OpenLIFULib import (
 from OpenLIFULib.util import replace_widget, create_noneditable_QStandardItem, get_openlifu_data_parameter_node
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 
 if TYPE_CHECKING:
     import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
@@ -119,6 +120,10 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.globalAnalysisTableModel = qt.QStandardItemModel() # analysis metrics that are for the whole solution, i.e. over all focus points
         self.ui.focusAnalysisTableView.setModel(self.focusAnalysisTableModel)
         self.ui.globalAnalysisTableView.setModel(self.globalAnalysisTableModel)
+
+        # User account banner widget replacement
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -6,11 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>258</width>
-    <height>520</height>
+    <width>358</width>
+    <height>640</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_10">
+   <item>
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_11">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QWidget" name="algorithmInputWidgetPlaceholder" native="true">
      <layout class="QVBoxLayout" name="verticalLayout">
@@ -39,11 +52,11 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="analysisCollapsible" native="true">
-     <property name="text" stdset="0">
+    <widget class="ctkCollapsibleButton" name="analysisCollapsible">
+     <property name="text">
       <string>Solution analysis</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -55,6 +55,7 @@ from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.skinseg import generate_skin_mesh
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
+from OpenLIFULib.user_account_mode_util import UserAccountBanner
 
 if TYPE_CHECKING:
     import openlifu
@@ -1151,6 +1152,10 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # Prevents possible creation of two OpenLIFUData widgets
         # see https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/120
         slicer.util.getModule("OpenLIFUData").widgetRepresentation()
+
+        # User account banner widget replacement
+        self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
+        replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1153,9 +1153,12 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         # see https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/120
         slicer.util.getModule("OpenLIFUData").widgetRepresentation()
 
-        # User account banner widget replacement
+        # User account banner widget replacement. Note: the visibility is
+        # initialized to false because this widget will *always* exist before
+        # the login module parameter node.
         self.user_account_banner = UserAccountBanner(parent=self.ui.userAccountBannerPlaceholder.parentWidget())
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
+        self.user_account_banner.visible = False
 
         # ---- Inject guided mode workflow controls ----
 

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -12,6 +12,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QWidget" name="userAccountBannerPlaceholder" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QLabel" name="userAccountBannerPlaceholderLabel">
+        <property name="text">
+         <string>Placeholder for a UserAccountBanner widget</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="permissionsWidget" native="true">
      <property name="slicer.openlifu.allowed-roles" stdset="0">
       <stringlist>


### PR DESCRIPTION
This PR adds a small banner to the top of all modules (those coming after the login module in the guided mode workflow) that has text and a small icon to go to the login module. It works through adding the placeholder to the top of the ui and replacing when `setup()` is invoked in each module.

Note that the convention for update propagation **is the same** as for permissions. That is, updates happen from within the login module by looping over external modules. This was done for consistency's sake with permissions enforcement. 

## For review:

Do a random walk through the app, with higher transition probability toward login-related entities, and see if app behavior defies your expectations. This review is mostly about whether we agree with the way the banner looks.  