### PR TITLE
Refine transducer tracking approvals workflow

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1420,7 +1420,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     def save_session(self) -> None:
         """Save the current session to the openlifu database.
         This first writes the transducer and target information into the in-memory openlifu Session object,
-        and then it writes that Session object to the database.
+        and then it writes that Session object and any affiliated Photoscan objects to the database.
         """
 
         if get_cur_db() is None:
@@ -1433,6 +1433,10 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
         OnConflictOpts : "openlifu.db.database.OnConflictOpts" = openlifu_lz().db.database.OnConflictOpts
         get_cur_db().write_session(self._subjects[session_openlifu.subject_id],session_openlifu,on_conflict=OnConflictOpts.OVERWRITE)
+
+        # Write any affiliated photoscan objects
+        for photoscan in self.getParameterNode().loaded_session.get_affiliated_photoscans():
+            get_cur_db().write_photoscan(session_openlifu.subject_id, session_openlifu.id, photoscan, on_conflict=OnConflictOpts.OVERWRITE)
 
     def update_underlying_openlifu_session(self) -> "openlifu.db.Session":
         """Update the underlying openlifu session of the currently loaded session, if there is one.

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -968,7 +968,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         if loaded_session is not None and session_id == loaded_session.get_session_id():
             self.logic.update_photoscans_affiliated_with_loaded_session()
             # Update the transducer tracking drop down to reflect new photoscans 
-            transducer_tracking_widget = slicer.util.getModule('OpenLIFUTransducerTracker').widgetRepresentation()
+            transducer_tracking_widget = slicer.modules.OpenLIFUTransducerTrackerWidget
             transducer_tracking_widget.self().algorithm_input_widget.update()
 
     def addSessionsToSubjectSessionSelector(self, index : qt.QModelIndex, session_name: str = None, session_id: str = None) -> None:
@@ -1747,6 +1747,10 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         )
 
         for (transducer_to_volume_node, photoscan_to_volume_node) in newly_added_tt_result_nodes:
+            transducer_tracking_widget = slicer.modules.OpenLIFUTransducerTrackerWidget
+            transducer_tracking_widget.watchTransducerTrackingNode(transducer_to_volume_node)
+            transducer_tracking_widget.watchTransducerTrackingNode(photoscan_to_volume_node)
+
             newly_loaded_transducer.move_node_into_transducer_sh_folder(transducer_to_volume_node)
             newly_loaded_transducer.move_node_into_transducer_sh_folder(photoscan_to_volume_node)
 

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -218,6 +218,11 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.updateGuidedModeButton()
         self.logic.workflow.enforceGuidedModeVisibility(self._parameterNode.guided_mode)
 
+        # Update whether transducer tracking is enabled/disabled based on guided_mode state
+        transducer_tracking_widget = slicer.util.getModule('OpenLIFUTransducerTracker').widgetRepresentation()
+        transducer_tracking_widget.self().checkCanRunTracking()
+
+
 #
 # OpenLIFUHomeLogic
 #

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -137,8 +137,8 @@ class SlicerOpenLIFUPhotoscan:
     def get_id(self) -> 'str':
         return self.photoscan.photoscan.id
     
-    def toggle_approval(self) -> None:
-        self.photoscan.photoscan.photoscan_approved = not self.photoscan.photoscan.photoscan_approved 
+    def set_approval(self, approval_state: bool) -> None:
+        self.photoscan.photoscan.photoscan_approved = approval_state
                      
     def initialize_facial_landmarks_from_node(self, fiducial_node: vtkMRMLMarkupsFiducialNode):
         """ Clones the provided vtkMRMLMarkupsFiducialNode and assigns the clone to the photoscan attribute. The input fiducial node

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -159,13 +159,20 @@ class SlicerOpenLIFUSession:
         
         self.affiliated_photocollections = affiliated_photocollections
 
