### PR TITLE
Harmonize TT wizard approval workflow

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1906,6 +1906,8 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         self.update_photocollections_affiliated_with_loaded_session()
 
         # Check if there are any photoscans with approved transducer tracking results
+        # TODO: This assumes a single approved photoscan per session. This check needs to be udpated to allow for 
+        # approved_photoscan_id containing multiple photoscan IDs. 
         approved_photoscan_id = self.getParameterNode().loaded_session.get_transducer_tracking_approvals()
         if approved_photoscan_id:
             approved_photoscan_id = approved_photoscan_id[0]

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1306,7 +1306,6 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
                     + (f"{num_vf_approved} targets" if num_vf_approved > 1 else f"target \"{approved_vf_targets[0]}\"")
                 )
 
-            # TODO: Fix this later.
             approved_tt_photoscans = self.logic.get_transducer_tracking_approvals_in_session()
             num_tt_approved = len(approved_tt_photoscans)
             if num_tt_approved > 0:

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -212,9 +212,9 @@ class SlicerOpenLIFUSession:
 
         return self.session.session
 
-    def get_transducer_tracking_approvals(self, approved_photoscans_only = False) -> List[str]:
+    def get_transducer_tracking_approvals(self) -> List[str]:
         """Get the transducer tracking approval state in the current session object, a list of photoscan IDs for which
-        transducer tracking is approved. If approved_photoscans_only is True, only the photoscan IDs with approval are returned.
+        transducer tracking is approved.
         """
         session_openlifu = self.session.session
         approved_tt_results = [
@@ -224,15 +224,7 @@ class SlicerOpenLIFUSession:
             and tt_result.photoscan_to_volume_tracking_approved
             ]
         
-        if approved_photoscans_only:
-            approved_tt_photoscans = [
-            photoscan.id
-            for photoscan in self.get_affiliated_photoscans()
-            if photoscan.photoscan_approved
-            and any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)
-            ]
-        else:
-            approved_tt_photoscans = [
+        approved_tt_photoscans = [
             photoscan.id
             for photoscan in self.get_affiliated_photoscans()
             if any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -214,7 +214,7 @@ class SlicerOpenLIFUSession:
 
     def get_transducer_tracking_approvals(self, approved_photoscans_only = False) -> List[str]:
         """Get the transducer tracking approval state in the current session object, a list of photoscan IDs for which
-        transducer tracking is approved. If approved_photoscans_only is True, only the photoscan ID with approval is returned.
+        transducer tracking is approved. If approved_photoscans_only is True, only the photoscan IDs with approval are returned.
         """
         session_openlifu = self.session.session
         approved_tt_results = [
@@ -237,9 +237,6 @@ class SlicerOpenLIFUSession:
             for photoscan in self.get_affiliated_photoscans()
             if any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)
             ]
-        # TODO: I think just removing this check should allow this function to return a list of multiple approved photoscan ID
-        if len(approved_tt_photoscans) > 1:
-            raise RuntimeError("Multiple  photoscans with approved transducer tracking results detected (IDs: {approved_photoscans}). Only one tracking result should be approved per session.")
 
         return approved_tt_photoscans
     

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -237,6 +237,7 @@ class SlicerOpenLIFUSession:
             for photoscan in self.get_affiliated_photoscans()
             if any(photoscan.id == tt_result.photoscan_id for tt_result in approved_tt_results)
             ]
+        # TODO: I think just removing this check should allow this function to return a list of multiple approved photoscan ID
         if len(approved_tt_photoscans) > 1:
             raise RuntimeError("Multiple  photoscans with approved transducer tracking results detected (IDs: {approved_photoscans}). Only one tracking result should be approved per session.")
 

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -194,7 +194,7 @@ class SlicerOpenLIFUTransducer:
         query_transform_node.GetMatrixTransformToParent(query_transform_matrix)
 
         is_matching = (
-            slicer.util.arrayFromVTKMatrix(current_transform_matrix) == slicer.util.arrayFromVTKMatrix(query_transform_matrix)
-            ).all()
+            np.isclose(slicer.util.arrayFromVTKMatrix(current_transform_matrix), slicer.util.arrayFromVTKMatrix(query_transform_matrix))
+        ).all()
         
         return is_matching

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -784,6 +784,9 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
         self.wizard().updateCurrentPageLockButton(locked = self.page_locked)
         self.ui.controlsWidget.enabled = not self.page_locked
 
+        if self.runningRegistration:
+            self.disable_manual_registration()
+
     def onTransformModified(self, node, eventID,):
         
         # If the transform node was initialized based on a previously computed tt result, modifying the transform
@@ -816,22 +819,28 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
         """ This allows the user to manually edit the transducer-volume transform. """
         
         if not self.transducer_to_volume_transform_node.GetDisplayNode().GetEditorVisibility():
