### PR TITLE
Add Photoscan-MRI ICP registration

### DIFF
--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -678,28 +678,29 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         photoscan_landmarks_hardened.SetAndObserveTransformNodeID(self.photoscan_to_volume_transform_node.GetID())
         photoscan_landmarks_hardened.HardenTransform()
 
-        photoscan_roi_submesh = self.wizard()._logic.extract_facial_roi_submesh(
-            fiducial_node = photoscan_landmarks_hardened,
-            surface_model_node = photoscan_hardened
-        )
+        with BusyCursor():
+            photoscan_roi_submesh = self.wizard()._logic.extract_facial_roi_submesh(
+                fiducial_node = photoscan_landmarks_hardened,
+                surface_model_node = photoscan_hardened
+            )
 
-        self.photoscan_to_volume_icp_transform_node = self.wizard()._logic.run_icp_model_registration(
-            input_fixed_model = self.wizard().skin_mesh_node,
-            input_moving_model = photoscan_roi_submesh)
-        
-        if self.photoscan_to_volume_icp_transform_node:
-            self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_icp_transform_node.GetID())
-            self.photoscan_to_volume_transform_node.HardenTransform() # Combine ICP and initialization transform
-        
-            # Reset the photoscan to volume transform and now observe the ICP result
-            self.resetScalingTransform()
-            self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.scaling_transform_node.GetID())
+            self.photoscan_to_volume_icp_transform_node = self.wizard()._logic.run_icp_model_registration(
+                input_fixed_model = self.wizard().skin_mesh_node,
+                input_moving_model = photoscan_roi_submesh)
+            
+            if self.photoscan_to_volume_icp_transform_node:
+                self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_icp_transform_node.GetID())
+                self.photoscan_to_volume_transform_node.HardenTransform() # Combine ICP and initialization transform
+            
+                # Reset the photoscan to volume transform and now observe the ICP result
+                self.resetScalingTransform()
+                self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.scaling_transform_node.GetID())
 
-        # Remove temporary hardened nodes and icp transform node
-        slicer.mrmlScene.RemoveNode(photoscan_hardened)
-        slicer.mrmlScene.RemoveNode(photoscan_landmarks_hardened)
-        slicer.mrmlScene.RemoveNode(photoscan_roi_submesh)
-        slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_icp_transform_node)
+            # Remove temporary hardened nodes and icp transform node
+            slicer.mrmlScene.RemoveNode(photoscan_hardened)
+            slicer.mrmlScene.RemoveNode(photoscan_landmarks_hardened)
+            slicer.mrmlScene.RemoveNode(photoscan_roi_submesh)
+            slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_icp_transform_node)
 
     def onManualRegistrationClicked(self):
         """ Enables the interaction handles on the transform, allowing the user to manually edit the photoscan-volume transform. """

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -519,14 +519,20 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             and self.wizard().skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
         if self.has_facial_landmarks:
             self.ui.initializePVRegistration.enabled = True
+            self.ui.initializePVRegistration.setToolTip("Run fiducial-based registration between the photoscan mesh and skin surface.")
+            self.ui.runICPRegistrationPV.enabled = True
+            self.ui.runICPRegistrationPV.setToolTip("Run Iterative Closest Point (ICP) registration of the face.")
             if self.photoscan_to_volume_transform_node:
                 self.ui.initializePVRegistration.setText("Re-initialize photoscan-volume transform")
-                self.ui.initializePVRegistration.setToolTip("Run fiducial-based registration between the photoscan mesh and skin surface.")
         else:
             self.ui.initializePVRegistration.setText("Initialize photoscan-volume transform")
             self.ui.initializePVRegistration.enabled = False
             self.ui.initializePVRegistration.setToolTip("Please place fiducial landmarks on both the photoscan"
-            " and skin surface mesh on the preceding pages to enable initialization.")
+            " and skin surface mesh on the preceding pages to enable fiducial-based registration.")
+            self.ui.runICPRegistrationPV.enabled = False
+            self.ui.runICPRegistrationPV.setToolTip("Iterative Closest Point (ICP) registration of the face requires the user to"
+            " first define fiducial landmarks on the facial surface on the preceding pages to delineate the region of interest.")
+
 
         if self.photoscan_to_volume_transform_node:
             self.setupTransformNode()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -62,6 +62,8 @@ from OpenLIFULib.user_account_mode_util import UserAccountBanner
 from OpenLIFULib.util import add_slicer_log_handler, BusyCursor, get_cloned_node, replace_widget 
 from OpenLIFULib.virtual_fit_results import get_best_virtual_fit_result_node,  get_virtual_fit_approval_for_target
 
