### PR TITLE
Update workflow for revoking transducer tracking approval

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1835,7 +1835,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             tt_results_openlifu = session_openlifu.transducer_tracking_results,
             session_id = session_openlifu.id,
             transducer = newly_loaded_transducer.transducer.transducer,
-            replace=True, # If there happen to already be some virtual fit result nodes that clash, loading a session will silently overwrite them.
+            replace=True, # If there happen to already be some transducer tracking result nodes that clash, loading a session will silently overwrite them.
         )
 
         for (transducer_to_volume_node, photoscan_to_volume_node) in newly_added_tt_result_nodes:
@@ -1876,7 +1876,32 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             self.remove_photocollection(photocollection_reference_number) 
         self.update_photocollections_affiliated_with_loaded_session()
 
-        self.session_loading_unloading_in_progress = False
+        # Check if there are any approved photoscans with approved transducer tracking results
+        approved_photoscan_id = self.getParameterNode().loaded_session.get_transducer_tracking_approvals()
+        if not approved_photoscan_id:
+            return  # No approved photoscan ID, so we can stop here
+
+        approved_photoscan_id = approved_photoscan_id[0]
+        approved_tracking_result = None
+
+        for transducer_to_volume_node, _ in newly_added_tt_result_nodes:
+            current_photoscan_id = get_photoscan_id_from_transducer_tracking_result(transducer_to_volume_node)
+            if current_photoscan_id == approved_photoscan_id:
+                if newly_loaded_transducer.is_matching_transform(transducer_to_volume_node):
+                    approved_tracking_result = transducer_to_volume_node
+                    break  # Found a match, no need to continue searching
+
+        if approved_tracking_result:
+            newly_loaded_transducer.set_current_transform_to_match_transform_node(approved_tracking_result)
+        else:
+            # revoke transducer tracking approval
+            transducer_tracking_widget = slicer.modules.OpenLIFUTransducerTrackerWidget
+            transducer_tracking_widget.revokeTransducerTrackingApprovalIfAny(
+                photoscan_id=approved_photoscan_id,
+                reason="The transducer transform does not match the approved tracking result."
+            )
+
+        self.session_loading_unloading_in_progress = False  
 
     # TODO: This should be a widget level function
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
@@ -2199,7 +2224,6 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     def get_transducer_tracking_approvals_in_session(self) -> List[str]:
         """Get the transducer tracking approval state in the current session object, a list of photoscan IDs for which
         transducer tracking is approved.
-        This does not first check whether there is an active session; make sure that one exists before using this.
         """
         session = self.getParameterNode().loaded_session
         if session is None:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -47,6 +47,7 @@ from OpenLIFULib.transducer_tracking_results import (
     add_transducer_tracking_results_from_openlifu_session_format,
     clear_transducer_tracking_results,
     get_photoscan_id_from_transducer_tracking_result,
+    is_transducer_tracking_result_node,
 )
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
 from OpenLIFULib.util import (
@@ -1041,7 +1042,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
             self.logic.update_photoscans_affiliated_with_loaded_session()
             # Update the transducer tracking drop down to reflect new photoscans 
             transducer_tracking_widget = slicer.modules.OpenLIFUTransducerTrackerWidget
-            transducer_tracking_widget.self().algorithm_input_widget.update()
+            transducer_tracking_widget.algorithm_input_widget.update()
 
     @display_errors
     def onImportPhotocollectionFromDiskClicked(self, checked:bool):
@@ -1910,13 +1911,15 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         if matching_transform_id:
             # If its a transducer tracking node, revoke approval if approved
             transform_node = slicer.mrmlScene.GetNodeByID(matching_transform_id)
-            if transform_node:
+            if transform_node and is_transducer_tracking_result_node(transform_node):
                 photoscan_id = get_photoscan_id_from_transducer_tracking_result(transform_node)
                 transducer_tracking_widget = slicer.modules.OpenLIFUTransducerTrackerWidget
                 transducer_tracking_widget.revokeTransducerTrackingApprovalIfAny(
                     photoscan_id = photoscan_id,
                     reason = "The transducer transform was modified"
                 )
+            
+            transducer.set_matching_transform(None)
 
     def load_protocol_from_file(self, filepath:str) -> None:
         protocol = openlifu_lz().Protocol.from_file(filepath)

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1805,7 +1805,6 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             transducer_matrix_units = session_openlifu.array_transform.units,
             replace_confirmed = True,
         )
