### PR TITLE
Set transducer module color to matching transform type

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1833,6 +1833,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             transducer_matrix_units = session_openlifu.array_transform.units,
             replace_confirmed = True,
         )
+        newly_loaded_transducer.set_visibility(False)
 
         # === Load protocol ===
 
@@ -1861,6 +1862,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             # transform matches the virtual fit result in terms of matrix values.
             if int(vf_node.GetAttribute("VF:rank")) == 1 and newly_loaded_transducer.is_matching_transform(vf_node):
                 newly_loaded_transducer.set_matching_transform(vf_node)
+                newly_loaded_transducer.set_visibility(True)
 
         # === Load transducer tracking results ===
 
@@ -1925,6 +1927,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 if current_photoscan_id == approved_photoscan_id:
                     if newly_loaded_transducer.is_matching_transform(transducer_to_volume_node):
                         newly_loaded_transducer.set_matching_transform(transducer_to_volume_node)
+                        newly_loaded_transducer.set_visibility(True)
                     else:
                         transducer_tracking_widget.revokeTransducerTrackingApprovalIfAny(
                             photoscan_id=approved_photoscan_id,

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1856,6 +1856,11 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
             # Place virtual fit results under the transducer folder
             newly_loaded_transducer.move_node_into_transducer_sh_folder(vf_node)
+            
+            # For the best virtual fit result nodes, check if the current transducer
+            # transform matches the virtual fit result in terms of matrix values.
+            if int(vf_node.GetAttribute("VF:rank")) == 1 and newly_loaded_transducer.is_matching_transform(vf_node):
+                newly_loaded_transducer.set_matching_transform(vf_node)
 
         # === Load transducer tracking results ===
 
@@ -1919,7 +1924,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 current_photoscan_id = get_photoscan_id_from_transducer_tracking_result(transducer_to_volume_node)
                 if current_photoscan_id == approved_photoscan_id:
                     if newly_loaded_transducer.is_matching_transform(transducer_to_volume_node):
-                        newly_loaded_transducer.set_current_transform_to_match_transform_node(transducer_to_volume_node)
+                        newly_loaded_transducer.set_matching_transform(transducer_to_volume_node)
                     else:
                         transducer_tracking_widget.revokeTransducerTrackingApprovalIfAny(
                             photoscan_id=approved_photoscan_id,

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
 
 # Define transducer color dictionary
 TRANSDUCER_MODEL_COLORS = {
-    "default": [230, 230, 77], # yellow
-    "virtual_fit_result": [255, 170, 0], # orange
-    "transducer_tracking_result": [255, 0, 0], # red
+    "default": [230, 230, 77], # YELLOW
+    "virtual_fit_result": [0, 85, 255], # BLUE
+    "transducer_tracking_result": [0, 170, 0], # GREEN
 }
 
 @parameterPack

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -224,3 +224,12 @@ class SlicerOpenLIFUTransducer:
         ).all()
         
         return is_matching
+    
+    def set_visibility(self, visibility: bool):
+        """Sets the visibility of any model nodes associated with the transducer"""
+
+        self.model_node.GetDisplayNode().SetVisibility(visibility)
+        if self.body_model_node:
+            self.body_model_node.GetDisplayNode().SetVisibility(visibility)
+        if self.surface_model_node:
+            self.surface_model_node.GetDisplayNode().SetVisibility(visibility)

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -105,7 +105,7 @@ def get_virtual_fit_result_nodes(
         raise ValueError("It does not make sense to both sort by rank and retrieve only rank 1 results.")
 
     vf_result_nodes : Iterable[vtkMRMLTransformNode] = [
-        t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if t.GetAttribute("isVirtualFitResult") == "1"
+        t for t in slicer.util.getNodesByClass('vtkMRMLTransformNode') if is_virtual_fit_result_node(t)
     ]
 
     if session_id is not None:
@@ -325,3 +325,10 @@ def get_target_id_from_virtual_fit_result_node(node : vtkMRMLTransformNode) -> s
     if node.GetAttribute("VF:targetID") is None:
         raise RuntimeError("Node does not have a target ID.")
     return node.GetAttribute("VF:targetID")
+
+def is_virtual_fit_result_node(transform_node: vtkMRMLTransformNode) -> bool:
+    """Returns True if the given node is a virtual fit result node"""
+    if transform_node.GetAttribute("isVirtualFitResult") == "1":
+        return True
+    else:
+        return False

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -610,6 +610,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             # TODO: Make the virtual fit button both update the transducer transform and populate in the virtual fit results
             activeData["Transducer"].set_current_transform_to_match_transform_node(virtual_fit_result)
             self.watchVirtualFit(virtual_fit_result)
+            activeData["Transducer"].set_visibility(True)
 
         self.updateApproveButton()
         self.updateApprovalStatusLabel()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1729,6 +1729,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.watchTransducerTrackingNode(transducer_to_volume_transform_node)
             # Set the current transducer transform node to the transducer tracking result.
             selected_transducer.set_current_transform_to_match_transform_node(transducer_to_volume_transform_node)
+            selected_transducer.set_visibility(True)
             self.updateWorkflowControls()
 
     def watchTransducerTrackingNode(self, transducer_tracking_transform_node: vtkMRMLTransformNode):


### PR DESCRIPTION
Closes #361 

Sets the transducer model (incl. body and surface) display color to indicate the matching transform. The default model color is yellow. The transducer model is blue (when matching VF result) and green (when matching TT result). When loading a session, the transducer is hidden if it does not match VF or TT. However, manually loaded transducers (i.e. using the 'Load Transducer') button are always shown. 

### For Review

- After running virtual fit, the transducer model should turn blue
- After running transducer tracking, the transducer model should turn green
- If you manually change the current transducer transform (i.e. by editing the transform in the transform module or using interaction handles), the transducer model should turn back to yellow. (And transducer tracking approval is revoked if applicable).
- When you load a session, if the transducer transform matches either the virtual fit result or transducer tracking result, the model color should change to blue or green respectively and get displayed in the scene. Transducer visibility is turned off otherwise. 