+import ModelRegistration
+
 # These imports are for IDE and static analysis purposes only
 if TYPE_CHECKING:
     import openlifu
@@ -247,6 +249,7 @@ class FacialLandmarksMarkupPageBase(qt.QWizardPage):
         # invalidates the result and resets previously initialized transform nodes
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._valid_tt_result_exists = False
+            self.wizard().photoscanVolumeTrackingPage.resetScalingTransform()
             self.wizard().photoscanVolumeTrackingPage.photoscan_to_volume_transform_node = None
             self.wizard().transducerPhotoscanTrackingPage.transducer_to_volume_transform_node = None
 
@@ -338,7 +341,6 @@ class PhotoscanMarkupPage(FacialLandmarksMarkupPageBase):  # Inherit from the ba
         if self.facial_landmarks_fiducial_node is None:
             self._initialize_facial_landmarks_fiducial_node(node_name = "photoscan-wizard-faciallandmarks")
             self.setupMarkupsWidget()
-            # self.wizard()._valid_tt_result_exists = False # TODO: Do I need this here?
 
         if self.ui.placeLandmarksButton.text == "Place/Edit Registration Landmarks":
             self.facial_landmarks_fiducial_node.SetLocked(False)
@@ -474,6 +476,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
         self.ui.approveTransformButton.clicked.connect(self.onTransformApproveClicked)
         self.ui.enableManualPVRegistration.clicked.connect(self.onManualRegistrationClicked)
+        self.ui.runICPRegistrationPV.clicked.connect(self.onRunICPRegistrationClicked)
         self.ui.initializePVRegistration.clicked.connect(self.onInitializeRegistrationClicked)
         self.runningRegistration = False
 
@@ -487,11 +490,10 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.ui.scalingTransformMRMLSliderWidget.pageStep = 1.0
         self.ui.scalingTransformMRMLSliderWidget.setToolTip(_('Adjust the scale of the photosan mesh."'))
         self.ui.scalingTransformMRMLSliderWidget.connect("valueChanged(double)", self.updateScaledTransformNode)
-        self.ui.scalingTransformWidget.hide()
 
-        self.scaledTransformNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
-        self.scaledTransformNode.SetName("wizard_photoscan_volume-scaled")
         self.photoscan_to_volume_transform_node: vtkMRMLTransformNode = None
+        self.scaling_transform_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+        self.scaling_transform_node.SetName("wizard_photoscan_volume-scaling_factor")
     
     def initializePage(self):
         """ This function is called when the user clicks 'Next'."""
@@ -506,6 +508,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             # Clone the existing node
             existing_transform_node = self.wizard().photoscan_to_volume_transform_node
             self.photoscan_to_volume_transform_node = get_cloned_node(existing_transform_node)
+            self.photoscan_to_volume_transform_node.CreateDefaultDisplayNodes()
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetVisibility(False)
             self.photoscan_to_volume_transform_node.RemoveAttribute('isTT-PHOTOSCAN_TO_VOLUME')
             self.transform_approved = get_approval_from_transducer_tracking_result_node(existing_transform_node)
@@ -528,14 +531,10 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         if self.photoscan_to_volume_transform_node:
             self.setupTransformNode()
         else:
-            self.ui.enableManualPVRegistration.enabled = False
+            self.ui.runICPRegistrationPV.enabled = False
+            self.ui.ManualRegistrationGroupBox.enabled = False
             self.ui.approveTransformButton.enabled = False
             self.transform_approved = False
-        
-        self.updateScaledTransformNode() 
-        self.wizard().photoscan.model_node.SetAndObserveTransformNodeID(self.scaledTransformNode.GetID())
-        if self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node:
-            self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(self.scaledTransformNode.GetID())
         
         self.updateTransformApprovalStatusLabel()
         self.updateTransformApproveButton()
@@ -579,9 +578,6 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
     def onTransformApproveClicked(self):
 
-        if self.photoscan_to_volume_transform_node is None: # should not happen
-            raise RuntimeError("Photoscan-volume transform not found.")
-
         self.transform_approved = not self.transform_approved
 
         if self.transform_approved:
@@ -609,22 +605,22 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         """ This function is called when the user clicks 'Next'."""
 
         # Clear previous result