-        newly_loaded_transducer.observe_transform_modified(self._on_transducer_transform_modified)
 
         # === Load protocol ===
 
@@ -1986,7 +1985,6 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         }
         
         newly_loaded_transducer = self.load_transducer_from_openlifu(transducer, transducer_abspaths_info)
-        newly_loaded_transducer.observe_transform_modified(self._on_transducer_transform_modified)
 
     def load_transducer_from_openlifu(
             self,
@@ -2036,6 +2034,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             transducer_matrix_units=transducer_matrix_units,
         )
         self.getParameterNode().loaded_transducers[transducer.id] = newly_loaded_transducer
+        newly_loaded_transducer.observe_transform_modified(self._on_transducer_transform_modified)
         return newly_loaded_transducer
 
     def remove_transducer(self, transducer_id:str, clean_up_scene:bool = True) -> None:

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -231,14 +231,14 @@ class SlicerOpenLIFUSession:
             if photoscan.photoscan_approved
             and any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)
             ]
-            if len(approved_tt_photoscans) > 1:
-                raise RuntimeError("Multiple approved photoscans detected (IDs: {approved_photoscans}). Only one should be approved per session.")
         else:
             approved_tt_photoscans = [
             photoscan.id
             for photoscan in self.get_affiliated_photoscans()
             if any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)
             ]
+        if len(approved_tt_photoscans) > 1:
+            raise RuntimeError("Multiple  photoscans with approved transducer tracking results detected (IDs: {approved_photoscans}). Only one tracking result should be approved per session.")
 
         return approved_tt_photoscans
     

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -183,3 +183,18 @@ class SlicerOpenLIFUTransducer:
             shNode.GetItemByDataNode(node),
             shNode.GetItemParent(shNode.GetItemByDataNode(self.transform_node)),
         )
+
+    def is_matching_transform(self, query_transform_node: vtkMRMLTransformNode) -> bool:
+        """Returns true if the transform associated with the transducer matches the given transform node"""
+
+        current_transform_matrix = vtk.vtkMatrix4x4()
+        self.transform_node.GetMatrixTransformToParent(current_transform_matrix)
+
+        query_transform_matrix = vtk.vtkMatrix4x4()
+        query_transform_node.GetMatrixTransformToParent(query_transform_matrix)
+
+        is_matching = (
+            slicer.util.arrayFromVTKMatrix(current_transform_matrix) == slicer.util.arrayFromVTKMatrix(query_transform_matrix)
+            ).all()
+        
+        return is_matching

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -167,6 +167,15 @@ class SlicerOpenLIFUTransducer:
         transform_node.GetMatrixTransformToParent(transform_matrix)
         self.transform_node.SetMatrixTransformToParent(transform_matrix)
 
