### PR TITLE
Add status update during photoscan generation

### DIFF
--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1448,6 +1448,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updatePhotoscanGeneratorProgressBar(new_photoscan_generator_progress_value = 0)
             self.ui.photoscanGenerationStatusMessage.show()
             self.ui.photoscanGenerationStatusMessage.text = ("Generating mesh... this process can take up to 20 minutes.")
+            self.ui.photoscanGenerationStatusMessage.styleSheet = "color:red;"
             try:
                 self.logic.generate_photoscan(
                     subject_id = subject_id,
@@ -1456,11 +1457,12 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                     meshroom_pipeline = photoscan_generation_options_dialog.get_selected_meshroom_pipeline(),
                     image_width = photoscan_generation_options_dialog.get_entered_image_width(),
                 )
+                self.updatePhotoscanGeneratorProgressBar(new_photoscan_generator_progress_value = 100)
             except CalledProcessError as e:
                 slicer.util.errorDisplay("The underlying Meshroom process encountered an error.", "Meshroom error")
                 raise e
-            self.updatePhotoscanGeneratorProgressBar(new_photoscan_generator_progress_value = 100)
-            self.ui.photoscanGenerationStatusMessage.hide()
+            finally:
+                self.ui.photoscanGenerationStatusMessage.hide()
         data_logic : OpenLIFUDataLogic = slicer.util.getModuleLogic("OpenLIFUData")
         data_logic.update_photoscans_affiliated_with_loaded_session()
         self.updateInputOptions()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1447,8 +1447,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         if photoscan_generation_options_dialog.exec_() == qt.QDialog.Accepted:
             self.updatePhotoscanGeneratorProgressBar(new_photoscan_generator_progress_value = 0)
             self.ui.photoscanGenerationStatusMessage.show()
-            self.ui.photoscanGenerationStatusMessage.text = ("Please note that this process can take up to 20 minutes."
-            "The progress bar is currently not fully functional and will update only upon completion.")
+            self.ui.photoscanGenerationStatusMessage.text = ("Generating mesh... this process can take up to 20 minutes.")
             try:
                 self.logic.generate_photoscan(
                     subject_id = subject_id,

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -101,7 +101,17 @@
             <number>0</number>
            </property>
            <property name="textVisible">
-            <bool>false</bool>
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="photoscanGenerationStatusMessage">
+           <property name="text">
+            <string>(placeholder_photoscangeneration_status_label)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Closes #264 

(@ebrahimebrahim does this close this issue or should we keep it open till we connect meshroom updates?)

- Adds dummy connections to the photoscan generation progress bar. It updates to 100% once phtoscan geenration is finished, and resets to 0 when `Start Photoscan Generation` is clicked.
- Adds a status update message that should only show up while photoscan generation is running


**For review:**
I don't have meshroom set up on my computer so wasn't able to test it out while the pipeline running. I think it should work but it would  be great if you could look over the code and test it out. 