### PR TITLE
Hide user account mode banner in guided mode (#344)

### DIFF
--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -59,6 +59,8 @@ class UserAccountBanner(qt.QWidget):
         group_layout.addWidget(self.go_to_login_button)
 
         top_level_layout.addWidget(group_box)  # Add the group box to the top_level_layout
+
+        self.setProperty("slicer.openlifu.hide-in-guided-mode", True)  # dynamic property to hide in guided mode
     
     def change_active_user(self, new_active_user: Optional["openlifu.db.User"]):
         if new_active_user is None or new_active_user.id == "anonymous":


### PR DESCRIPTION
Closes #344 

This adds the `slicer.openlifu.hide-in-guided-mode` property set to `True` to all `UserAccountBanner`s at the end of their construction. The current intended guided mode experience is that the banner is hidden.

Note: If `enforceGuidedModeVisibility()` is called before the `UserAccountBanner`s are inserted into each module, they will fail to be hidden.

## For review:

Read the "Note" above. Then, review the code.

I have noticed in testing that the banners are always removed when enabling guided mode, so things work as expected. In the custom app, I suspect things will behave likewise, as the algorithm inputs *also* are added in via `replace_widget` (so the "Note" above applies to algorithm input widgets as well). The algorithm inputs do not fail to enforce guided mode visibility in the custom app.