-        slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_transform_node) # Clear current node
+        slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_transform_node) # Clear current result node if it exists (restarting process)
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._valid_tt_result_exists = False
 
         self.photoscan_to_volume_transform_node = self.wizard()._logic.run_fiducial_registration(
             moving_landmarks = self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node,
             fixed_landmarks = self.wizard().skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
-        self.updateTransformApprovalStatusLabel()
         self.setupTransformNode()
-        self.ui.initializePVRegistration.setText("Re-initialize transducer-photoscan transform")
+        self.resetScalingTransform()
 
-        # Reset scaling transform node
-        self.ui.scalingTransformMRMLSliderWidget.value = 1
+        self.updateTransformApprovalStatusLabel()
+        self.ui.initializePVRegistration.setText("Re-initialize photoscan-volume transform")
 
         # Enable approval and registration fine-tuning buttons
-        self.ui.enableManualPVRegistration.enabled = True
+        self.ui.runICPRegistrationPV.enabled = True
+        self.ui.ManualRegistrationGroupBox.enabled = True
         self.ui.approveTransformButton.enabled = True
 
     def setupTransformNode(self):
@@ -633,7 +629,12 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             [self.wizard().volume_view_node.GetID()]
             ) # Specify a view node for display
         self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
-
+        
+        # Update photoscan model and fiducial to observe transform
+        self.wizard().photoscan.model_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_transform_node.GetID())
+        if self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node:
+            self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_transform_node.GetID())
+        
         # Set the center of the transformation to the center of the photocan model node
         bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         self.wizard().photoscan.model_node.GetRASBounds(bounds)
@@ -648,35 +649,59 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.photoscan_to_volume_transform_node.GetTransformFromWorld(transform_from_world)
         transform_from_world.TransformPoint(center_world,center_local )
         self.photoscan_to_volume_transform_node.SetCenterOfTransformation(center_local)
-        self.scaledTransformNode.SetAndObserveTransformNodeID(self.photoscan_to_volume_transform_node.GetID())
 
+        self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.scaling_transform_node.GetID())
         # Add observer after setup
         self.photoscan_to_volume_transform_node.AddObserver(slicer.vtkMRMLTransformNode.TransformModifiedEvent, self.onTransformModified)
+
+    def resetScalingTransform(self):
+        self.ui.scalingTransformMRMLSliderWidget.value = 1
+        self.updateScaledTransformNode()
+
+    def onRunICPRegistrationClicked(self):
+
+        self.photoscan_to_volume_transform_node.HardenTransform()
+        # Clone photoscan model node to harden transform since ICP uses the coordinate space of the model
+        photoscan_hardened = get_cloned_node(self.wizard().photoscan.model_node)
+        photoscan_hardened.SetAndObserveTransformNodeID(self.photoscan_to_volume_transform_node.GetID())
+        photoscan_hardened.HardenTransform()
+
+        self.photoscan_to_volume_icp_transform_node = self.wizard()._logic.run_icp_model_registration(
+            input_fixed_model = self.wizard().skin_mesh_node,
+            input_moving_model = photoscan_hardened)
+
+        self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_icp_transform_node.GetID())
+        self.photoscan_to_volume_transform_node.HardenTransform() # Combine ICP and initialization transform
         
+        # Remove hardened photoscan node and icp transform node
+        slicer.mrmlScene.RemoveNode(photoscan_hardened)
+        slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_icp_transform_node)
+
+        # Reset the photoscan to volume transform and now observe the ICP result
+        self.resetScalingTransform()
+        self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.scaling_transform_node.GetID())
+
     def onManualRegistrationClicked(self):
-        """ This is a temporary implementation that allows the user to manually edit the photoscan-volume transform. In the 
-        future, ICP registration will be integrated here. """
+        """ Enables the interaction handles on the transform, allowing the user to manually edit the photoscan-volume transform. """
+
         if not self.photoscan_to_volume_transform_node.GetDisplayNode().GetEditorVisibility():
 
             self.ui.enableManualPVRegistration.text = "Disable manual transform interaction"
-
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
             self.runningRegistration = True
             
             # For now, disable the approval and initialization button while in manual editing mode
             self.ui.initializePVRegistration.enabled = False
+            self.ui.runICPRegistrationPV.enabled = False
             self.ui.approveTransformButton.enabled = False
-
-            # Enabling scaling of transform node
-            self.ui.scalingTransformWidget.show()
 
         else:
             self.ui.enableManualPVRegistration.text = "Enable manual transform interaction"
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
             self.runningRegistration = False
             self.ui.initializePVRegistration.enabled = True if self.has_facial_landmarks else False
