### PR TITLE
Add improvements to protocol config

### DIFF
--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1767,44 +1767,50 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
                     elif isinstance(child, qt.QCheckBox):
                         child.stateChanged.connect(callback)
 
-    def modify_field_spinbox(self, field: str, default_value = None, min_value = None, max_value = None, num_decimals = None) -> None:
+    def modify_widget_spinbox(self, widget: qt.QWidget, default_value=None, min_value=None, max_value=None, num_decimals=None) -> None:
         """
-        Sets the default, minimum & maximum values, and number of decimals (if
-        applicable) for a spin box widget associated with a specific field.
+        Configures a QSpinBox or QDoubleSpinBox widget with specified default, min/max values, and decimal precision.
 
         Args:
-            field (str): The name of the field associated with the widget.
+            widget (qt.QWidget): The widget to configure.
 
         Raises:
-            TypeError: If the widget is not a QSpinBox or QDoubleSpinBox, as
-            only these types support numeric range control.
+            TypeError: If the widget is not a QSpinBox or QDoubleSpinBox.
         """
-        w: qt.QWidget = self._field_widgets[field]
-
-        if isinstance(w, qt.QSpinBox):
+        if isinstance(widget, qt.QSpinBox):
             if default_value is None:
                 default_value = self.DEFAULT_INT_VALUE
             if min_value is None:
                 min_value = self.DEFAULT_INT_RANGE[0]
             if max_value is None:
-                min_value = self.DEFAULT_INT_RANGE[1]
-        elif isinstance(w, qt.QDoubleSpinBox):
+                max_value = self.DEFAULT_INT_RANGE[1]
+        elif isinstance(widget, qt.QDoubleSpinBox):
             if default_value is None:
                 default_value = self.DEFAULT_FLOAT_VALUE
             if min_value is None:
                 min_value = self.DEFAULT_FLOAT_RANGE[0]
             if max_value is None:
-                min_value = self.DEFAULT_FLOAT_RANGE[1]
+                max_value = self.DEFAULT_FLOAT_RANGE[1]
             if num_decimals is None:
                 num_decimals = self.DEFAULT_FLOAT_NUM_DECIMALS
-            w.setDecimals(num_decimals)
+            widget.setDecimals(num_decimals)
         else:
             raise TypeError(
-                f"Widget for field '{field}' must be a QSpinBox or QDoubleSpinBox to set range and default."
-                f"Got {type(w).__name__} instead."
+                f"Expected QSpinBox or QDoubleSpinBox, got {type(widget).__name__} instead."
             )
-        w.setRange(min_value, max_value)
-        w.setValue(default_value)
+
+        widget.setRange(min_value, max_value)
+        widget.setValue(default_value)
+
+    def modify_field_spinbox(self, field: str, default_value=None, min_value=None, max_value=None, num_decimals=None) -> None:
+        """
+        Applies spinbox configuration to a field's associated widget.
+
+        Args:
+            field (str): The field whose widget will be configured.
+        """
+        widget = self._field_widgets[field]
+        self.modify_widget_spinbox(widget, default_value, min_value, max_value, num_decimals)
 
 class OpenLIFUAbstractMultipleABCDefinitionFormWidget(qt.QWidget):
     def __init__(self, cls_list: List[Type[Any]], parent: Optional[qt.QWidget] = None, is_collapsible: bool = True, collapsible_title: Optional[str] = None, custom_abc_title: Optional[str] = None):

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -251,7 +251,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.sim_setup_definition_widget = OpenLIFUSimSetupDefinitionFormWidget(parent=self.ui.simSetupDefinitionWidgetPlaceholder.parentWidget())
         replace_widget(self.ui.simSetupDefinitionWidgetPlaceholder, self.sim_setup_definition_widget, self.ui)
 
-        self.abstract_delay_method_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")
+        self.abstract_delay_method_definition_widget = OpenLIFUAbstractDelayMethodDefinitionFormWidget()
         replace_widget(self.ui.abstractDelayMethodDefinitionWidgetPlaceholder, self.abstract_delay_method_definition_widget, self.ui)
 
         self.abstract_apodization_method_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.apod_methods.MaxAngle, openlifu_lz().bf.apod_methods.PiecewiseLinear, openlifu_lz().bf.apod_methods.Uniform], is_collapsible=False, collapsible_title="Apodization Method", custom_abc_title="Apodization Method")
