### PR TITLE
Impose solution analysis safety limits

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1906,6 +1906,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     # TODO: This should be a widget level function
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
+        slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTransducerTransformModified
+
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:
             # If its a transducer tracking node, revoke approval if approved
@@ -2034,7 +2036,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             transducer_matrix_units=transducer_matrix_units,
         )
         self.getParameterNode().loaded_transducers[transducer.id] = newly_loaded_transducer
+
         newly_loaded_transducer.observe_transform_modified(self._on_transducer_transform_modified)
+
         return newly_loaded_transducer
 
     def remove_transducer(self, transducer_id:str, clean_up_scene:bool = True) -> None:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -68,6 +68,8 @@ if TYPE_CHECKING:
     import openlifu
     import openlifu.nav.photoscan
     from OpenLIFUPrePlanning.OpenLIFUPrePlanning import OpenLIFUPrePlanningWidget
+    from OpenLIFUSonicationPlanner.OpenLIFUSonicationPlanner import OpenLIFUSonicationPlannerLogic
+
 #
 # OpenLIFUData
 #
@@ -1906,7 +1908,15 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     # TODO: This should be a widget level function
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
-        slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTransducerTransformModified
+        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
+        sonication_planner_logic : "OpenLIFUSonicationPlannerLogic" = slicer.util.getModuleLogic('OpenLIFUSonicationPlanner')
+        if sonication_planner_logic.solution_analysis_exists():
+            data_logic.clear_solution(clean_up_scene=False)
+            self._parameterNode.solution_analysis = None
+            slicer.util.infoDisplay(
+                text= "Computed solution has been deleted due to moving the transducer.",
+                windowTitle="Solution deleted"
+            )
 
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -68,7 +68,6 @@ if TYPE_CHECKING:
     import openlifu
     import openlifu.nav.photoscan
     from OpenLIFUPrePlanning.OpenLIFUPrePlanning import OpenLIFUPrePlanningWidget
-    from OpenLIFUSonicationPlanner.OpenLIFUSonicationPlanner import OpenLIFUSonicationPlannerLogic
 
 #
 # OpenLIFUData
@@ -1908,15 +1907,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     # TODO: This should be a widget level function
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
-        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        sonication_planner_logic : "OpenLIFUSonicationPlannerLogic" = slicer.util.getModuleLogic('OpenLIFUSonicationPlanner')
-        if sonication_planner_logic.solution_analysis_exists():
-            data_logic.clear_solution(clean_up_scene=False)
-            self._parameterNode.solution_analysis = None
-            slicer.util.infoDisplay(
-                text= "Computed solution has been deleted due to moving the transducer.",
-                windowTitle="Solution deleted"
-            )
+        slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason="The transducer was moved.")
 
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -306,6 +306,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             reason = "The target was modified."
             self.revokeApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)
+            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTargetModified()
                         
     def onPointModified(self, node:vtkMRMLMarkupsFiducialNode, caller, event):
         self.updateTargetPositionInputs()
@@ -315,6 +316,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             reason = "The target was modified."
             self.revokeApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)
+            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTargetModified()
 
     def onLockModified(self, caller, event):
         self.updateLockButtonIcon()

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -306,7 +306,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             reason = "The target was modified."
             self.revokeApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)
-            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTargetModified()
+            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason=reason)
                         
     def onPointModified(self, node:vtkMRMLMarkupsFiducialNode, caller, event):
         self.updateTargetPositionInputs()
@@ -316,7 +316,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             reason = "The target was modified."
             self.revokeApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)
-            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').onTargetModified()
+            slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason=reason)
 
     def onLockModified(self, caller, event):
         self.updateLockButtonIcon()

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -433,6 +433,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._updating_solution_analysis = True
             self.updateSolutionAnalysis()
             self._updating_solution_analysis = False
+        self.updateApproveButton()
 
         # ---- Revoke the solution approval in certain cases ----
         if get_openlifu_data_parameter_node().loaded_solution is not None:

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -319,16 +319,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
                 windowTitle="Solution deleted"
             )
 
-    def onTransducerTransformModified(self, transducer):
-        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        if self.logic.solution_analysis_exists():
-            data_logic.clear_solution(clean_up_scene=False)
-            self._parameterNode.solution_analysis = None
-            slicer.util.infoDisplay(
-                text= "Computed solution has been deleted due to moving the transducer.",
-                windowTitle="Solution deleted"
-            )
-
     def onComputeSolutionClicked(self):
         activeData = self.algorithm_input_widget.get_current_data()
 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -309,9 +309,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onTargetNameModified(self, caller, event):
         self.updateInputOptions()
 
