### PR TITLE
Update virtual fit approvals workflow

### DIFF
--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -502,7 +502,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.logic.toggle_virtual_fit_approval(target_id=target_id, session_id=session_id)
         self.updateApproveButton()
         self.updateApprovalStatusLabel()
-        self.updateWorkflowControls()  # TODO: workflow controls should check for approval too!
+        self.updateWorkflowControls()  
 
     def updateApprovalStatusLabel(self):
         approved_target_ids = self.logic.get_approved_target_ids()
@@ -527,9 +527,12 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         elif not list(get_virtual_fit_result_nodes(session_id=session_id)):
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "Run a virtual fit result for a target to proceed."
+        elif not self.logic.get_approved_target_ids():
+            self.workflow_controls.can_proceed = False
+            self.workflow_controls.status_text = "A virtual fit result needs to be approved for a target to proceed."
         else:
             self.workflow_controls.can_proceed = True
-            self.workflow_controls.status_text = "Virtual fit result detected, proceed to the next step."
+            self.workflow_controls.status_text = "Approved virtual fit result detected, proceed to the next step."
 
     def onVirtualfitClicked(self):
         activeData = self.algorithm_input_widget.get_current_data()


### PR DESCRIPTION
Closes #257 

- In guided mode, you should not be able to proceed to transducer tracking without an approved VF result.
- If a target is removed, approval is revoked (if any) and the associated VF results are cleared.
- If a target is modified (point modified or added/removed), approval is revoked (if any) and the user is asked to confirm deletion of VF results.
- In guided mode, if the virtual fit results are cleared, the workflow status updates accordingly. 

`OnNodeRemoved` is triggered when you unload a session. Since the `loaded_session` gets set to `None` before the associated target node is cleared, we don't get prompted about approval being revoked (if any) on the target node when a session is unloaded. 
However, we want to prompt the user that VF results are getting cleared (regardless of approval status). This prompt will therefore pop up when a session is unloaded, and also when a session is loaded (because OnPointModified and PointAddedRemoved are triggered when you load a session). To address this, I have added a flag to the Data module to indicate when  session loading/unloading is in progress. Approval revokation and VF result clearing only gets triggered when nodes are modified/cleared outside of  session loading/clearing. 