-            self.ui.enableManualTPRegistration.text = "Disable manual transform interaction"
-            self.transducer_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
-            self.runningRegistration = True
-            # For now, disable the approval and initialization button while in manual editing mode
-            self.ui.initializeTPRegistration.enabled = False
-            self.ui.runICPRegistrationTP.enabled = False
+            self.enable_manual_registration()
         else:
-            self.ui.enableManualTPRegistration.text = "Enable manual transform interaction"
-            self.transducer_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
-            self.runningRegistration = False
-            self.ui.initializeTPRegistration.enabled = True
-            self.ui.runICPRegistrationTP.enabled = True
+            self.disable_manual_registration()
     
         # Emit signal to update the enable/disable state of 'Finish' button. 
         self.completeChanged()
     
+    def enable_manual_registration(self):
+        self.ui.enableManualTPRegistration.text = "Disable manual transform interaction"
+        self.transducer_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
+        self.runningRegistration = True
+        # For now, disable the approval and initialization button while in manual editing mode
+        self.ui.initializeTPRegistration.enabled = False
+        self.ui.runICPRegistrationTP.enabled = False
+
+    def disable_manual_registration(self):
+        self.ui.enableManualTPRegistration.text = "Enable manual transform interaction"
+        self.transducer_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
+        self.runningRegistration = False
+        self.ui.initializeTPRegistration.enabled = True
+        self.ui.runICPRegistrationTP.enabled = True
+
     def onRunICPRegistrationClicked(self):
 
         # Harden the photoscan to volume registration result

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1659,9 +1659,9 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             if transducer.surface_model_node is None: # Check that the selected transducer has an affiliated registration surface model
                 self.ui.runTrackingButton.enabled = False
                 self.ui.runTrackingButton.setToolTip("The selected transducer does not have an affiliated registration surface model, which is needed to run tracking.")
-            elif get_guided_mode_state() and (photoscan and not photoscan.photoscan_approved): # GM: Check that the selected photoscan is approved
-                self.ui.runTrackingButton.enabled = False 
-                self.ui.runTrackingButton.setToolTip("The selected photoscan has not been approved for transducer tracking.")
+            # elif get_guided_mode_state() and (photoscan and not photoscan.photoscan_approved): # GM: Check that the selected photoscan is approved
+            #     self.ui.runTrackingButton.enabled = False
+            #     self.ui.runTrackingButton.setToolTip("The selected photoscan has not been approved for transducer tracking.")
             elif get_guided_mode_state() and (target and not target_is_approved): # GM: Check that virtual fit is approved for the selected target
                 self.ui.runTrackingButton.enabled = False
                 self.ui.runTrackingButton.setToolTip("Virtual fit has not been approved for the selected target.")

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -347,7 +347,6 @@ class PhotoscanMarkupPage(FacialLandmarksMarkupPageBase):  # Inherit from the ba
         #If the result in the scene remains valid, i.e. points aren't modified, the existing approval can be toggled. 
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._existing_approval_revoked = not self.wizard()._existing_approval_revoked
-        # self.wizard().updateWarningLabel()
 
         if not self.page_locked:
             self.facial_landmarks_fiducial_node.SetLocked(False)
@@ -430,7 +429,6 @@ class SkinSegmentationMarkupPage(FacialLandmarksMarkupPageBase):  # Inherit from
         #If the result in the scene remains valid, i.e. points aren't modified, the existing approval can be toggled. 
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._existing_approval_revoked = not self.wizard()._existing_approval_revoked
-        # self.wizard().updateWarningLabel()
 
         if not self.page_locked:
             self.facial_landmarks_fiducial_node.SetLocked(False)
@@ -553,7 +551,6 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._existing_approval_revoked = not self.wizard()._existing_approval_revoked
         self.completeChanged()
-        # self.wizard().updateWarningLabel()
 
     def updatePageLock(self):
 
@@ -754,7 +751,6 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
         if self.wizard()._valid_tt_result_exists:
             self.wizard()._existing_approval_revoked = not self.wizard()._existing_approval_revoked
         self.completeChanged()
-        # self.wizard().updateWarningLabel()
 
     def updatePageLock(self):
 
@@ -978,29 +974,6 @@ class TransducerTrackingWizard(qt.QWizard):
         
         # Reset the wizard volume view node based on the display settings
         reset_view_node_camera(self.volume_view_node)
