### PR TITLE
Organize interaction between virtual fit and transducer tracking

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1940,6 +1940,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
         slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason="The transducer was moved.")
+        slicer.util.getModuleWidget('OpenLIFUTransducerTracker').updateVirtualFitResultForDisplay()
 
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:
@@ -1954,6 +1955,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 )
             
             transducer.set_matching_transform(None)
+
 
     def load_protocol_from_file(self, filepath:str) -> None:
         protocol = openlifu_lz().Protocol.from_file(filepath)

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-openlifu==v0.5.0
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@f2675d15d82844d2fce6323e493f9a2fe6e683e8
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@f2675d15d82844d2fce6323e493f9a2fe6e683e8
+openlifu==v0.6.0
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -153,6 +153,7 @@ class SlicerOpenLIFUSession:
         # Load targets
         target_nodes = [openlifu_point_to_fiducial(target) for target in session.targets]
 
+
         return SlicerOpenLIFUSession(SlicerOpenLIFUSessionWrapper(session), volume_node, target_nodes)
 
     def set_affiliated_photocollections(self, affiliated_photocollections : List[str]):

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -30,6 +30,7 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLMo
     normalized_color = [c / 255.0 for c in model_color]
     skin_mesh_node.GetDisplayNode().SetColor(normalized_color)
     skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
+    skin_mesh_node.GetDisplayNode().SetSelectable(False)
 
     return skin_mesh_node
 

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -3,14 +3,57 @@
 from OpenLIFULib.lazyimport import openlifu_lz
 from slicer import vtkMRMLScalarVolumeNode, vtkMRMLModelNode
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
+from OpenLIFULib.transducer import TRANSDUCER_MODEL_COLORS
 import slicer
+from typing import Union
 
-def generate_skin_mesh(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLModelNode:
+def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLModelNode:
+    """Computes the skin segmentation for the given volume. The ID of the volume node used to create the 
+    skin segmentation is added as a model node attribute. Note, this is different from the openlifu volume id.
+    """
     volume_array = slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)) # the array indices come in KJI rather than IJK so we permute them
     volume_affine_RAS = get_IJK2RAS(volume_node)
-    foreground_mask_array = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
-    foreground_mask_vtk_image = openlifu_lz().seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
-    skin_mesh = openlifu_lz().seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
-    skin_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
-    skin_node.SetAndObservePolyData(skin_mesh)
-    return skin_node
+    skin_mesh = openlifu_lz().virtual_fit.compute_skin_mesh_from_volume(
+        volume_array = volume_array,
+        volume_affine_RAS = volume_affine_RAS)
+    skin_mesh_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
+    skin_mesh_node.SetAndObservePolyData(skin_mesh)
+    
+    skin_mesh_node.SetName(f'{volume_node.GetName()}-skinsegmentation')
+    # Set the ID of corresponding volume as a node attribute 
+    skin_mesh_node.SetAttribute('OpenLIFUData.volume_id', volume_node.GetID())
+    skin_mesh_node.CreateDefaultDisplayNodes()
+    skin_mesh_node.GetDisplayNode().SetVisibility(False) # visibility is turned on by default
+
+    return skin_mesh_node
+
+def get_skin_segmentation(volume : Union[vtkMRMLScalarVolumeNode, str]) -> vtkMRMLModelNode:
+    """Returns the model node containing the skin segmentation associated with the specified volume 
+    node or ID. Returns None if no skin segmentation is found.
+    """
+
+    if isinstance(volume,vtkMRMLScalarVolumeNode):
+        volume_id = volume.GetID()
+    elif isinstance(volume, str):
+        volume_id = volume
+    else:
+        raise ValueError("Invalid input type.")
+
+    skin_mesh_node = [
+        node for node in slicer.util.getNodesByClass('vtkMRMLModelNode') 
+        if node.GetAttribute('OpenLIFUData.volume_id') == volume_id
+        ]
+    if not skin_mesh_node:
+        return None
+    elif len(skin_mesh_node) > 1:
+        raise RuntimeError(f"Found multiple skin segmentation models affiliated with volume {volume_id}")
+    else:
+        return skin_mesh_node[0]
+
+def display_skin_segmentation(skin_mesh_node: vtkMRMLModelNode) -> None:
+    # Default display settings
+    model_color = TRANSDUCER_MODEL_COLORS["virtual_fit_result"]
+    normalized_color = [c / 255.0 for c in model_color]
+    skin_mesh_node.GetDisplayNode().SetColor(normalized_color)
+    skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
+    skin_mesh_node.GetDisplayNode().SetVisibility(True)

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -30,7 +30,7 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLMo
     normalized_color = [c / 255.0 for c in model_color]
     skin_mesh_node.GetDisplayNode().SetColor(normalized_color)
     skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
