### PR TITLE
Give default admin when no db connected

### DIFF
--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -861,7 +861,10 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
             self.ui.loginStateNotificationLabel.setProperty("text", f"Welcome, {self.logic.active_user.name}!")
             self.ui.loginStateNotificationLabel.setProperty("styleSheet", f"color: {text_color}; font-weight: bold; font-size: 16px; border: none;")
         elif self._cur_login_state == LoginState.DEFAULT_ADMIN:
-            self.ui.loginStateNotificationLabel.setProperty("text", f"Welcome! Please connect a database with an admin account for user accounts to work.")
+            self.ui.loginStateNotificationLabel.setProperty("text",
+                "Welcome! You currently have root permissions. "
+                "Connect to a database and add an admin account for user account permissions to engage across the application."
+            )
 
     def updateUserAccountModeButton(self):
         if self._parameterNode.user_account_mode:


### PR DESCRIPTION
Closes #354 

This also makes simple refactorings and edits to comments and typos in displayed strings.

## For review

Code review should be enough. However, if interested in trying, start the app, skip connecting a db, and activate user account mode. You should be a superuser (i.e. have admin privileges despite a DB not being connected).

## After merging
- [ ] Close [OpenLIFU-app#39](https://github.com/OpenwaterHealth/OpenLIFU-app/issues/39) in a commit that updates the SlicerOpenLIFU revision, as this PR should address it