-        # self.updateWarningLabel()
-
-    # def updateWarningLabel(self):
-
-    #     current_page = self.page(self.currentId)
-    #     # Trigger an update of the warning label on the relevant wizard page
-    #     if self._existing_approval_revoked:
-    #         text = "WARNING: Modifying a previously approved tracking result!"
-    #     else:
-    #         text = ""
-        
-    #     if isinstance(current_page, PhotoscanMarkupPage):
-    #             self.photoscanMarkupPage.ui.warningTrackingResultLabel.text = text
-    #             self.photoscanMarkupPage.ui.warningTrackingResultLabel.styleSheet = "color:red;"
-    #     elif isinstance(current_page, SkinSegmentationMarkupPage):
-    #         self.skinSegmentationMarkupPage.ui.warningTrackingResultLabel.text = text
-    #         self.skinSegmentationMarkupPage.ui.warningTrackingResultLabel.styleSheet = "color:red;"
-    #     elif isinstance(current_page, PhotoscanVolumeTrackingPage):
-    #         self.photoscanVolumeTrackingPage.ui.warningTrackingResultLabel.text = text
-    #         self.photoscanVolumeTrackingPage.ui.warningTrackingResultLabel.styleSheet = "color:red;"
-    #     elif isinstance(current_page, TransducerPhotoscanTrackingPage):
-    #         self.transducerPhotoscanTrackingPage.ui.warningTrackingResultLabel.text = text
-    #         self.transducerPhotoscanTrackingPage.ui.warningTrackingResultLabel.styleSheet = "color:red;"
 
     def updateCurrentPageLockButton(self, locked = False):
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
 class FacialLandmarksMarkupPageBase(qt.QWizardPage):
     def __init__(self, parent=None):
         super().__init__(parent)
+        # TODO: This placelandmarks flag can probably be removed now. Since the self.page_locked flag conveys that same information.
         self.placingLandmarks = False
         self._pointModifiedObserverTag = None
         self._currentlyPlacingIndex = -1
@@ -884,9 +885,9 @@ class TransducerTrackingWizard(qt.QWizard):
             photoscan_id = self.photoscan.get_id(),
             transform_type = TransducerTrackingTransformType.TRANSDUCER_TO_VOLUME)
         
-        self._existing_approval_revoked = False
+        self._existing_approval_revoked = False # This flag gets set to True when the user `unlocks` a page to allow editing of a valid tt result. 
         if self.photoscan_to_volume_transform_node and self.transducer_to_volume_transform_node:
-            self._valid_tt_result_exists = True
+            self._valid_tt_result_exists = True # This flag gets set to False when the existing tt result is invalidated i.e. a point is modified or transform is modified.
             if not (
                 get_approval_from_transducer_tracking_result_node(self.photoscan_to_volume_transform_node) 
                 and get_approval_from_transducer_tracking_result_node(self.transducer_to_volume_transform_node)
@@ -1047,10 +1048,10 @@ class TransducerTrackingWizard(qt.QWizard):
                 photoscan_id = self.photoscan.get_id(),
                 transducer = self.transducer)
 
-                # Update the approval status of the associated openlifu photoscan object
-                self._logic.update_photoscan_approval(
-                    photoscan = self.photoscan,
-                    approval_state = True)
+            # Update the approval status of the associated openlifu photoscan object
+            self._logic.update_photoscan_approval(
+                photoscan = self.photoscan,
+                approval_state = True)
 
         else:
             raise RuntimeError("Something went wrong. You should not be able to complete the wizard without creating transducer tracking transforms.")
@@ -1901,6 +1902,7 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
 
         if current_state != approval_state: # If the approval state has changed
 
+            # TODO: Remove this constraint of only one approved photoscan per session. Might just need to remove this check. 
             # Check that the session doesn't have another approved photoscan
             if approval_state and session: # Only a single photoscan in a session can be approved
                 approved_photoscans = self.get_photoscan_ids_with_approval()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1901,20 +1901,6 @@ class OpenLIFUTransducerTrackerLogic(ScriptedLoadableModuleLogic):
         current_state = photoscan.is_approved()
 
         if current_state != approval_state: # If the approval state has changed
-
-            # TODO: Remove this constraint of only one approved photoscan per session. Might just need to remove this check. 
-            # Check that the session doesn't have another approved photoscan
-            if approval_state and session: # Only a single photoscan in a session can be approved
-                approved_photoscans = self.get_photoscan_ids_with_approval()
-                if approved_photoscans:
-                    if len(approved_photoscans) > 1:
-                        raise RuntimeError("Multiple approved photoscans detected (IDs: {approved_photoscans}). Only one should be approved per session.")
-                    slicer.util.infoDisplay(
-                    text= f"Only one photoscan can be approved per session. Photoscan ID {approved_photoscans[0]} is already approved. Revoke it to approve another.",
-                    windowTitle="Approved photoscan exists"
-                    )
-                    return
-
             photoscan.set_approval(approval_state = approval_state)
             # Update the loaded SlicerOpenLIFUPhotoscan.
             data_parameter_node.loaded_photoscans[photoscan.get_id()] = photoscan 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -551,6 +551,9 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
         self.wizard().updateCurrentPageLockButton(locked = self.page_locked)
         self.ui.controlsWidget.enabled = not self.page_locked