+        # Add an attribute which specifies the ID of the transform being matched
+        self.set_matching_transform(transform_node)
+
+    def set_matching_transform(self, node: vtkMRMLTransformNode = None) -> None:
+        if node:
+            self.transform_node.SetAttribute("matching_transform", node.GetID())
+        else:
+            self.transform_node.SetAttribute("matching_transform", None)
+
     def move_node_into_transducer_sh_folder(self, node : vtkMRMLNode) -> None:
         """In the subject hiearchy, move the given `node` into this transducer's transform node folder."""
         shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -310,9 +310,19 @@ def get_complete_transducer_tracking_results(session_id: Optional[str], photosca
         tp_nodes = filter(lambda t : t.GetAttribute("TT:sessionID") is None, tp_nodes)
         pv_nodes = filter(lambda t : t.GetAttribute("TT:sessionID") is None, pv_nodes)
 
-    # Both transform nodes need to be there for a complete tracking result
-    tt_results : Iterable[Tuple[vtkMRMLTransformNode,vtkMRMLTransformNode]] = [
-        (t, p) for t in tp_nodes for p in pv_nodes if t.GetAttribute("TT:photoscanID") == p.GetAttribute("TT:photoscanID")]
+    tp_nodes = list(tp_nodes)
+    pv_nodes = list(pv_nodes)
+
+    pv_nodes_by_id = {}
+    for pv_node in pv_nodes:
+        photoscan_id = pv_node.GetAttribute("TT:photoscanID")
+        pv_nodes_by_id[photoscan_id] = pv_node
+
+    tt_results = []
+    for tp_node in tp_nodes:
+        photoscan_id = tp_node.GetAttribute("TT:photoscanID")
+        if photoscan_id in pv_nodes_by_id:
+            tt_results.append((tp_node, pv_nodes_by_id[photoscan_id]))
 
     return tt_results
 

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -81,7 +81,6 @@ def add_transducer_tracking_result(
     else:
         transducer_tracking_result_node = transform_node
 
-
     if transform_type == TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME:
         transducer_tracking_result_node.SetName(f"TT transducer-volume {photoscan_id}")
         transducer_tracking_result_node.SetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}","1")
@@ -229,7 +228,7 @@ def get_transducer_tracking_result_nodes_in_scene(
     """
 
     tt_result_nodes = [
-        t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if t.GetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}") == "1" or t.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") == "1"
+        t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if is_transducer_tracking_result_node(t)
         ]
 
     if session_id is not None:
@@ -348,9 +347,7 @@ def set_transducer_tracking_approval_for_node(approval_state: bool, transform_no
         approval_state: new approval state to apply
         transform_node: vtkMRMLTransformNode
     """
-    if (transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}") != "1" 
-        and transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") != "1"
-    ):
+    if not is_transducer_tracking_result_node(transform_node):
         raise ValueError("The specified transform node is a not a transducer tracking result node")
     transform_node.SetAttribute("TT:approvalStatus", "1" if approval_state else "0")
 
@@ -422,3 +419,13 @@ def clear_transducer_tracking_results(
 
     for node in nodes_to_remove:
         slicer.mrmlScene.RemoveNode(node)
+    
+def is_transducer_tracking_result_node(transform_node) -> bool:
+    """Returns True if the given node is a transducer tracking result node"""
+    if (
+        transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}") == "1" 
+        or transform_node.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") == "1"
+        ):
+        return True
+    else:
+        False

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -364,12 +364,20 @@ def get_approval_from_transducer_tracking_result_node(node : vtkMRMLTransformNod
         raise RuntimeError("Node does not have a transducer tracking approval status.")
     return node.GetAttribute("TT:approvalStatus") == "1"
 
+def get_transform_type_from_transducer_tracking_result_node(node : vtkMRMLTransformNode) -> TransducerTrackingTransformType:
+    if node.GetAttribute(f"isTT-{TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME.name}") == "1":
+        return TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME
+    elif node.GetAttribute(f"isTT-{TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME.name}") == "1":
+        return TransducerTrackingTransformType.PHOTOSCAN_TO_VOLUME
+    else:
+        raise RuntimeError("The given node is not a transducer tracking result transform.")
+
 def get_photoscan_id_from_transducer_tracking_result(result: Union[vtkMRMLTransformNode, Tuple[vtkMRMLTransformNode, vtkMRMLTransformNode]]) -> str:
     """Returns the photoscan ID associated with a transducer tracking transform node. 
     If a transducer tracking result i.e. tuple of transform nodes is provided, this function
     includes a check to ensure that the paired transform nodes are associated with the same photoscan ID."""
     
-    if isinstance(result, vtkMRMLTransformNode):
+    if isinstance(result, vtkMRMLTransformNode) and result.GetAttribute("TT:photoscanID") is not None:
         transform_node = result
     elif isinstance(result,tuple):
         if result[0].GetAttribute("TT:photoscanID") != result[1].GetAttribute("TT:photoscanID"):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -322,7 +322,7 @@ class PhotoscanMarkupPage(FacialLandmarksMarkupPageBase):  # Inherit from the ba
         else:
             self.ui.trackingApprovalWidget.show()
             self.ui.approveTransformButton.hide()
-            self.ui.approvalStatusLabel.text = ("A transducer tracking is currently approved for this photoscan."
+            self.ui.approvalStatusLabel.text = ("A transducer tracking is currently approved for this photoscan. "
             "To re-do or edit fiducial landmarks, navigate to the "
             "'Register photoscan to skin surface' page and revoke the existing approval.")
 
@@ -844,7 +844,7 @@ class TransducerTrackingWizard(qt.QWizard):
                  target: vtkMRMLMarkupsFiducialNode):
         super().__init__()
 
-        self._logic = OpenLIFUTransducerTrackerLogic()
+        self._logic = slicer.util.getModuleLogic('OpenLIFUTransducerTracker')
         
         with BusyCursor():
 
@@ -1167,8 +1167,8 @@ class PhotoscanPreviewWizard(qt.QWizard):
     def __init__(self, photoscan : "openlifu.nav.photoscan.Photoscan"):
         super().__init__()
 
-        self.logic = OpenLIFUTransducerTrackerLogic()
-        self.photoscan = self.logic.load_openlifu_photoscan(photoscan)
+        self._logic = self._logic = slicer.util.getModuleLogic('OpenLIFUTransducerTracker')
+        self.photoscan = self._logic.load_openlifu_photoscan(photoscan)
         self.photoscan_approved: bool = self.photoscan.is_approved()
 
         self.setupViewNode()
@@ -1191,7 +1191,7 @@ class PhotoscanPreviewWizard(qt.QWizard):
         self.photoscan_approved = self.photoscanPreviewPage._photoscan_approved
 
         # Update the photoscan approval status in the underlying openlifu photoscan object
-        self.logic.update_photoscan_approval(
+        self._logic.update_photoscan_approval(
             photoscan = self.photoscan,
             approval_state = self.photoscan_approved)
 

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>331</width>
-    <height>367</height>
+    <width>633</width>
+    <height>599</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,7 +31,7 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>4</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="photoscanPreview">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -241,6 +241,19 @@
                </property>
               </widget>
              </item>
+             <item>
+              <spacer name="verticalSpacer_6">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
             </layout>
            </widget>
           </item>
@@ -308,7 +321,20 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="approvalWidget" native="true">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="trackingApprovalWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_10">
       <item>
        <widget class="QPushButton" name="approveTransformButton">
@@ -320,7 +346,7 @@
       <item>
        <widget class="QLabel" name="approvalStatusLabel">
         <property name="text">
-         <string/>
+         <string>(placeholder approval status)</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -328,6 +354,13 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="warningTrackingResultLabel">
+     <property name="text">
+      <string>(placeholder warning message)</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>778</width>
-    <height>688</height>
+    <width>331</width>
+    <height>367</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,208 +20,267 @@
     </widget>
    </item>
    <item>
-    <widget class="QStackedWidget" name="dialogControls">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>3</number>
-     </property>
-     <widget class="QWidget" name="photoscanPreview">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QLabel" name="photoscanApprovalStatusLabel">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="photoscanApprovalButton">
-         <property name="text">
-          <string>Approve Photoscan</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="photoscanMarkup">
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QLabel" name="photoscanApprovalStatusLabel_Markup">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="placeLandmarksButton">
-         <property name="text">
-          <string>Place/Edit Registration Landmarks</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="landmarkPlacementStatus">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="contextMenuPolicy">
-          <enum>Qt::NoContextMenu</enum>
-         </property>
-         <property name="nodeSelectorVisible">
-          <bool>false</bool>
-         </property>
-         <property name="optionsVisible">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="skinSegmentationMarkup">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QPushButton" name="placeLandmarksButtonSkinSeg">
-         <property name="text">
-          <string>Place/Edit Registration Landmarks</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="landmarkPlacementStatus_2">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="qSlicerSimpleMarkupsWidget" name="skinSegMarkupsWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="contextMenuPolicy">
-          <enum>Qt::NoContextMenu</enum>
-         </property>
-         <property name="nodeSelectorVisible">
-          <bool>false</bool>
-         </property>
-         <property name="optionsVisible">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="PhotoscanVolumeTracking">
-      <layout class="QVBoxLayout" name="verticalLayout_5">
-       <item>
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_11">
+    <widget class="QWidget" name="controlsWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_13">
+      <item>
+       <widget class="QStackedWidget" name="dialogControls">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="currentIndex">
+         <number>4</number>
+        </property>
+        <widget class="QWidget" name="photoscanPreview">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QPushButton" name="initializePVRegistration">
+           <widget class="QLabel" name="photoscanApprovalStatusLabel">
             <property name="text">
-             <string>Initialize photoscan-volume transform</string>
+             <string/>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
+           <widget class="QPushButton" name="photoscanApprovalButton">
             <property name="text">
-             <string>Run ICP-based registration fine-tuning</string>
+             <string>Approve Photoscan</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QWidget" name="scalingTransformWidget" native="true">
-            <layout class="QFormLayout" name="formLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="scalingLabel">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="photoscanMarkup">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QLabel" name="photoscanApprovalStatusLabel_Markup">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="placeLandmarksButton">
+            <property name="text">
+             <string>Place/Edit Registration Landmarks</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="landmarkPlacementStatus">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="contextMenuPolicy">
+             <enum>Qt::NoContextMenu</enum>
+            </property>
+            <property name="nodeSelectorVisible">
+             <bool>false</bool>
+            </property>
+            <property name="optionsVisible">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="skinSegmentationMarkup">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QPushButton" name="placeLandmarksButtonSkinSeg">
+            <property name="text">
+             <string>Place/Edit Registration Landmarks</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="landmarkPlacementStatus_2">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="qSlicerSimpleMarkupsWidget" name="skinSegMarkupsWidget">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="contextMenuPolicy">
+             <enum>Qt::NoContextMenu</enum>
+            </property>
+            <property name="nodeSelectorVisible">
+             <bool>false</bool>
+            </property>
+            <property name="optionsVisible">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="PhotoscanVolumeTracking">
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_11">
+             <item>
+              <widget class="QPushButton" name="initializePVRegistration">
                <property name="text">
-                <string>Scale:</string>
+                <string>Initialize photoscan-volume transform</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
-              <widget class="qMRMLSliderWidget" name="scalingTransformMRMLSliderWidget">
-               <property name="singleStep">
-                <double>0.010000000000000</double>
+             <item>
+              <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
+               <property name="text">
+                <string>Run ICP-based registration fine-tuning</string>
                </property>
-               <property name="minimum">
-                <double>-0.800000000000000</double>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="scalingTransformWidget" native="true">
+               <layout class="QFormLayout" name="formLayout">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="scalingLabel">
+                  <property name="text">
+                   <string>Scale:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="qMRMLSliderWidget" name="scalingTransformMRMLSliderWidget">
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="minimum">
+                   <double>-0.800000000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>1.200000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
+                  </property>
+                  <property name="quantity">
+                   <string notr="true"/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="ICPPlaceholderLabel">
+               <property name="text">
+                <string/>
                </property>
-               <property name="maximum">
-                <double>1.200000000000000</double>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
-               <property name="value">
-                <double>1.000000000000000</double>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="TransducerPhotoscanTracking">
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QGroupBox" name="groupBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8">
+             <item>
+              <widget class="QPushButton" name="initializeTPRegistration">
+               <property name="text">
+                <string>Initialize transducer-photoscan transform</string>
                </property>
-               <property name="quantity">
-                <string notr="true"/>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="runTransducerPhotoscanRegistration">
+               <property name="text">
+                <string>Run ICP-based registration fine-tuning</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="ICPPlaceholderLabel_2">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -229,138 +288,46 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="ICPPlaceholderLabel">
-            <property name="text">
-             <string/>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-            <property name="wordWrap">
-             <bool>true</bool>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
             </property>
-           </widget>
+           </spacer>
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_10">
-          <item>
-           <widget class="QPushButton" name="approvePhotoscanVolumeTransform">
-            <property name="text">
-             <string>Approve photoscan-volume transform</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="photoscanVolumeTransformApprovalStatusLabel">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="TransducerPhotoscanTracking">
-      <layout class="QVBoxLayout" name="verticalLayout_7">
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_8">
-          <item>
-           <widget class="QPushButton" name="initializeTPRegistration">
-            <property name="text">
-             <string>Initialize transducer-photoscan transform</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="runTransducerPhotoscanRegistration">
-            <property name="text">
-             <string>Run ICP-based registration fine-tuning</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="ICPPlaceholderLabel_2">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
-          <item>
-           <widget class="QPushButton" name="approveTransducerPhotoscanTransform">
-            <property name="text">
-             <string>Approve transducer - photoscan transform</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="transducerPhotoscanTransformApprovalStatusLabel">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="approvalWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_10">
+      <item>
+       <widget class="QPushButton" name="approveTransformButton">
+        <property name="text">
+         <string>Approve tracking result</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="approvalStatusLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Closes #259 
Closes #289 

- When a transduer tracking result is computed, the result is copied to the current transducer transform. An observer is added to the current transducer transform so that it revokes tt approval for the associated "matching_transform" when modified.
- When approving a photoscan is a session-based workflow, added a check to enforce that only one photoscan can be approved per session.
- When loading a session, if there is a photoscan (could be approved or unapproved) associated with an approved transducer tracking result, we check whether the current transducer transform matches the tracking result and set the "matching_transform" attribute on that transform if it is. This will then revoke approval on the tracking result if the transform is moved. 
- Only one transducer tracking result can be approved within a session. If a user computes a second transducer tracking result, approval of the previously computed result is revoked.
- The wizard now includes clear messaging when a previously computed result is being modified within the wizard. In order to make any edits to an existing result, the user has to first click to revoke approval before being able to make changes. 

When reviewing, it would be helpful if you could just look over the code and play around with the wizard and test out creating a new result from scratch, editing a previous result, computing a second result etc to see if there are any edge cases I missed. 