+            self.ui.runICPRegistrationPV.enabled = True
             self.ui.approveTransformButton.enabled = True
-            self.ui.scalingTransformWidget.hide()
 
         # Emit signal to update the enable/disable state of 'Next button'. 
         self.completeChanged()
@@ -685,7 +710,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
         scaling_value = self.ui.scalingTransformMRMLSliderWidget.value
         scaling_matrix = np.diag([scaling_value, scaling_value, scaling_value, 1])
-        self.scaledTransformNode.SetMatrixTransformToParent(numpy_to_vtk_4x4(scaling_matrix))
+        self.scaling_transform_node.SetMatrixTransformToParent(numpy_to_vtk_4x4(scaling_matrix))
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
@@ -900,7 +925,7 @@ class TransducerTrackingWizard(qt.QWizard):
                 get_approval_from_transducer_tracking_result_node(self.photoscan_to_volume_transform_node) 
                 and get_approval_from_transducer_tracking_result_node(self.transducer_to_volume_transform_node)
             ): #Flag to keep track of when approval is revoked and an existing result can be modified
-                self._existing_approval_revoked = True            
+                self._existing_approval_revoked = True    
         
     def customexec_(self):
         returncode = self.exec_()
@@ -1015,11 +1040,14 @@ class TransducerTrackingWizard(qt.QWizard):
         
         # Add the transducer tracking result nodes to the slicer scene
         # Shouldn't be able to get to this final stage without both transform nodes
-        if self.photoscanVolumeTrackingPage.scaledTransformNode and self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node:
-            self.photoscanVolumeTrackingPage.scaledTransformNode.HardenTransform() 
+        if self.photoscanVolumeTrackingPage.photoscan_to_volume_transform_node and self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node:
+            
+            # Remove observer
+            self.photoscanVolumeTrackingPage.photoscan_to_volume_transform_node.RemoveAllObservers()
+            self.photoscanVolumeTrackingPage.photoscan_to_volume_transform_node.HardenTransform() 
             
             self.photoscan_to_volume_transform_node, self.transducer_to_volume_transform_node = self._logic.add_transducer_tracking_result(
-                photoscan_to_volume_transform = self.photoscanVolumeTrackingPage.scaledTransformNode,
+                photoscan_to_volume_transform = self.photoscanVolumeTrackingPage.photoscan_to_volume_transform_node,
                 photoscan_to_volume_approval_state = self.photoscanVolumeTrackingPage.transform_approved,
                 transducer_to_volume_transform = self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node,
                 transducer_to_volume_approval_state = self.transducerPhotoscanTrackingPage.transform_approved,
@@ -1065,8 +1093,8 @@ class TransducerTrackingWizard(qt.QWizard):
         slicer.mrmlScene.RemoveNode(self.skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
 
         slicer.mrmlScene.RemoveNode(self.photoscanVolumeTrackingPage.photoscan_to_volume_transform_node)
-        slicer.mrmlScene.RemoveNode(self.photoscanVolumeTrackingPage.scaledTransformNode)
         slicer.mrmlScene.RemoveNode(self.transducerPhotoscanTrackingPage.transducer_to_volume_transform_node)
+        slicer.mrmlScene.RemoveNode(self.photoscanVolumeTrackingPage.scaling_transform_node)
 
     def setupViewNodes(self):
                 
@@ -2109,7 +2137,7 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
             fixed_landmarks: vtkMRMLMarkupsFiducialNode) -> vtkMRMLTransformNode:
         """Runs fiducial registration between the provided fixed and moving fiducial node landmarks and returns the result as a `vtkMRMLTransformNode`."""
         
-        fiducial_result_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+        fiducial_result_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode","fiducial_transform_result")
         fiducial_registration_cli = slicer.modules.fiducialregistration
         parameters = {}
         parameters["fixedLandmarks"] = fixed_landmarks
@@ -2118,6 +2146,44 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
         parameters["transformType"] = "Similarity"
         slicer.cli.run(fiducial_registration_cli, node = None, parameters = parameters, wait_for_completion = True, update_display = False)
         return fiducial_result_node
+
+    def run_icp_model_registration(
+        self,
+        input_fixed_model: vtkMRMLModelNode,
+        input_moving_model: vtkMRMLModelNode,
+        transformType: int = 1
+    ):
+        """Registers a moving model to a fixed model using the Iterative Closest Point (ICP) algorithm.
+        Note: This function operates directly on the point sets of the
+        input models and does not consider any parent transforms. Therefore,
+        both input models should be defined within the coordinate system intended for registration.
+
+        Args:
+            input_fixed_model (vtkMRMLModelNode): The fixed model (target) to which the moving model will be registered.
+            input_moving_model (vtkMRMLModelNode): The moving model (source) that will be transformed to align with the fixed model.
+            transformType (int, optional): The type of transformation to be estimated.
+                - 0: Rigid body transformation
+                - 1: Similarity transformation
+                - 2: Affine transformation 
+                Defaults to 1 (Similarity).
+
+        Returns:
+            vtkMRMLTransformNode or None: A new vtkMRMLTransformNode containing the computed
+            transformation that aligns the moving model with the fixed model. Returns None
+            if the registration fails. The transform node will be automatically added to the
+            scene.
+        """
+        
+        icp_result_node =  slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "icp_transform_result")
+        model_registration_logic = ModelRegistration.ModelRegistrationLogic()
+        model_registration_logic.run(
+            inputSourceModel = input_moving_model,
+            inputTargetModel = input_fixed_model,
+            outputSourceToTargetTransform = icp_result_node,
+            transformType = transformType
+        )
+
+        return icp_result_node
 
     def add_transducer_tracking_result(
         self,

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -515,6 +515,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             self.wizard().photoscanMarkupPage.facial_landmarks_fiducial_node
             and self.wizard().skinSegmentationMarkupPage.facial_landmarks_fiducial_node)
         if self.has_facial_landmarks:
+            self.ui.initializePVRegistration.enabled = True
             if self.photoscan_to_volume_transform_node:
                 self.ui.initializePVRegistration.setText("Re-initialize photoscan-volume transform")
                 self.ui.initializePVRegistration.setToolTip("Run fiducial-based registration between the photoscan mesh and skin surface.")

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -250,6 +250,9 @@ class FacialLandmarksMarkupPageBase(qt.QWizardPage):
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._valid_tt_result_exists = False
             self.wizard().photoscanVolumeTrackingPage.resetScalingTransform()
+            # Clear downstream nodes
+            slicer.mrmlScene.RemoveNode(self.wizard().photoscanVolumeTrackingPage.photoscan_to_volume_transform_node)
+            slicer.mrmlScene.RemoveNode(self.wizard().transducerPhotoscanTrackingPage.transducer_to_volume_transform_node)
             self.wizard().photoscanVolumeTrackingPage.photoscan_to_volume_transform_node = None
             self.wizard().transducerPhotoscanTrackingPage.transducer_to_volume_transform_node = None
 
@@ -272,12 +275,14 @@ class FacialLandmarksMarkupPageBase(qt.QWizardPage):
         return all_points_defined
 
     def isComplete(self):
-        if self.wizard()._valid_tt_result_exists:
+        if self.placingLandmarks:
+            return False
+        elif self.wizard()._valid_tt_result_exists:
             return True
         elif self.facial_landmarks_fiducial_node is not None:
-            return self._checkAllLandmarksDefined() and not self.placingLandmarks
+            return self._checkAllLandmarksDefined()
         else:
-            return not self.placingLandmarks
+            True
 
     # Abstract methods to be implemented by subclasses
     def initializePage(self):
@@ -610,7 +615,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
     def onInitializeRegistrationClicked(self):
         """ This function is called when the user clicks 'Next'."""
 
-        # Clear previous result
+        # Clear previous result if it exists
         slicer.mrmlScene.RemoveNode(self.photoscan_to_volume_transform_node) # Clear current result node if it exists (restarting process)
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._valid_tt_result_exists = False

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -473,7 +473,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.ui.dialogControls.setCurrentIndex(3)
 
         self.ui.approveTransformButton.clicked.connect(self.onTransformApproveClicked)
-        self.ui.runPhotoscanVolumeRegistration.clicked.connect(self.onRunRegistrationClicked)
+        self.ui.enableManualPVRegistration.clicked.connect(self.onManualRegistrationClicked)
         self.ui.initializePVRegistration.clicked.connect(self.onInitializeRegistrationClicked)
         self.runningRegistration = False
 
@@ -528,7 +528,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         if self.photoscan_to_volume_transform_node:
             self.setupTransformNode()
         else:
-            self.ui.runPhotoscanVolumeRegistration.enabled = False
+            self.ui.enableManualPVRegistration.enabled = False
             self.ui.approveTransformButton.enabled = False
             self.transform_approved = False
         
@@ -624,7 +624,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         self.ui.scalingTransformMRMLSliderWidget.value = 1
 
         # Enable approval and registration fine-tuning buttons