-    def onTargetModified(self):
-        self.deleteSolutionAndSolutionAnalysisIfAny(reason="The target was moved.")
-
     def onComputeSolutionClicked(self):
         activeData = self.algorithm_input_widget.get_current_data()
 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -309,6 +309,16 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onTargetNameModified(self, caller, event):
         self.updateInputOptions()
 
+    def onTransducerTransformModified(self, transducer):
+        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
+        if self.logic.solution_analysis_exists():
+            data_logic.clear_solution(clean_up_scene=False)
+            self._parameterNode.solution_analysis = None
+            slicer.util.infoDisplay(
+                text= "Computed solution has been deleted due to moving the transducer.",
+                windowTitle="Solution deleted"
+            )
+
     def onComputeSolutionClicked(self):
         activeData = self.algorithm_input_widget.get_current_data()
 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -310,14 +310,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateInputOptions()
 
     def onTargetModified(self):
-        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        if self.logic.solution_analysis_exists():
-            data_logic.clear_solution(clean_up_scene=False)
-            self._parameterNode.solution_analysis = None
-            slicer.util.infoDisplay(
-                text= "Computed solution has been deleted due to moving the target.",
-                windowTitle="Solution deleted"
-            )
+        self.deleteSolutionAndSolutionAnalysisIfAny(reason="The target was moved.")
 
     def onComputeSolutionClicked(self):
         activeData = self.algorithm_input_widget.get_current_data()
@@ -342,6 +335,19 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.logic.render_pnp()
         else:
             self.logic.hide_pnp()
+
+    def deleteSolutionAndSolutionAnalysisIfAny(self, reason:str):
+        """Delete the solution in the data module and the solution analysis in
+        the sonication planner module, and show a message dialog to that effect.
+        """
+        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
+        if self.logic.solution_analysis_exists():
+            data_logic.clear_solution(clean_up_scene=False)
+            self._parameterNode.solution_analysis = None
+            slicer.util.infoDisplay(
+                text= "Computed solution has been deleted for the following reason:\n"+reason,
+                windowTitle="Solution deleted"
+            )
 
     def updateVirtualFitApprovalStatus(self) -> None:
         loaded_session = get_openlifu_data_parameter_node().loaded_session

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -369,6 +369,14 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.approveButton.setEnabled(False)
             self.ui.approveButton.setToolTip("There is no active solution to write the approval")
             self.ui.approveButton.setText("Approve solution")
+        elif not self.logic.solution_analysis_exists():
+            self.ui.approveButton.setEnabled(False)
+            self.ui.approveButton.setToolTip("The solution cannot be approved because there is no solution analysis.")
+            self.ui.approveButton.setText("Approve solution")
+        elif self.logic.solution_analysis_has_errors():
+            self.ui.approveButton.setEnabled(False)
+            self.ui.approveButton.setToolTip("The solution cannot be approved because the solution analysis has errors.")
+            self.ui.approveButton.setText("Approve solution")
         else:
             self.ui.approveButton.setEnabled(True)
             if data_parameter_node.loaded_solution.is_approved():

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -387,7 +387,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             else:
                 self.ui.approveButton.setText("Approve solution")
                 self.ui.approveButton.setToolTip(
-                    "Approve the sonicaiton solution"
+                    "Approve the sonication solution"
                 )
 
     def onApproveClicked(self):

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -309,6 +309,16 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onTargetNameModified(self, caller, event):
         self.updateInputOptions()
 
+    def onTargetModified(self):
+        data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
+        if self.logic.solution_analysis_exists():
+            data_logic.clear_solution(clean_up_scene=False)
+            self._parameterNode.solution_analysis = None
+            slicer.util.infoDisplay(
+                text= "Computed solution has been deleted due to moving the target.",
+                windowTitle="Solution deleted"
+            )
+
     def onTransducerTransformModified(self, transducer):
         data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
         if self.logic.solution_analysis_exists():


### PR DESCRIPTION
Closes #261 

This PR implements safety protections for sonication solutions and sonication solution analyses.

- Delete solution and solution analysis when sonication target or transducer transform is modified
- Update solution approval logic based on solution analysis validity (exists & not in error state)
- Revoke solution approval when the solution analysis is modified (cannot currently occur, but logically important)

## For Review

Make sure to check the parts where I inject `OpenLIFUSonicationPlanner` related callbacks and invocations from external modules. For instance, the callback for the sonication target being modified was _not_ registered, it was called directly in `OpenLIFUPrePlanning/OpenLIFUPrePlanning.py`. I did a similar thing in `OpenLIFUData/OpenLIFUData.py` for the transducer, except the callback registration is more explicit through `observe_transform_modified` in `load_transducer_from_openlifu`.

If you want, you can also attempt loading the example session, computing the solution, approving it, and moving a target, but I already checked that it works.

## Before merge

- [ ] Make sure [SlicerOpenLIFU PR#284](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/284) is merged to main and then rebase this branch to main before merging.