-    skin_mesh_node.GetDisplayNode().SetSelectable(False)
+    skin_mesh_node.SetSelectable(False)
 
     return skin_mesh_node
 

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -25,6 +25,12 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLMo
     skin_mesh_node.CreateDefaultDisplayNodes()
     skin_mesh_node.GetDisplayNode().SetVisibility(False) # visibility is turned on by default
 
+    # Default display settings
+    model_color = TRANSDUCER_MODEL_COLORS["virtual_fit_result"]
+    normalized_color = [c / 255.0 for c in model_color]
+    skin_mesh_node.GetDisplayNode().SetColor(normalized_color)
+    skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
+
     return skin_mesh_node
 
 def get_skin_segmentation(volume : Union[vtkMRMLScalarVolumeNode, str]) -> vtkMRMLModelNode:
@@ -49,11 +55,3 @@ def get_skin_segmentation(volume : Union[vtkMRMLScalarVolumeNode, str]) -> vtkMR
         raise RuntimeError(f"Found multiple skin segmentation models affiliated with volume {volume_id}")
     else:
         return skin_mesh_node[0]
-
-def display_skin_segmentation(skin_mesh_node: vtkMRMLModelNode) -> None:
-    # Default display settings
-    model_color = TRANSDUCER_MODEL_COLORS["virtual_fit_result"]
-    normalized_color = [c / 255.0 for c in model_color]
-    skin_mesh_node.GetDisplayNode().SetColor(normalized_color)
-    skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
-    skin_mesh_node.GetDisplayNode().SetVisibility(True)