-        self.ui.runPhotoscanVolumeRegistration.enabled = True
+        self.ui.enableManualPVRegistration.enabled = True
         self.ui.approveTransformButton.enabled = True
 
     def setupTransformNode(self):
@@ -653,15 +653,12 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         # Add observer after setup
         self.photoscan_to_volume_transform_node.AddObserver(slicer.vtkMRMLTransformNode.TransformModifiedEvent, self.onTransformModified)
         
-    def onRunRegistrationClicked(self):
+    def onManualRegistrationClicked(self):
         """ This is a temporary implementation that allows the user to manually edit the photoscan-volume transform. In the 
         future, ICP registration will be integrated here. """
         if not self.photoscan_to_volume_transform_node.GetDisplayNode().GetEditorVisibility():
-    
-            self.ui.ICPPlaceholderLabel.text = "This run button is a placeholder. The transducer tracking algorithm is under development. " \
-            "Use the interaction handles to manually align the photoscan and volume mesh." \
-            "You can click the run button again to remove the interaction handles."
-            self.ui.ICPPlaceholderLabel.setProperty("styleSheet", "color: red;")
+
+            self.ui.enableManualPVRegistration.text = "Disable manual transform interaction"
 
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
             self.runningRegistration = True
@@ -674,7 +671,7 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
             self.ui.scalingTransformWidget.show()
 
         else:
-            self.ui.ICPPlaceholderLabel.text = ""
+            self.ui.enableManualPVRegistration.text = "Enable manual transform interaction"
             self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
             self.runningRegistration = False
             self.ui.initializePVRegistration.enabled = True if self.has_facial_landmarks else False

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>633</width>
-    <height>599</height>
+    <width>635</width>
+    <height>610</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -192,7 +192,7 @@
         <widget class="QWidget" name="PhotoscanVolumeTracking">
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
-           <widget class="QGroupBox" name="groupBox_3">
+           <widget class="QGroupBox" name="automatedRegistration">
             <property name="title">
              <string/>
             </property>
@@ -211,10 +211,22 @@
                </property>
               </widget>
              </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="ctkCollapsibleGroupBox" name="ManualRegistrationGroupBox">
+            <property name="title">
+             <string>Manual registration refinement</string>
+            </property>
+            <property name="collapsed">
+             <bool>true</bool>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_9">
              <item>
               <widget class="QPushButton" name="enableManualPVRegistration">
                <property name="text">
-                <string>Enable manual transform interaction </string>
+                <string>Enable interaction handles</string>
                </property>
               </widget>
              </item>
@@ -249,29 +261,6 @@
                 </item>
                </layout>
               </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="ICPPlaceholderLabel">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_6">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
              </item>
             </layout>
            </widget>
@@ -405,6 +394,12 @@
    <class>qSlicerSimpleMarkupsWidget</class>
    <extends>qSlicerWidget</extends>
    <header>qSlicerSimpleMarkupsWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>ctkSliderWidget</class>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -43,7 +43,7 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>1</number>
+         <number>3</number>
         </property>
         <widget class="QWidget" name="photoscanPreview">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -205,9 +205,16 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="runPhotoscanVolumeRegistration">
+              <widget class="QPushButton" name="runICPRegistrationPV">
                <property name="text">
                 <string>Run ICP-based registration fine-tuning</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="enableManualPVRegistration">
+               <property name="text">
+                <string>Enable manual transform interaction </string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Closes #326 

This PR updates the UI to include a 'Run ICP registration' button and includes the logic for performing ICP when the button is clicked. The ICP result fine-tunes the fiducial registration  result. ICP is run between the  full photoscan and skin segmentation mesh.

Running ICP involves interpolating additional control points on the photoscan surface using the 3 manually placed facial landmarks, using the interpolated points to extract a submesh of the face from the photoscan model, and running ICP using the submesh. 

There was a bug in the order in which transforms were being composed when applied to the photoscan mesh i.e. when composing the fiducial transform result with the scaling transform. This PR addresses that issue. 

### For review

- Test out the ICP button (only on the photoscan to volume tracking page) and check that the ICP runs and updates the photoscan mesh as expected.
- You should be able to manually edit the transform after fiducial registration or ICP
- A look over the code would also be help. In particular, error handling when calling the ICP registration logic. 
-(Feel free to play around with the wizard a little and make sure nothing was broken by the changes in this PR).

Types of isses to look out for: new wizard-related nodes visible in the slicer scene while the wizard is running, any temp wizard nodes remaining in the scene after exiting the wizard. 


