### PR TITLE
Propagate param node updates to QSettings and GUI (#308)

### DIFF
--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -120,7 +120,6 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         self.initializeParameterNode()
 
         # Call the routine to update from data parameter node
-        self.onDataParameterNodeModified()
         self.updateWorkflowControls()
 
     def cleanup(self) -> None:
@@ -150,9 +149,6 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
         if self.parent.isEntered:
             self.initializeParameterNode()
-
-    def onDataParameterNodeModified(self, caller = None, event = None):
-        pass
 
     @display_errors
     def onLoadDatabaseClicked(self, checked:bool):

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -213,6 +213,16 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
             self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.onParameterNodeModified)
 
     def onParameterNodeModified(self, caller, event) -> None:
+        # Update QSettings from changed parameter node
+        for parameter_name in [
+            "databaseDirectory",
+        ]:
+            self.updateSettingFromParameter(parameter_name)
+
+        # Make sure the line edit showing the directory path matches the parameter node state (if changed)
+        self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).text = self._parameterNode.databaseDirectory
+
+        # Update workflow controls
         self.updateWorkflowControls()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -114,6 +114,13 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
             lambda : self.onLoadDatabaseClicked(checked=True)
         )
 
+        # You do not need to connect databaseDirectoryLineEdit
+        # currentPathChanged to something that updates the parameter node
+        # because the SlicerParameterName dynamic property was given to the
+        # ctkPathLineEdit and given a bidirectional connection in
+        # self._parameterNode.connectGui(self.ui) (the line edit inside of the
+        # widget always matches the parameter node)
+
         # ====================================
         
         # Make sure parameter node is initialized (needed for module reload)
@@ -204,7 +211,9 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         self._parameterNode = inputParameterNode
         if self._parameterNode:
             # Note: in the .ui file, a Qt dynamic property called "SlicerParameterName" is set on each
-            # ui element that needs connection.
+            # ui element that needs connection. This creates a bidirectional
+            # connection between, e.g. the content within the ctk line edit and
+            # the parameter node will always update each other
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
             self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.onParameterNodeModified)
 
@@ -214,9 +223,6 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
             "databaseDirectory",
         ]:
             self.updateSettingFromParameter(parameter_name)
-
-        # Make sure the line edit showing the directory path matches the parameter node state (if changed)
-        self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).text = self._parameterNode.databaseDirectory
 
         # Update workflow controls
         self.updateWorkflowControls()

--- a/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
+++ b/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
@@ -43,6 +43,9 @@
         <property name="filters">
          <set>ctkPathLineEdit::Dirs</set>
         </property>
+        <property name="showHistoryButton">
+         <bool>false</bool>
+        </property>
         <property name="SlicerParameterName" stdset="0">
          <string>databaseDirectory</string>
         </property>


### PR DESCRIPTION
Closes #308 
Contributes to OpenLIFU-app #25

This PR makes it so that changes to the Database parameter node updates the QSettings and the GUI (the GUI part was already happening through the `self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)` construct). This will streamline setting the value from a default in external modules (external modules only need to update the Database parameter node) and default loading of those locations.

## For review

Just check the code. If you want, try also loading databases at custom paths and making sure the line edit changes.