-
     def set_affiliated_photoscans(self, affiliated_photoscans : Dict[str, "openlifu.nav.photoscan.Photoscan"]):
         
         # Wrap the list of affiliated openlifu photoscans using the SlicerOpenLIFUPhotoscanWrapper for 
         # compatability with the SlicerOpenLIFUSession parameter pack. 
         wrapped_openlifu_photoscans = {photoscan.id:SlicerOpenLIFUPhotoscanWrapper(photoscan) for photoscan in affiliated_photoscans.values()}
         self.affiliated_photoscans = wrapped_openlifu_photoscans
+
+    def update_affiliated_photoscan(self, photoscan: "openlifu.nav.photoscan.Photoscan"):
+        """Update the openlifu photoscan object in the dictionary of photoscans affiliated with this session"""
+        if not self.affiliated_photoscans:
+            raise RuntimeError("No affiliated photoscans found. Call set_affiliated_photoscans first.") # This shouldn't happen 
+        if photoscan.id not in self.affiliated_photoscans.keys():
+            raise RuntimeError("The specified photoscan is not affiliated with this session") 
+        self.affiliated_photoscans[photoscan.id] = SlicerOpenLIFUPhotoscanWrapper(photoscan)
 
     def update_underlying_openlifu_session(self, targets : List[vtkMRMLMarkupsFiducialNode]) -> "openlifu.db.Session":
         """Update the underlying openlifu session and the list of target nodes that are considered to be affiliated with this session.

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -344,6 +344,21 @@ def set_transducer_tracking_approval_for_node(approval_state: bool, transform_no
         raise ValueError("The specified transform node is a not a transducer tracking result node")
     transform_node.SetAttribute("TT:approvalStatus", "1" if approval_state else "0")
 
+def set_transducer_tracking_approval_for_photoscan(approval_state: bool, photoscan_id: str, session_id: str):
+    """Set approval state on both the transform nodes affiliated with the given photoscan.
+    
+    Args:
+    approval_state: new approval state to apply
+    photoscan_id: photoscan ID for which to apply new approval state to the transducer tracking result nodes
+    session_id: session ID to help identify the correct transducer tracking result ndoes, or None to work with
+    only transducer tracking result nodes that do not have an affiliated session"""
+
+    pv_node = get_transducer_tracking_result(photoscan_id, TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME, session_id) 
+    set_transducer_tracking_approval_for_node(approval_state, pv_node)
+   
+    tv_node = get_transducer_tracking_result(photoscan_id, TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME, session_id) 
+    set_transducer_tracking_approval_for_node(approval_state, tv_node)
+
 def get_approval_from_transducer_tracking_result_node(node : vtkMRMLTransformNode) -> bool:
     if node.GetAttribute("TT:approvalStatus") is None:
         raise RuntimeError("Node does not have a transducer tracking approval status.")

--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -186,7 +186,7 @@ def replace_widget(old_widget: qt.QWidget, new_widget: qt.QWidget, ui_object=Non
     new_widget.show()
     layout.insertWidget(index, new_widget)
 
-def clone_node(node_to_clone: vtkMRMLNode) -> vtkMRMLNode:
+def get_cloned_node(node_to_clone: vtkMRMLNode) -> vtkMRMLNode:
 
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
     itemIDToClone = shNode.GetItemByDataNode(node_to_clone)

--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -3,6 +3,7 @@ from typing_extensions import get_type_hints as get_type_hints_ext # for <3.10 c
 import logging
 import qt
 import slicer
+from slicer import vtkMRMLNode
 if TYPE_CHECKING:
     from openlifu.db import Database
     from OpenLIFUDatabase.OpenLIFUDatabase import OpenLIFUDatabaseParameterNode
@@ -184,3 +185,12 @@ def replace_widget(old_widget: qt.QWidget, new_widget: qt.QWidget, ui_object=Non
     new_widget.setParent(parent)
     new_widget.show()
     layout.insertWidget(index, new_widget)
+
+def clone_node(node_to_clone: vtkMRMLNode) -> vtkMRMLNode:
+
+    shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+    itemIDToClone = shNode.GetItemByDataNode(node_to_clone)
+    clonedItemID = slicer.modules.subjecthierarchy.logic().CloneSubjectHierarchyItem(shNode, itemIDToClone)
+    cloned_node = shNode.GetItemDataNode(clonedItemID)
+
+    return cloned_node

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -3,6 +3,7 @@ from slicer import vtkMRMLTransformNode
 from typing import Optional, Iterable, List, Tuple, Dict, TYPE_CHECKING, Union
 from OpenLIFULib.transform_conversion import transducer_transform_node_to_openlifu, transducer_transform_node_from_openlifu
 from OpenLIFULib.lazyimport import openlifu_lz
+from OpenLIFULib.util import get_cloned_node
 
 if TYPE_CHECKING:
     from openlifu.geo import ArrayTransform
@@ -69,10 +70,7 @@ def add_virtual_fit_result(
         raise ValueError("Only the rank 1 (best) virtual fit result can be approved")
 
     if clone_node:
-        shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
-        itemIDToClone = shNode.GetItemByDataNode(transform_node)
-        clonedItemID = slicer.modules.subjecthierarchy.logic().CloneSubjectHierarchyItem(shNode, itemIDToClone)
-        virtual_fit_result : vtkMRMLTransformNode = shNode.GetItemDataNode(clonedItemID)
+        virtual_fit_result : vtkMRMLTransformNode = get_cloned_node(transform_node)
     else:
         virtual_fit_result = transform_node
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1515,6 +1515,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.wizard.exec_()
         self.wizard.deleteLater() # Needed to avoid memory leaks when slicer is exited. 
 
+        self.updateApprovalStatusLabel()
         self.updateWorkflowControls()
 
     def watchTransducerTrackingNode(self, transducer_tracking_transform_node: vtkMRMLTransformNode):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1585,15 +1585,24 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         session = get_openlifu_data_parameter_node().loaded_session
         session_id = None if session is None else session.get_session_id()
 
+        current_data = self.algorithm_input_widget.get_current_data()
+        selected_photoscan_openlifu = current_data['Photoscan']
+
         if session is None:
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "If you are seeing this, guided mode is being run out of order! Load a session to proceed."
-        elif not get_photoscan_ids_with_results(session_id=session_id):
+        elif not selected_photoscan_openlifu:
             self.workflow_controls.can_proceed = False
-            self.workflow_controls.status_text = "Run transducer tracking to proceed."
+            self.workflow_controls.status_text = "Select a photoscan to proceed."
+        elif not selected_photoscan_openlifu.photoscan_approved:
+            self.workflow_controls.can_proceed = False
+            self.workflow_controls.status_text = "Approve a photoscan to proceed."
+        elif not self.logic.get_approved_photoscan_ids():
+            self.workflow_controls.can_proceed = False
+            self.workflow_controls.status_text = "Run transducer tracking and approve the result to proceed."
         else:
             self.workflow_controls.can_proceed = True
-            self.workflow_controls.status_text = "Transducer tracking result detected, proceed to the next step."
+            self.workflow_controls.status_text = "Approved transducer tracking result detected, proceed to the next step."
 
 #
 # OpenLIFUTransducerTrackerLogic

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -519,6 +519,9 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         # Update the wizard page
         self.updateTransformApprovalStatusLabel()
         self.updateTransformApproveButton()
+
+        # Emit signal to update the enable/disable state of 'Next' button. 
+        self.completeChanged()
     
     def onInitializeRegistrationClicked(self):
         """ This function is called when the user clicks 'Next'."""
@@ -600,7 +603,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
-        return not self.runningRegistration
+        return not self.runningRegistration and self.transform_approved
 
 class TransducerPhotoscanTrackingPage(qt.QWizardPage):
     def __init__(self, parent = None):
@@ -679,6 +682,9 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
         # Update the wizard page
         self.updateTransformApprovalStatusLabel()
         self.updateTransformApproveButton()
+
+        # Emit signal to update the enable/disable state of 'Finish' button. 
+        self.completeChanged()
     
     def onInitializeRegistrationClicked(self):
 
@@ -729,7 +735,7 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
-        return not self.runningRegistration
+        return not self.runningRegistration and self.transform_approved
 
 class TransducerTrackingWizard(qt.QWizard):
     def __init__(self, photoscan: SlicerOpenLIFUPhotoscan, 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1642,18 +1642,22 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         current_data = self.algorithm_input_widget.get_current_data()
         selected_photoscan_openlifu = current_data['Photoscan']
 
+        photoscans_with_approved_tt = set(self.logic.get_photoscan_ids_with_approved_tt_results())
+        approved_photoscans = set(self.logic.get_photoscan_ids_with_approval())
+        approved_photoscan_with_approved_tt_exists = bool(approved_photoscans.intersection(photoscans_with_approved_tt))
+
         if session is None:
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "If you are seeing this, guided mode is being run out of order! Load a session to proceed."
         elif not selected_photoscan_openlifu:
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "Select a photoscan to proceed."
-        elif not selected_photoscan_openlifu.photoscan_approved:
+        elif not approved_photoscans:
             self.workflow_controls.can_proceed = False
             self.workflow_controls.status_text = "Approve a photoscan to proceed."
-        elif not self.logic.get_photoscan_ids_with_approved_tt_results():
+        elif not approved_photoscan_with_approved_tt_exists:
             self.workflow_controls.can_proceed = False
-            self.workflow_controls.status_text = "Run transducer tracking and approve the result to proceed."
+            self.workflow_controls.status_text = "Run transducer tracking for an approved photoscan and approve the result to proceed."
         else:
             self.workflow_controls.can_proceed = True
             self.workflow_controls.status_text = "Approved transducer tracking result detected, proceed to the next step."

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -135,6 +135,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="approvalWarningLabel">
+        <property name="text">
+         <string>(approval warnings here)</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Partially addresses #259 
Closes #258 

Photoscan:
- [x] Toggling approval updates the application state appropriately
- [x] Saving a session saves the approval state
- [x] Loading a session loads the approval state
- [x] (There is nothing that should cause a photoscan approval to be revoked, right? There is no way to mutate photoscans in the scene) - No 
- [x] In guided mode, It is not possible to proceed with transducer tracking with an unapproved photoscan.. It should be clear to the user why the can't proceed in this situation. When not in guided mode, display a warning is the photoscan is not approved.
- [x] Revoking approval on photoscan revokes approval on the corresponding transducer tracking result (if previously computed)

Transducer tracking
- [x] - Currently, unless you approve the transform during the wizard workflow, you cannot go back and approve a previously computed transform. A user should be able to click through wizard and see previous tt results and toggle approval. If a fiducial is moved, tt results are cleared and unapproved (wizard-level). **This does not work well when loading a session with a tt result and will be addressed as part of: https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/289.**
- [x] - Each step of the wizard is blocking - cannot proceed to transducer-volume tracking or click 'Finish' without approving the transform.
- [x] - In guided mode - check that the selected target has an approved VF result. Since in the case with multiple targets, you technically would be able to proceed as long as one of the targets is approved. In non-guided mode, provide a warning if VF is not approved for the selected target or the selected photoscan is not approved.
- [x] Toggling approval updates the application state appropriately (tt)
- [x] Saving a session saves the approval state (tt)
- [x] Loading a session loads the approval state (tt)
- [ ] Making changes in the scene to the transducer tracking transforms or the transducer transform (because it is what's used in the sonication planner), or the sonication target causes the transducer tracking approvals to be revoked. **Currently transducer tracking approval is revoked if the tracking transforms are modfied. Larger changes are needed to revoke approval when the target or transducer transform are modified. This is because the tracking results currently don't keep track of the affiliated target. I will address this last part in a separate PR.** 
- [x] Without fully approved transducer tracking results, the workflow doesn't allow proceeding from the transducer tracking module (so that would be something that is enforced when guided mode is enabled)