@@ -1898,3 +1898,19 @@ class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFo
         # Modify the default and range for spacing
         spacing_spinbox = self._field_widgets['spacing']
         self.modify_widget_spinbox(spacing_spinbox, default_value=1.0, min_value=0.1, max_value=2.0)
+
+class OpenLIFUAbstractDelayMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
+    def __init__(self):
+        super().__init__([openlifu_lz().bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")
+
+        # Select Direct as the default. Note: `get_default_delay_method` should
+        # make sure Direct is also set.
+        self.forms.setCurrentIndex(0)
+
+        # ---- Configure Direct class ----
+
+        direct_definition_form_widget = self.forms.widget(0)
+
+        # Modify the default and range for c0
+        c0_spinbox = direct_definition_form_widget._field_widgets['c0']
+        direct_definition_form_widget.modify_widget_spinbox(c0_spinbox, default_value=1480, min_value=1000, max_value=3000)

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1767,7 +1767,8 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
                     elif isinstance(child, qt.QCheckBox):
                         child.stateChanged.connect(callback)
 
-    def modify_widget_spinbox(self, widget: qt.QWidget, default_value=None, min_value=None, max_value=None, num_decimals=None) -> None:
+    @classmethod
+    def modify_widget_spinbox(cls, widget: qt.QWidget, default_value=None, min_value=None, max_value=None, num_decimals=None) -> None:
         """
         Configures a QSpinBox or QDoubleSpinBox widget with specified default, min/max values, and decimal precision.
 
@@ -1779,20 +1780,20 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
         """
         if isinstance(widget, qt.QSpinBox):
             if default_value is None:
-                default_value = self.DEFAULT_INT_VALUE
+                default_value = cls.DEFAULT_INT_VALUE
             if min_value is None:
-                min_value = self.DEFAULT_INT_RANGE[0]
+                min_value = cls.DEFAULT_INT_RANGE[0]
             if max_value is None:
-                max_value = self.DEFAULT_INT_RANGE[1]
+                max_value = cls.DEFAULT_INT_RANGE[1]
         elif isinstance(widget, qt.QDoubleSpinBox):
             if default_value is None:
-                default_value = self.DEFAULT_FLOAT_VALUE
+                default_value = cls.DEFAULT_FLOAT_VALUE
             if min_value is None:
-                min_value = self.DEFAULT_FLOAT_RANGE[0]
+                min_value = cls.DEFAULT_FLOAT_RANGE[0]
             if max_value is None:
-                max_value = self.DEFAULT_FLOAT_RANGE[1]
+                max_value = cls.DEFAULT_FLOAT_RANGE[1]
             if num_decimals is None:
-                num_decimals = self.DEFAULT_FLOAT_NUM_DECIMALS
+                num_decimals = cls.DEFAULT_FLOAT_NUM_DECIMALS
             widget.setDecimals(num_decimals)
         else:
             raise TypeError(

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -254,7 +254,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.abstract_delay_method_definition_widget = OpenLIFUAbstractDelayMethodDefinitionFormWidget()
         replace_widget(self.ui.abstractDelayMethodDefinitionWidgetPlaceholder, self.abstract_delay_method_definition_widget, self.ui)
 
-        self.abstract_apodization_method_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.apod_methods.MaxAngle, openlifu_lz().bf.apod_methods.PiecewiseLinear, openlifu_lz().bf.apod_methods.Uniform], is_collapsible=False, collapsible_title="Apodization Method", custom_abc_title="Apodization Method")
+        self.abstract_apodization_method_definition_widget = OpenLIFUAbstractApodizationMethodDefinitionFormWidget()
         replace_widget(self.ui.abstractApodizationMethodDefinitionWidgetPlaceholder, self.abstract_apodization_method_definition_widget, self.ui)
 
         self.segmentation_method_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().seg.SegmentationMethod, parent=self.ui.segmentationMethodDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Segmentation Method")
@@ -1914,3 +1914,19 @@ class OpenLIFUAbstractDelayMethodDefinitionFormWidget(OpenLIFUAbstractMultipleAB
         # Modify the default and range for c0
         c0_spinbox = direct_definition_form_widget._field_widgets['c0']
         direct_definition_form_widget.modify_widget_spinbox(c0_spinbox, default_value=1480, min_value=1000, max_value=3000)
+
+class OpenLIFUAbstractApodizationMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
+    def __init__(self):
+        super().__init__([openlifu_lz().bf.apod_methods.MaxAngle, openlifu_lz().bf.apod_methods.PiecewiseLinear, openlifu_lz().bf.apod_methods.Uniform], is_collapsible=False, collapsible_title="Apodization Method", custom_abc_title="Apodization Method")
+
+        # Select Uniform as the default. Note: `get_default_apodization_method`
+        # should make sure Uniform also set.
+        self.forms.setCurrentIndex(2)
+
+        # ---- Configure MaxAngle class ----
+
+        maxangle_definition_form_widget = self.forms.widget(0)
+
+        # Modify the default and range for max_angle
+        max_angle_spinbox = maxangle_definition_form_widget._field_widgets['max_angle']
+        maxangle_definition_form_widget.modify_widget_spinbox(max_angle_spinbox, default_value=30, min_value=0, max_value=90)

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1802,16 +1802,6 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
         widget.setRange(min_value, max_value)
         widget.setValue(default_value)
 
-    def modify_field_spinbox(self, field: str, default_value=None, min_value=None, max_value=None, num_decimals=None) -> None:
-        """
-        Applies spinbox configuration to a field's associated widget.
-
-        Args:
-            field (str): The field whose widget will be configured.
-        """
-        widget = self._field_widgets[field]
-        self.modify_widget_spinbox(widget, default_value, min_value, max_value, num_decimals)
-
 class OpenLIFUAbstractMultipleABCDefinitionFormWidget(qt.QWidget):
     def __init__(self, cls_list: List[Type[Any]], parent: Optional[qt.QWidget] = None, is_collapsible: bool = True, collapsible_title: Optional[str] = None, custom_abc_title: Optional[str] = None):
         """

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1963,6 +1963,28 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
             }
             self.inverse_operator_display_map = {v: k for k, v in self.operator_display_map.items()}
 
+            self.parameter_key_map = {
+                "Thermal Index (TIC)": "TIC",
+                "Mechanical Index (MI)": "MI",
+                "Mainlobe PNP (MPa)": "mainlobe_pnp_MPa",
+                "Mainlobe I_SPPA (W/cm^2)": "mainlobe_isppa_Wcm2",
+                "Mainlobe I_SPTA (W/cm^2)": "mainloba_ispta_Wcm2",
+                "3 dB Lateral Beamwidth (mm)": "beamwidth_lat_3dB_mm",
+                "3 dB Elevational Beamwidth (mm)": "beamwidth_ele_3dB_mm",
+                "3 dB Axial Beamwidth (mm)": "beamwidth_ax_3dB_mm",
+                "6 dB Lateral Beamwidth (mm)": "beamwidth_lat_6dB_mm",
+                "6 dB Elevational Beamwidth (mm)": "beamwidth_ele_6dB_mm",
+                "6 dB Axial Beamwidth (mm)": "beamwidth_ax_6dB_mm",
+                "Sidelobe PNP (MPa)": "sidelobe_pnp_MPa",
+                "Sidelobe I_SPPA (W/cm2)": "sidelobe_isppa_Wcm2",
+                "Global PNP (MPa)": "global_pnp_MPa",
+                "Global I_SPPA (W/cm^2)": "global_isppa_Wcm2",
+                "Global I_SPTA (W/cm^2)": "global_ispta_Wcm2",
+                "Emitted Pressure (MPa)": "p0_MPa",
+                "Emitted Power (W)": "power_W"
+            }
+            self.inverse_parameter_key_map = {v: k for k, v in self.parameter_key_map.items()}
+
             self.setup()
 
         def setup(self):
@@ -1973,7 +1995,8 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
             formLayout.setSpacing(5)
             self.setLayout(formLayout)
 
-            self.parameter_name_input = qt.QLineEdit()
+            self.parameter_name_input = qt.QComboBox()
+            self.parameter_name_input.addItems(list(self.parameter_key_map.keys()))
             formLayout.addRow(_(f"Parameter Name:"), self.parameter_name_input)
 
             self.operator_selector = qt.QComboBox()
@@ -2050,7 +2073,8 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
             return openlifu_lz().plan.ParameterConstraint(operator, warning_value, error_value)
 
         def _on_accept(self):
-            parameter_name = self.parameter_name_input.text
+            display_name = self.parameter_name_input.currentText
+            parameter_name = self.parameter_key_map[display_name]
 
             if not parameter_name:
                 slicer.util.errorDisplay("Parameter name cannot be empty.", parent=self)
@@ -2064,7 +2088,9 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
         def customexec_(self):
             returncode = self.exec_()
             if returncode == qt.QDialog.Accepted:
-                return returncode, self.parameter_name_input.text, self._get_parameter_constraint_as_class()
+                display_name = self.parameter_name_input.currentText
+                parameter_name = self.parameter_key_map[display_name]
+                return returncode, parameter_name, self._get_parameter_constraint_as_class()
             return returncode, None, None
 
     def __init__(self):

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -248,7 +248,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.abstract_focal_pattern_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.Wheel, openlifu_lz().bf.SinglePoint], is_collapsible=False, collapsible_title="Focal Pattern", custom_abc_title="Focal Pattern")
         replace_widget(self.ui.abstractFocalPatternDefinitionWidgetPlaceholder, self.abstract_focal_pattern_definition_widget, self.ui)
 
-        self.sim_setup_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().sim.SimSetup, parent=self.ui.simSetupDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Sim Setup")
+        self.sim_setup_definition_widget = OpenLIFUSimSetupDefinitionFormWidget(parent=self.ui.simSetupDefinitionWidgetPlaceholder.parentWidget())
         replace_widget(self.ui.simSetupDefinitionWidgetPlaceholder, self.sim_setup_definition_widget, self.ui)
 
         self.abstract_delay_method_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")
@@ -1878,3 +1878,23 @@ class OpenLIFUAbstractMultipleABCDefinitionFormWidget(qt.QWidget):
         for w_idx in range(self.forms.count):
             form = self.forms.widget(w_idx)
             form.add_value_changed_signals(callback)
+
+class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget):
+    def __init__(self, parent: Optional[qt.QWidget] = None):
+        super().__init__(openlifu_lz().sim.SimSetup, parent, is_collapsible=True, collapsible_title="Sim Setup")
+
+        # Modify the defaults and ranges for x_extent, y_extent, and z_extent
+        x_ext_hbox = self._field_widgets['x_extent'].layout()
+        y_ext_hbox = self._field_widgets['y_extent'].layout()
+        z_ext_hbox = self._field_widgets['z_extent'].layout()
+        
+        self.modify_widget_spinbox(x_ext_hbox.itemAt(0).widget(), default_value=-30, min_value=-200, max_value=-1)
+        self.modify_widget_spinbox(x_ext_hbox.itemAt(1).widget(), default_value=30, min_value=1, max_value=200)
+        self.modify_widget_spinbox(y_ext_hbox.itemAt(0).widget(), default_value=-30, min_value=-200, max_value=-1)
+        self.modify_widget_spinbox(y_ext_hbox.itemAt(1).widget(), default_value=30, min_value=1, max_value=200)
+        self.modify_widget_spinbox(z_ext_hbox.itemAt(0).widget(), default_value=-4, min_value=-4, max_value=-4)
+        self.modify_widget_spinbox(z_ext_hbox.itemAt(1).widget(), default_value=60, min_value=1, max_value=200)
+
+        # Modify the default and range for spacing
+        spacing_spinbox = self._field_widgets['spacing']
+        self.modify_widget_spinbox(spacing_spinbox, default_value=1.0, min_value=0.1, max_value=2.0)

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1767,6 +1767,45 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
                     elif isinstance(child, qt.QCheckBox):
                         child.stateChanged.connect(callback)
 
+    def modify_field_spinbox(self, field: str, default_value = None, min_value = None, max_value = None, num_decimals = None) -> None:
+        """
+        Sets the default, minimum & maximum values, and number of decimals (if
+        applicable) for a spin box widget associated with a specific field.
+
+        Args:
+            field (str): The name of the field associated with the widget.
+
+        Raises:
+            TypeError: If the widget is not a QSpinBox or QDoubleSpinBox, as
+            only these types support numeric range control.
+        """
+        w: qt.QWidget = self._field_widgets[field]
+
+        if isinstance(w, qt.QSpinBox):
+            if default_value is None:
+                default_value = self.DEFAULT_INT_VALUE
+            if min_value is None:
+                min_value = self.DEFAULT_INT_RANGE[0]
+            if max_value is None:
+                min_value = self.DEFAULT_INT_RANGE[1]
+        elif isinstance(w, qt.QDoubleSpinBox):
+            if default_value is None:
+                default_value = self.DEFAULT_FLOAT_VALUE
+            if min_value is None:
+                min_value = self.DEFAULT_FLOAT_RANGE[0]
+            if max_value is None:
+                min_value = self.DEFAULT_FLOAT_RANGE[1]
+            if num_decimals is None:
+                num_decimals = self.DEFAULT_FLOAT_NUM_DECIMALS
+            w.setDecimals(num_decimals)
+        else:
+            raise TypeError(
+                f"Widget for field '{field}' must be a QSpinBox or QDoubleSpinBox to set range and default."
+                f"Got {type(w).__name__} instead."
+            )
+        w.setRange(min_value, max_value)
+        w.setValue(default_value)
+
 class OpenLIFUAbstractMultipleABCDefinitionFormWidget(qt.QWidget):
     def __init__(self, cls_list: List[Type[Any]], parent: Optional[qt.QWidget] = None, is_collapsible: bool = True, collapsible_title: Optional[str] = None, custom_abc_title: Optional[str] = None):
         """

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -266,7 +266,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self.target_constraints_widget = ListTableWidget(object_name="Target Constraint", object_type=openlifu_lz().plan.TargetConstraints)
         replace_widget(self.ui.targetConstraintsWidgetPlaceholder, self.target_constraints_widget, self.ui)
 
-        self.solution_analysis_options_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().plan.SolutionAnalysisOptions, parent=self.ui.solutionAnalysisOptionsDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Solution Analysis Options")
+        self.solution_analysis_options_definition_widget = OpenLIFUSolutionAnalysisOptionsDefinitionFormWidget()
         replace_widget(self.ui.solutionAnalysisOptionsDefinitionWidgetPlaceholder, self.solution_analysis_options_definition_widget, self.ui)
 
         self.virtual_fit_options_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().VirtualFitOptions, parent=self.ui.virtualFitOptionsDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Virtual Fit Options")
@@ -2106,3 +2106,17 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
             return
 
         self._add_row(param, param_constraint)
+
+class OpenLIFUSolutionAnalysisOptionsDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget):
+    def __init__(self, parent: Optional[qt.QWidget] = None):
+        super().__init__(openlifu_lz().plan.SolutionAnalysisOptions, parent, collapsible_title="Solution Analysis Options")
+
+        # Modify the widget for configuring SolutionAnalysis.param_constraints
+        # so that it uses the OpenLIFUParameterConstraintsWidget
+        old_param_constraints_dicttablewidget = self._field_widgets['param_constraints']
+        new_param_constraints_widget = OpenLIFUParameterConstraintsWidget()
+
+        replace_widget(old_param_constraints_dicttablewidget, new_param_constraints_widget)
+
+        # Update internal mapping
+        self._field_widgets['param_constraints'] = new_param_constraints_widget


### PR DESCRIPTION
Contributes to #282 

## Summary (for future reference)

This PR adds setting parameter constraints and an API for bounding values. Initially, the fields of a protocol would be defined in forms created by the abstract form creator, e.g. `OpenLIFUAbstractDataclassDefinitionFormWidget`.  Here, an API is introduced in those abstract forms for modifying the specific ranges of configured values in the protocol config.  For instance, it may be desired that when configuring `SimSetup` for using k-wave to simulate wave propagation, the Axial Simulation Range (mm) (`z_extent`) be bounded between 1-200. This PR introduces a simple API for manually adjusting those bounds. 

### Using the API to set bounds

To use the API effectively, each class that wants custom bounds first:

1) Subclasses `OpenLIFUAbstractDataclassDefinitionFormWidget`, for example in the `SimSetup` example, we have `OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget)`
2) Constructs the parent
3) Set the bounds manually

### Subclassing for custom definitions (e.g. for `ParameterConstraint`s)

The subclass-and-modify pattern is also used for making a user-friendly way of defining parameter constraints (`ParameterConstraint` objects). Since the parameter constraints on a protocol is a dictionary mapping the parameter to a `ParameterConstraint` object, we:

1) Make the following subclass: `OpenLIFUParameterConstraintsWidget(DictTableWidget)`
2) Override dialogs, functions, and widgets to have the desired, hardcoded behavior.  For instance, you'll notice that constraints are defined by choosing from a list of parameters and constraint operators. The default forms would not create this type of an interface.
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/026227ad-3b1a-4e6e-aa61-2579978a2ae0" />

## For review

Test out loading and unloading protocols, and then loading one, adding some parameter constraints, and then saving it.

## What remains to complete #282 

After this is merged, we need to merge @peterhollender 's [OpenLIFU-python PR#289](https://github.com/OpenwaterHealth/OpenLIFU-python/pull/289) into openlifu and then change how `SegmentationMethods` are defined in the protocol config.