### PR TITLE
Prevent unallowed protocols being loaded through creating or loading sessions

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -944,7 +944,9 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
                 session_info = get_cur_db().load_session_info(subject_id, session_id)
                 protocol: openlifu.plan.Protocol = get_cur_db().load_protocol(session_info["protocol_id"]) 
                 if not any(role in protocol.allowed_roles for role in get_current_user().roles):
-                    slicer.util.errorDisplay(f"Could not load the session '{session_name}' ({session_id}) because it uses a protocol that you are not allowed to use.")
+                    slicer.util.errorDisplay(
+                        f"Could not load the session '{session_name}' ({session_id}) because it uses a protocol that does not allow any of the logged in user's roles."
+                    )
                     return
             # -----------------------------------------------------------
 

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -398,31 +398,13 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
                 protocol_text = f"{protocol_w.protocol.name} (ID: {protocol_id})"
                 if protocol_id in self.logic.cached_protocols:
                     protocol_text = "[  +  ]  " + protocol_text
-
-                if (
-                    not get_user_account_mode_state()
-                    or 'admin' in get_current_user().roles
-                    or any(
-                        user_role in protocol_w.protocol.allowed_roles
-                        for user_role in get_current_user().roles
-                    )
-                ):
-                    self.ui.protocolSelector.addItem(protocol_text, protocol_w.protocol)
+                self.ui.protocolSelector.addItem(protocol_text, protocol_w.protocol)
                     
             self.setProtocolEditButtonEnabled(True)
 
         for protocol_id in self.logic.new_protocol_ids:
             protocol = self.logic.cached_protocols[protocol_id]
-
-            if (
-                not get_user_account_mode_state()
-                or 'admin' in get_current_user().roles
-                or any(
-                    user_role in protocol.allowed_roles
-                    for user_role in get_current_user().roles
-                )
-            ):
-                self.ui.protocolSelector.addItem(f"[  +  ]  {protocol.name} (ID: {protocol.id})", protocol)
+            self.ui.protocolSelector.addItem(f"[  +  ]  {protocol.name} (ID: {protocol.id})", protocol)
 
         self.ui.protocolSelector.setToolTip(tooltip)
 


### PR DESCRIPTION
Closes #262 

#262 was reopened due to some [incorrect behavior](https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/262#issuecomment-2847781778) around enforcement of allowed protocols given the user roles.

This PR prevents unallowed protocols from being shown in the session creator, and attempts to load sessions with unallowed protocols will fail. I tested this example by adding "operator" to the allowed roles of the example session and using the example restricted user and example operator to compare. Things worked as expected.

## For review

You can try modifying the allowed roles on some protocols programmatically or in the JSON files (e.g. add "operator" to a protocol's list). Then, using the accounts below or a custom account, you can test that you can't see any unallowed protocols.

**### Credentials:**
```
complex_user/complex_user_hash
example_admin/example_admin_hash
example_operator/example_operator_hash
example_restricted/example_restricted_hash
```