### PR TITLE
Add quantitative metric comparing vf and tracked result

### DIFF
--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -152,6 +152,21 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="quantitativeTransducerTrackingMetricLabel">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Distance from virtual fit (mm):</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="approvalStatusLabel">
         <property name="text">
          <string>(approval status label)</string>
@@ -165,106 +180,106 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="ModelRenderingOptions">
-     <property name="text">
-      <string>Model rendering options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
-       <widget class="QWidget" name="photoscanVisibilitySettings" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="photoscanLabel">
-           <property name="text">
-            <string>Photoscan visibility:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="photoscanVisibilityCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="opacityLabel">
-           <property name="text">
-            <string>Opacity:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="qMRMLSliderWidget" name="photoscanOpacitySlider">
-           <property name="singleStep">
-            <double>0.050000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.500000000000000</double>
-           </property>
-           <property name="quantity">
-            <string notr="true"/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="skinMeshVisibilitySettings" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="skinMeshLabel">
-           <property name="text">
-            <string>Skin mesh visibility:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="skinMeshVisibilityCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="opacityLabel_2">
-           <property name="text">
-            <string>Opacity:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="qMRMLSliderWidget" name="skinMeshOpacitySlider">
-           <property name="singleStep">
-            <double>0.050000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.500000000000000</double>
-           </property>
-           <property name="quantity">
-            <string notr="true"/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="viewVirtualFitCheckBox">
+       <widget class="ctkCollapsibleButton" name="ModelRenderingOptions">
         <property name="text">
-         <string>View virtual fit transducer position</string>
+         <string>Model rendering options</string>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="QWidget" name="photoscanVisibilitySettings" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="photoscanLabel">
+              <property name="text">
+               <string>Photoscan visibility:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="photoscanVisibilityCheckBox">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="opacityLabel">
+              <property name="text">
+               <string>Opacity:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="qMRMLSliderWidget" name="photoscanOpacitySlider">
+              <property name="singleStep">
+               <double>0.050000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="quantity">
+               <string notr="true"/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="skinMeshVisibilitySettings" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="skinMeshLabel">
+              <property name="text">
+               <string>Skin mesh visibility:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="skinMeshVisibilityCheckBox">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="opacityLabel_2">
+              <property name="text">
+               <string>Opacity:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="qMRMLSliderWidget" name="skinMeshOpacitySlider">
+              <property name="singleStep">
+               <double>0.050000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="quantity">
+               <string notr="true"/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="viewVirtualFitCheckBox">
+           <property name="text">
+            <string>View virtual fit transducer position</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Closes #362 

- [x] Add logic and label for displaying a quantitative measure comparing the virtual fit and transducer tracking transform.
- [x] Update when the label is shown/hidden. It should be shown when a approved transducer tracking result is added to the scene. When approval is revoked i.e. the transducer is moved, hide the label since the result is no longer valid. 

For review:

-Relevant code changes are the last 2 commits.
-Check that when there is an approved tracking result in the scene (either when loaded in or after running tracking), the distance from virtual fit metric is displayed. If there is an approved tracking result, but no virtual fit result, then an error message is displayed. Otherwise, the label is hidden. 