### PR TITLE
Fix protocols saved via the protocol configuration module not being able to be used for solution computation

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-openlifu==0.3.1
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@0e09d41ae8eb862319de0598187687db21b3081b
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/class_definition_widgets.py
+++ b/OpenLIFULib/OpenLIFULib/class_definition_widgets.py
@@ -455,7 +455,7 @@ class OpenLIFUAbstractDataclassDefinitionFormWidget(qt.QWidget):
     DEFAULT_INT_RANGE = (-1_000_000, 1_000_000)
     DEFAULT_FLOAT_VALUE = 0.
     DEFAULT_FLOAT_RANGE = (-1e6, 1e6)
-    DEFAULT_FLOAT_NUM_DECIMALS = 4
+    DEFAULT_FLOAT_NUM_DECIMALS = 8
 
     def __init__(self, cls: Type[Any], parent: Optional[qt.QWidget] = None, is_collapsible: bool = True, collapsible_title: Optional[str] = None):
         """

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1199,7 +1199,7 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
                 "Mechanical Index (MI)": "MI",
                 "Mainlobe PNP (MPa)": "mainlobe_pnp_MPa",
                 "Mainlobe I_SPPA (W/cm^2)": "mainlobe_isppa_Wcm2",
-                "Mainlobe I_SPTA (W/cm^2)": "mainloba_ispta_Wcm2",
+                "Mainlobe I_SPTA (W/cm^2)": "mainlobe_ispta_Wcm2",
                 "3 dB Lateral Beamwidth (mm)": "beamwidth_lat_3dB_mm",
                 "3 dB Elevational Beamwidth (mm)": "beamwidth_ele_3dB_mm",
                 "3 dB Axial Beamwidth (mm)": "beamwidth_ax_3dB_mm",

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1087,7 +1087,7 @@ class OpenLIFUAbstractApodizationMethodDefinitionFormWidget(OpenLIFUAbstractMult
         max_angle_spinbox = maxangle_definition_form_widget._field_widgets['max_angle']
         maxangle_definition_form_widget.modify_widget_spinbox(max_angle_spinbox, default_value=30, min_value=0, max_value=90)
 
-def _get_form_as_segmentation_method(self):
+def _get_form_as_segmentation_method(self, post_init: bool = True):
     """
     Custom replacement for get_form_as_class, used to override
     widgets inside the segmentation method form.
@@ -1098,7 +1098,11 @@ def _get_form_as_segmentation_method(self):
     if self._cls.__name__ in ["UniformWater", "UniformTissue"]:
         d.pop("ref_material")
 
-    return self._cls(**d)
+    if post_init:
+        return self._cls(**d)
+    else:
+        return instantiate_without_post_init(self._cls, **d)
+
 
 class OpenLIFUAbstractSegmentationMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
 

--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -274,13 +274,13 @@ OpenLIFUAbstractApodizationMethodDefinitionWidget</string>
            </widget>
           </item>
           <item>
-           <widget class="QWidget" name="segmentationMethodDefinitionWidgetPlaceholder" native="true">
+           <widget class="QWidget" name="abstractSegmentationMethodDefinitionWidgetPlaceholder" native="true">
             <layout class="QVBoxLayout" name="verticalLayout_13">
              <item>
-              <widget class="QLabel" name="segmentationMethodDefinitionWidgetPlaceholderLabel">
+              <widget class="QLabel" name="abstractSegmentationMethodDefinitionWidgetPlaceholderLabel">
                <property name="text">
                 <string>Placeholder for an
-OpenLIFUSegmentationMethodDefinitionWidget</string>
+OpenLIFUAbstractSegmentationMethodDefinitionWidget</string>
                </property>
               </widget>
              </item>

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -311,7 +311,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateInputOptions()
 
     @display_errors
-    def onComputeSolutionClicked(self):
+    def onComputeSolutionClicked(self, checked:bool):
         activeData = self.algorithm_input_widget.get_current_data()
 
         # In case a PNP was previously being displayed, hide it since it is about to no longer belong to the active solution.


### PR DESCRIPTION
Closes #318 

Addresses the new structure of `SegmentationMethod` and some cases in which an existing protocol had decimal values set to 0 due to a lack of precision in the GUI. Note that for this last case, an issue was opened in [OpenLIFU-python#302](https://github.com/OpenwaterHealth/OpenLIFU-python/issues/302), which is the correct place to address the possibility of setting a `Pulse.duration` to 0 in the protocol config module. Protocols configured in the protocol config module can now be used for solution computation.

## For review

Try using the protocol configuration module to set some parameters and possibly experiment with some random interesting parameter constraints. Then compute a sonication solution.