+
+        if self.runningRegistration:
+            self.disable_manual_registration()
     
     def update_runICPRegistrationPV_button(self):
         """Update enabledness and tooltip of the 'Run ICP' button"""
@@ -691,24 +694,30 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
         """ Enables the interaction handles on the transform, allowing the user to manually edit the photoscan-volume transform. """
 
         if not self.photoscan_to_volume_transform_node.GetDisplayNode().GetEditorVisibility():
-
-            self.ui.enableManualPVRegistration.text = "Disable manual transform interaction"
-            self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
-            self.runningRegistration = True
-            
-            # For now, disable the approval and initialization button while in manual editing mode
-            self.ui.initializePVRegistration.enabled = False
-
+            self.enable_manual_registration()
         else:
-            self.ui.enableManualPVRegistration.text = "Enable manual transform interaction"
-            self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
-            self.runningRegistration = False
-            self.ui.initializePVRegistration.enabled = True if self.has_facial_landmarks else False
-        
-        self.update_runICPRegistrationPV_button()
+            self.disable_manual_registration()
 
         # Emit signal to update the enable/disable state of 'Next button'. 
         self.completeChanged()
+    
+    def enable_manual_registration(self):
+        self.ui.enableManualPVRegistration.text = "Disable manual transform interaction"
+        self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(True)
+        self.runningRegistration = True
+
+        # For now, disable the approval and initialization button while in manual editing mode
+        self.ui.initializePVRegistration.enabled = False
+
+        self.update_runICPRegistrationPV_button()
+    
+    def disable_manual_registration(self):
+        self.ui.enableManualPVRegistration.text = "Enable manual transform interaction"
+        self.photoscan_to_volume_transform_node.GetDisplayNode().SetEditorVisibility(False)
+        self.runningRegistration = False
+        self.ui.initializePVRegistration.enabled = True if self.has_facial_landmarks else False
+
+        self.update_runICPRegistrationPV_button()
     
     def updateScaledTransformNode(self):
 

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -223,19 +223,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="warningTrackingResultLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>(placeholder warning message)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QWidget" name="lockPanel" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -342,6 +342,32 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QWidget" name="lockPanel" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>770</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QToolButton" name="pageLockButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -43,7 +43,7 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>4</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="photoscanPreview">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -53,26 +53,6 @@
              <string/>
             </property>
            </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="photoscanApprovalButton">
-            <property name="text">
-             <string>Approve Photoscan</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -43,19 +43,8 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
-        <widget class="QWidget" name="photoscanPreview">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QLabel" name="photoscanApprovalStatusLabel">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
         <widget class="QWidget" name="photoscanMarkup">
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -79,20 +79,6 @@
         <widget class="QWidget" name="photoscanMarkup">
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QLabel" name="photoscanApprovalStatusLabel_Markup">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="placeLandmarksButton">
-            <property name="text">
-             <string>Place/Edit Registration Landmarks</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QLabel" name="landmarkPlacementStatus">
             <property name="text">
              <string/>
@@ -121,30 +107,10 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="skinSegmentationMarkup">
          <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QPushButton" name="placeLandmarksButtonSkinSeg">
-            <property name="text">
-             <string>Place/Edit Registration Landmarks</string>
-            </property>
-           </widget>
-          </item>
           <item>
            <widget class="QLabel" name="landmarkPlacementStatus_2">
             <property name="text">
@@ -174,19 +140,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="PhotoscanVolumeTracking">
@@ -211,7 +164,7 @@
              <string>Manual registration refinement</string>
             </property>
             <property name="collapsed">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_9">
              <item>
@@ -280,7 +233,7 @@
              <string>Manual registration refinement</string>
             </property>
             <property name="collapsed">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_12">
              <item>
@@ -295,35 +248,6 @@
           </item>
          </layout>
         </widget>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="trackingApprovalWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_10">
-      <item>
-       <widget class="QPushButton" name="approveTransformButton">
-        <property name="text">
-         <string>Approve tracking result</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="approvalStatusLabel">
-        <property name="text">
-         <string>(placeholder approval status)</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Closes #322 

- Removes approval toggling from the photoscan preview wizard
- Adds a lock button to each page of the wizard which acts as an approval button. The final tracking result is saved and approved when the user clicks `Approve` on the last page. This also approves the associated photoscan
- Updates session-workflow to allows for multiple approved photoscans per session
-  Removes warning label when modifying previous tracking result