### PR TITLE
Update workflow controls when adding target (#252)

### DIFF
--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -301,6 +301,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     def onPointAddedOrRemoved(self, node:vtkMRMLMarkupsFiducialNode, caller, event):
         self.updateTargetsListView()
         self.updateInputOptions()
+        self.updateWorkflowControls()
         data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
         if not data_logic.session_loading_unloading_in_progress:
             reason = "The target was modified."


### PR DESCRIPTION
Closes #252 

Adding a sonication target now updates the workflow controls to prompt for running a virtual fit.

## For review

Code review should be enough -- I only modified the `onPointAddedOrRemoved` to update workflow controls. I would like the reviewer's opinion on my **only** adding the update there (for instance, I did not add it to `onPointModified`). This is because while we could issue updates on every `on..` routine call, it may make the code less maintainable because it's probably redundant (would the workflow controls ever update due to a target modification)?