### PR TITLE
Hide protocol to/from file buttons in guided mode (#251)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/guided_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/guided_mode_util.py
@@ -242,7 +242,7 @@ class Workflow:
 
         hide_in_guided_mode_widgets = []  # widgets with dynamic property
         call_enforce_in_guided_mode_widgets = []  # widgets with their own defined enforceGuidedModeVisibility()
-        for moduleName in self.modules:
+        for moduleName in self.modules + ["OpenLIFUProtocolConfig"]:
             module = slicer.util.getModule(moduleName)
             widgetRepresentation = module.widgetRepresentation()
             all_widgets = slicer.util.findChildren(widgetRepresentation)

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Load Protocol From File</string>
        </property>
+       <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -338,6 +341,9 @@ OpenLIFUVirtualFitOptionsDefinitionWidget</string>
          <widget class="QPushButton" name="protocolFileSaveButton">
           <property name="text">
            <string>Save Protocol To File</string>
+          </property>
+          <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Closes #251 

This commit required adding "OpenLIFUProtocolConfig" to the list of modules looped over within the guided_mode_util, even when OpenLIFUProtocolConfig is not part of the guided mode workflow.  This code shouldn't need review other than looking at the code.