### PR TITLE
Add protocol validity indicator

### DIFF
--- a/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
+++ b/OpenLIFUProtocolConfig/Resources/UI/OpenLIFUProtocolConfig.ui
@@ -365,6 +365,13 @@ OpenLIFUVirtualFitOptionsDefinitionWidget</string>
        <widget class="ctkDynamicSpacer" name="DynamicSpacer"/>
       </item>
       <item>
+       <widget class="QLabel" name="protocolValidityIndicator">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="saveStateLabel">
         <property name="alignment">
          <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Closes #334 

This adds a simple validity indicator which checks that when a field is edited, whether it would produce an erroneous value. 

## For review:

A code review should be good enough, but you can also try dynamically changing some values in the protocol configuration and checking that any exceptions that would be thrown are reported at the bottom. You can try switching between protocols that have/don't have errors and fixing your errors, and *before saving*, you should know that your protocol has at least one error.

**Note**: We do not add the ability to list all the errors because some exceptions are thrown in control flow within `__post_init__`; some exceptions involving objects such as `Sequence` are raised in a mutually exclusive manner. If desired, we can still attempt to handle exceptions by collecting them in a list and then print them all, but this was omitted for now. This also potentially leads to an arbitrary long list of exceptions that would stretch the label until blocking other UI elements. Therefore the language is clear by [saying "at least one error,"](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/353/commits/e112a4194bb85e6dfc59deab1dbed5df5ad7e815#diff-0416f7e8759becf4cc7996173be0ce7660701c1c218c3e38dd9b878f465c154fR834) and in this PR, we only list one exception.

## Before merging:

- [x] Make sure to merge PR #332 , which closes #324 . This branches off of that code as they handle very similar functions in the codebase.  Once PR #332 is merged, rebase this to main and then merge.