### PR TITLE
Validate protocols in the protocol config module

### DIFF
--- a/OpenLIFULib/OpenLIFULib/class_definition_widgets.py
+++ b/OpenLIFULib/OpenLIFULib/class_definition_widgets.py
@@ -940,9 +940,9 @@ class CreateAbstractClassDialog(qt.QDialog):
         top_level_layout.addWidget(self.buttonBox)
 
         self.buttonBox.rejected.connect(self.reject)
-        self.buttonBox.accepted.connect(self.objectidateInputs)
+        self.buttonBox.accepted.connect(self.validateInputs)
 
-    def objectidateInputs(self):
+    def validateInputs(self):
         """
         Ensure object is valid
         """

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import (
     List,
     Optional,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -42,7 +41,6 @@ from OpenLIFULib.util import (
 # but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
-    import openlifu.db
 
 #
 # OpenLIFUProtocolConfig

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -482,8 +482,14 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     @display_errors
     def onSaveProtocolToFileClicked(self, checked:bool) -> None:
+        # Try getting entered protocol object from GUI. If it fails, print an error.
+        try:
+            protocol: "openlifu.plan.Protocol" = self.getProtocolFromGUI(post_init=True)
+        except Exception as e:
+            slicer.util.errorDisplay(f"Could not save the protocol due to the following reason:\n{e}")
+            return
+
         initial_dir = slicer.app.defaultScenePath
-        protocol: "openlifu.plan.Protocol" = self.getProtocolFromGUI()
 
         safe_protocol_id = "".join(c if c.isalnum() or c in (' ', '-', '_') else "_" for c in protocol.id)
 
@@ -514,7 +520,12 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     @display_errors
     def onSaveProtocolToDatabaseClicked(self, checked: bool) -> None:
-        protocol: "openlifu.plan.Protocol" = self.getProtocolFromGUI()
+        # Try getting entered protocol object from GUI. If it fails, print an error.
+        try:
+            protocol: "openlifu.plan.Protocol" = self.getProtocolFromGUI(post_init=True)
+        except Exception as e:
+            slicer.util.errorDisplay(f"Could not save the protocol due to the following reason:\n{e}")
+            return
 
         if protocol.id == "":
             slicer.util.errorDisplay("You cannot save a protocol without entering in a Protocol ID.")

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -343,7 +343,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
         # Cache a WIP (other modules might load one)
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
-            protocol_changed = self.getProtocolFromGUI()
+            protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
 
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
@@ -412,7 +412,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     def onProtocolSelectorIndexChanged(self):
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
-            protocol_changed = self.getProtocolFromGUI()
+            protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
 
         protocol = self.ui.protocolSelector.currentData
@@ -566,7 +566,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         # You could load a non-cached protocol if you edit one, don't change
         # protocols, then load the same protocol
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
-            protocol_changed = self.getProtocolFromGUI()
+            protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
 
         qsettings = qt.QSettings()
@@ -593,7 +593,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         # You could load a non-cached protocol if you edit one, don't change
         # protocols, then load the same protocol
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
-            protocol_changed = self.getProtocolFromGUI()
+            protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
 
         if not get_cur_db():


### PR DESCRIPTION
Closes #324 

Newly created protocols run through validation algorithms defined in the `__post_init__`  method, both for the top-level `Protocol` class and all sub-objects. This PR officially handles thrown exceptions (i.e. for "out of bounds" attribute values) by displaying them to the researcher and failing to publish the Protocol to the database.

Caches skip the validation through an introduced utility `instantiate_without_post_init` that does not call `__init__`.

## For review

I already tested this by configuring protocols with values that cause `__post_init__` to fail ("erroneous values"). Caching protocols does not fail (via the utility with `post_init=False`). Then, when any "save" routine is performed, an explanation for a failed save is given via `errorDisplay`.

If you would like to test this, you can alternate between edited protocols with erroneous values. For instance, a `Sequence` with the following settings will fail `__post_init__`:
```
pulse_interval=1.0
pulse_count=4
pulse_train_interval=1.0
pulse_train_count=1
```