--- a/OpenLIFULib/OpenLIFULib/transducer.py
+++ b/OpenLIFULib/OpenLIFULib/transducer.py
@@ -253,14 +253,24 @@ class SlicerOpenLIFUTransducer:
             that observes the virtual fit transform.
         """
 
-        # Only one virtual fit result can be visualized at a time
+        # Check if the cloned model already exists and if it's the correct one
+        # This avoids unnecessary re-cloning if the virtual_fit_transform is the same.
+        current_cloned_transform_id = None
         if self.cloned_virtual_fit_model:
-            slicer.mrmlScene.RemoveNode(self.cloned_virtual_fit_model)
+            current_cloned_transform_id = self.cloned_virtual_fit_model.GetTransformNodeID()
 
+        # Only clone if the model doesn't exist or is observing a different transform
+        if current_cloned_transform_id == virtual_fit_transform.GetID():
+            return self.cloned_virtual_fit_model
+        elif self.cloned_virtual_fit_model:
+            slicer.mrmlScene.RemoveNode(self.cloned_virtual_fit_model)
+            
         if self.body_model_node:
             model_to_clone = self.body_model_node
-        else:
+        elif self.surface_model_node:
             model_to_clone = self.surface_model_node
+        else:
+            model_to_clone = self.model_node
         
         self.cloned_virtual_fit_model = get_cloned_node(model_to_clone)
         self.cloned_virtual_fit_model.SetAndObserveTransformNodeID(virtual_fit_transform.GetID())
@@ -268,5 +278,6 @@ class SlicerOpenLIFUTransducer:
         normalized_color = [c / 255.0 for c in TRANSDUCER_MODEL_COLORS["virtual_fit_result"]] # Normalize color to 0-1 range
         self.cloned_virtual_fit_model.GetDisplayNode().SetColor(normalized_color)
         self.cloned_virtual_fit_model.GetDisplayNode().SetVisibility(False)
+        self.cloned_virtual_fit_model.GetDisplayNode().SetOpacity(0.5)
 
         return self.cloned_virtual_fit_model

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_wizard_utils.py
@@ -114,6 +114,9 @@ def hide_displayable_nodes_from_view(wizard_view_nodes: List[vtkMRMLViewNode]):
                     vrDisplayNode.SetViewNodeIDs(views_mainwindow)
         elif displayable_node.IsA('vtkMRMLTransformNode') and displayable_node.GetDisplayNode() is not None:
             displayable_node.GetDisplayNode().SetEditorVisibility(False)
+        elif displayable_node.IsA('vtkMRMLMarkupsNode') and displayable_node.GetDisplayVisibility():
+            fiducial_views = views_mainwindow + ['vtkMRMLSliceNodeRed','vtkMRMLSliceNodeYellow','vtkMRMLSliceNodeGreen']
+            displayable_node.GetDisplayNode().SetViewNodeIDs(fiducial_views)
         elif displayable_node.GetDisplayVisibility() and not displayable_node.GetDisplayNode().GetViewNodeIDs():
             displayable_node.GetDisplayNode().SetViewNodeIDs(views_mainwindow)
     

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -604,6 +604,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             skin_mesh_node = get_skin_segmentation(activeData["Volume"])
             display_skin_segmentation(skin_mesh_node)
             activeData["Transducer"].set_visibility(True)
+            slicer.modules.OpenLIFUTransducerTrackerWidget.updateVirtualFitResultDisplay()
 
         self.updateApproveButton()
         self.updateApprovalStatusLabel()

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -33,7 +33,7 @@ from OpenLIFULib import (
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
-from OpenLIFULib.skinseg import get_skin_segmentation, generate_skin_segmentation, display_skin_segmentation
+from OpenLIFULib.skinseg import get_skin_segmentation, generate_skin_segmentation
 from OpenLIFULib.targets import fiducial_to_openlifu_point_id
 from OpenLIFULib.transform_conversion import transducer_transform_node_from_openlifu
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
@@ -602,9 +602,10 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             activeData["Transducer"].set_current_transform_to_match_transform_node(virtual_fit_result)
             self.watchVirtualFit(virtual_fit_result)
             skin_mesh_node = get_skin_segmentation(activeData["Volume"])
-            display_skin_segmentation(skin_mesh_node)
+            skin_mesh_node.SetDisplayVisibility(True)
             activeData["Transducer"].set_visibility(True)
-            slicer.modules.OpenLIFUTransducerTrackerWidget.updateVirtualFitResultDisplay()
+            slicer.modules.OpenLIFUTransducerTrackerWidget.updateVirtualFitResultForDisplay()
+            slicer.modules.OpenLIFUTransducerTrackerWidget.updateModelRenderingSettings()
 
         self.updateApproveButton()
         self.updateApprovalStatusLabel()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1196,7 +1196,7 @@ class TransducerTrackingWizard(qt.QWizard):
         # Set view nodes for the skin mesh, transducer and photoscan
         self.skin_mesh_node.GetDisplayNode().SetViewNodeIDs([self.volume_view_node.GetID()])
         self.skin_mesh_node.GetDisplayNode().SetOpacity(1.0)
-        self.skin_mesh_node.GetDisplayNode().SetSelectable(True)
+        self.skin_mesh_node.SetSelectable(True)
 
         # For transducers, ensure that the parent folder visibility is turned on
         # and save the current view settings on the transducer surface
@@ -1250,7 +1250,7 @@ class TransducerTrackingWizard(qt.QWizard):
         self.skin_mesh_node.GetDisplayNode().SetViewNodeIDs(())
         self.skin_mesh_node.GetDisplayNode().SetVisibility(True)
         self.skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
-        self.skin_mesh_node.GetDisplayNode().SetSelectable(False) # so fiducial nodes don't stick to mesh
+        self.skin_mesh_node.SetSelectable(False) # so fiducial nodes don't stick to mesh
 
         skin_facial_landmarks_node = self._logic.get_volume_facial_landmarks(self.skin_mesh_node)
         if skin_facial_landmarks_node:
@@ -1946,6 +1946,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updateWorkflowControls()
         
             # Enable photoscan rendering options if tracking was run successfully and display the skin segmentation
+            skin_seg = get_skin_segmentation(activeData["Volume"])
             self.ui.skinMeshVisibilityCheckBox.setChecked(True)
             self.updateModelRenderingSettings()
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1196,6 +1196,7 @@ class TransducerTrackingWizard(qt.QWizard):
         # Set view nodes for the skin mesh, transducer and photoscan
         self.skin_mesh_node.GetDisplayNode().SetViewNodeIDs([self.volume_view_node.GetID()])
         self.skin_mesh_node.GetDisplayNode().SetOpacity(1.0)
+        self.skin_mesh_node.GetDisplayNode().SetSelectable(True)
 
         # For transducers, ensure that the parent folder visibility is turned on
         # and save the current view settings on the transducer surface
@@ -1249,6 +1250,8 @@ class TransducerTrackingWizard(qt.QWizard):
         self.skin_mesh_node.GetDisplayNode().SetViewNodeIDs(())
         self.skin_mesh_node.GetDisplayNode().SetVisibility(True)
         self.skin_mesh_node.GetDisplayNode().SetOpacity(0.5)
+        self.skin_mesh_node.GetDisplayNode().SetSelectable(False) # so fiducial nodes don't stick to mesh
+
         skin_facial_landmarks_node = self._logic.get_volume_facial_landmarks(self.skin_mesh_node)
         if skin_facial_landmarks_node:
             skin_facial_landmarks_node.GetDisplayNode().SetVisibility(False)

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -2073,6 +2073,13 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.viewVirtualFitCheckBox.setToolTip("No virtual fit result available for the selected target.")
             return
 
+        # Disable the check box if the current transducer position matches the virtual fit result
+        vfresult_is_current = selected_transducer.transform_node.GetAttribute("matching_transform") == best_virtual_fit_result_node.GetID()
+        if vfresult_is_current:
+            self.ui.viewVirtualFitCheckBox.enabled = False
+            self.ui.viewVirtualFitCheckBox.setToolTip("Transducer is already at the virtual fit position.")
+            return
+
         self.ui.viewVirtualFitCheckBox.enabled = True
         self.ui.viewVirtualFitCheckBox.setToolTip("")
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -992,6 +992,8 @@ class TransducerTrackingWizard(qt.QWizard):
             ): #Flag to keep track of when approval is revoked and an existing result can be modified
                 self._existing_approval_revoked = True    
         
+        self.adjustSize()
+        
     def customexec_(self):
         returncode = self.exec_()
         return (returncode, self.photoscan_to_volume_transform_node, self.transducer_to_volume_transform_node)

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>548</width>
-    <height>539</height>
+    <width>563</width>
+    <height>722</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -175,6 +175,92 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
+       <widget class="QWidget" name="photoscanVisibilitySettings" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="photoscanLabel">
+           <property name="text">
+            <string>Photoscan visibility:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="photoscanVisibilityCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="opacityLabel">
+           <property name="text">
+            <string>Opacity:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="qMRMLSliderWidget" name="photoscanOpacitySlider">
+           <property name="singleStep">
+            <double>0.050000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="quantity">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="skinMeshVisibilitySettings" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="skinMeshLabel">
+           <property name="text">
+            <string>Skin mesh visibility:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="skinMeshVisibilityCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="opacityLabel_2">
+           <property name="text">
+            <string>Opacity:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="qMRMLSliderWidget" name="skinMeshOpacitySlider">
+           <property name="singleStep">
+            <double>0.050000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="quantity">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="viewVirtualFitCheckBox">
         <property name="text">
          <string>View virtual fit transducer position</string>
@@ -208,6 +294,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -218,6 +309,11 @@
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -169,6 +169,22 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="ModelRenderingOptions">
+     <property name="text">
+      <string>Model rendering options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <widget class="QCheckBox" name="viewVirtualFitCheckBox">
+        <property name="text">
+         <string>View virtual fit transducer position</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -195,6 +211,12 @@
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1089</width>
+    <width>553</width>
     <height>804</height>
    </rect>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -33,6 +39,12 @@
        <verstretch>4</verstretch>
       </sizepolicy>
      </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_13">
       <item>
        <widget class="QStackedWidget" name="dialogControls">
@@ -43,7 +55,7 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>2</number>
+         <number>3</number>
         </property>
         <widget class="QWidget" name="photoscanMarkup">
          <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -60,7 +72,7 @@
           <item>
            <widget class="qSlicerSimpleMarkupsWidget" name="photoscanMarkupsWidget">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -93,7 +105,7 @@
           <item>
            <widget class="qSlicerSimpleMarkupsWidget" name="skinSegMarkupsWidget">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -469,8 +481,8 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>770</width>
-          <height>20</height>
+          <width>0</width>
+          <height>0</height>
          </size>
         </property>
        </spacer>


### PR DESCRIPTION
Closes #195 
Closes #358 
Closes #367 

Should be merged after https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/375 as it uses the model colors introduced in that PR. 

Depends on openlifu python fix: https://github.com/OpenwaterHealth/OpenLIFU-python/pull/330

- [x] Merge openlifu PR and update python requirements
- [x] Fix bugs in how visibility settings interact between wizard and main window

### Changes introduced

- After running virtual fit, the skin segmentaiton model node is added to the scene and displayed *at 50% opacity in VF color (blue))
- The same skin segmentation model is used for tracking (if available)
- Model rendering options have been added to the tansducer tracking module to enable visualization of the virtual fit transducer position, photoscan and skin segmentation in the main slicer scene. 
- The VF result is shown at 50% opacity. The user can adjust the photoscan and skin segmentation opacity.
- Photoscans can be displayed if selected, loaded in and associated with a photoscan-volume tracking transform
- Skin segmentations can be displayed if a volume is selected and a skin mesh has been added to the scene (via tracking or virtual fit)

### For review
The challenging part of this PR is ensuring that the visibility settings are enabled/disabled correctly based on the state of the scene and the currenly selected input options. I tested a few different sessions/scenarios but it **would be helpful if you could test it out more incase I missed any edge cases.** The visibility settings in the main slicer scene also should not intefere with how models are displayed within the wizard.
Since these enabled-ness checks need to happen whever the combo boxes are modified, the check is linked to `updateInputOptions` and `indexChanged` on the input drop downs. However, these functions are called ** ALOT** i.e. when nodes are added/removed/parameter nodes are modified etc which leads to alot of recursive function calls and unwanted behavior. To avoid this, I had to add various flags to minimize issues. **Feel free to look over the code in case if you have suggestions for how to better handle this.** Each commit addresses a separate issue to you can look over the changes from each commit individually. 


