### PR TITLE
Handle meshroom logs and errors

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-openlifu==0.2.0
+openlifu==0.2.1
 bcrypt


### PR DESCRIPTION
Closes #277 

Adds the new Meshroom logger (just a logger called "Meshroom") to the slicer logging world. (This required adding a mode to the log handler that doesn't show any dialogs, because Meshroom emits log calls from a separate thread and Qt was very unhappy with me trying to parent an error dialog from one thread to a slicer main window in another thread.)

Also catches a CalledProcessError and gives an error dialog that essentally says "hey this error isn't slicer's fault, it's meshroom!"

For review: Please just eyeball the code that this won't break anything important, and since it touches the log handler which is involved in a lot of stuff maybe just build the application and make sure nothing is obviously broken. Optionally try photoscan generation, but you don't have to. Thanks!
