### PR TITLE
Enable adjustment/selection of best virtual fit result

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2325,7 +2325,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
         slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason="The transducer was moved.")
-        slicer.util.getModuleWidget('OpenLIFUTransducerTracker').updateVirtualFitResultDisplay()
+        slicer.util.getModuleWidget('OpenLIFUTransducerTracker').checkCanDisplayVirtualFitResult()
 
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2324,7 +2324,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
     def _on_transducer_transform_modified(self, transducer: SlicerOpenLIFUTransducer) -> None:
 
         slicer.util.getModuleWidget('OpenLIFUSonicationPlanner').deleteSolutionAndSolutionAnalysisIfAny(reason="The transducer was moved.")
-        slicer.util.getModuleWidget('OpenLIFUTransducerTracker').updateVirtualFitResultForDisplay()
+        slicer.util.getModuleWidget('OpenLIFUTransducerTracker').updateVirtualFitResultDisplay()
 
         matching_transform_id = transducer.transform_node.GetAttribute("matching_transform")
         if matching_transform_id:

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1597,6 +1597,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
 
     def updateSessionStatus(self):
         """Update the active session status view and related buttons"""
+
         session_status_field_widgets = [
             self.ui.sessionStatusSubjectNameIdValueLabel,
             self.ui.sessionStatusSessionNameIdValueLabel,

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-openlifu==v0.6.0
+openlifu==v0.7.0
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -207,5 +207,6 @@ def get_cloned_node(node_to_clone: vtkMRMLNode) -> vtkMRMLNode:
     itemIDToClone = shNode.GetItemByDataNode(node_to_clone)
     clonedItemID = slicer.modules.subjecthierarchy.logic().CloneSubjectHierarchyItem(shNode, itemIDToClone)
     cloned_node = shNode.GetItemDataNode(clonedItemID)
+    cloned_node.SetAttribute("cloned", "True")
 
     return cloned_node

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -159,7 +159,7 @@ def get_virtual_fit_results_in_openlifu_session_format(session_id:str, units:str
     return virtual_fit_results_openlifu
 
 def add_virtual_fit_results_from_openlifu_session_format(
-    vf_results_openlifu : "Dict[str,Tuple[bool,List[ArrayTransform]]]",
+    vf_results_openlifu : "Dict[str, List[Tuple[bool, ArrayTransform]]]",
     session_id:str,
     transducer:"Transducer",
     replace = False,
@@ -181,7 +181,7 @@ def add_virtual_fit_results_from_openlifu_session_format(
     See also the reverse function `get_virtual_fit_results_in_openlifu_session_format`
     """
     nodes_that_have_been_added = []
-    for target_id, list_of_transforms in vf_results_openlifu.items(): 
+    for target_id, list_of_transforms in vf_results_openlifu.items():
         for i, (is_approved, array_transform) in enumerate(list_of_transforms):
             virtual_fit_result_transform = transducer_transform_node_from_openlifu(
                 openlifu_transform_matrix = array_transform.matrix,

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -78,6 +78,7 @@ def add_virtual_fit_result(
     virtual_fit_result.SetAttribute("VF:approvalStatus", "1" if approval_status else "0")
     if session_id is not None:
         virtual_fit_result.SetAttribute("VF:sessionID", session_id)
+    virtual_fit_result.CreateDefaultDisplayNodes()
 
     return virtual_fit_result
 

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -181,7 +181,7 @@ def add_virtual_fit_results_from_openlifu_session_format(
     See also the reverse function `get_virtual_fit_results_in_openlifu_session_format`
     """
     nodes_that_have_been_added = []
-    for target_id, list_of_transforms in vf_results_openlifu.items(): #(is_approved, array_transforms) 
+    for target_id, list_of_transforms in vf_results_openlifu.items(): 
         for i, (is_approved, array_transform) in enumerate(list_of_transforms):
             virtual_fit_result_transform = transducer_transform_node_from_openlifu(
                 openlifu_transform_matrix = array_transform.matrix,

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -71,11 +71,7 @@ def add_virtual_fit_result(
     else:
         virtual_fit_result = transform_node
 
-    if rank < 101:
-        virtual_fit_result.SetName(f"VF {target_id} {rank}")
-    else:
-        vf_result_node.SetName(f"VF {target_id} Manual-{rank-100}")
-
+    virtual_fit_result.SetName(f"VF {target_id} {rank}")
     virtual_fit_result.SetAttribute("isVirtualFitResult", "1")
     virtual_fit_result.SetAttribute("VF:targetID", target_id)
     virtual_fit_result.SetAttribute("VF:rank", str(rank))

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -213,7 +213,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.ui.virtualfitButton.clicked.connect(self.onRunAutoFitClicked)
 
         # ---- Virtual fit result options ----
-        self.ui.virtualFitResultTable.itemClicked.connect(self.onVirtualFitResultSelected)
+        # self.ui.virtualFitResultTable.itemClicked.connect(self.onVirtualFitResultSelected)
+        self.ui.virtualFitResultTable.itemSelectionChanged.connect(self.onVirtualFitResultSelected)
         self.ui.modifyTransformPushButton.clicked.connect(self.onModifyTransformClicked)
         self.ui.modifyTransformPushButton.setStyleSheet("""
         QPushButton:checked {
@@ -730,6 +731,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         if not selected_item:
             raise RuntimeError("Cannot find the given node in the virtual fit results table")
         self.ui.virtualFitResultTable.selectRow(selected_item[0].row())
+        self.ui.virtualFitResultTable.scrollToItem(selected_item[0], qt.QAbstractItemView.PositionAtCenter)
         
     def onRunAutoFitClicked(self):  
         self.create_virtual_fit_result(auto_fit = True)

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -222,8 +222,9 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         padding: 4px;
         }
         """)
+        self.ui.modifyTransformPushButton.setToolTip("Modify virtual fit transform")
         self.ui.addTransformPushButton.clicked.connect(self.onAddVirtualFitResultClicked)
-        self.ui.addTransformPushButton.clicked.connect("Create new virtual fit result")
+        self.ui.addTransformPushButton.setToolTip("Create new virtual fit result")
         self.updateVirtualFitResultsTable()
         slicer.util.getModule("OpenLIFUTransducerTracker").widgetRepresentation() 
         self.logic.call_on_chosen_virtual_fit_changed(slicer.modules.OpenLIFUTransducerTrackerWidget.setVirtualFitResultForTracking)
@@ -688,7 +689,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             
             self.ui.approveButton.enabled = True
             self.ui.modifyTransformPushButton.enabled = True
-            self.ui.addTransformPushButton.enabled = True
 
             # Restore the most recent selection if it's still valid
             if 0 <= most_recent_selection < self.ui.virtualFitResultTable.rowCount:
@@ -708,7 +708,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             self.ui.approveButton.setText("Approve virtual fit")
             self.ui.approveButton.setToolTip("Please select a virtual fit first")
             self.ui.modifyTransformPushButton.enabled = False
-            self.ui.addTransformPushButton.enabled = False
             slicer.modules.OpenLIFUTransducerTrackerWidget.setVirtualFitResultForTracking(None) # Initialize based on target
 
     def getCurrentVirtualFitSelection(self):

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -561,7 +561,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         
         if self.algorithm_input_widget.has_valid_selections():
             self.ui.virtualfitButton.enabled = True
-            self.ui.virtualfitButton.setToolTip("Run virtual fit algorithm to automatically suggest a transducer positioning")
+            self.ui.virtualfitButton.setToolTip("Run virtual fit algorithm to automatically suggest a transducer positioning." \
+                "Any existing virtual fit results for the selected target will be removed.")
         else:
             self.ui.virtualfitButton.enabled = False
             self.ui.virtualfitButton.setToolTip("Specify all required inputs to enable virtual fitting")
@@ -723,7 +724,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         if not selected_item:
             raise RuntimeError("Cannot find the given node in the virtual fit results table")
         self.ui.virtualFitResultTable.selectRow(selected_item[0].row())
-        self.ui.virtualFitResultTable.scrollToItem(selected_item[0], qt.QAbstractItemView.PositionAtCenter)
         
     def onRunAutoFitClicked(self):  
         self.create_virtual_fit_result(auto_fit = True)
@@ -791,6 +791,9 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         def progress_callback(progress_percent:int, step_description:str) -> None:
             self.setVirtualFitProgressDisplay(value = progress_percent, status_text = step_description)
             slicer.app.processEvents()
+
+        target_id = fiducial_to_openlifu_point_id(target)
+        notify(f"Removing any existing virtual fit results for {target_id}.")
 
         with BusyCursor():
             try:

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -659,11 +659,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         target_id = fiducial_to_openlifu_point_id(target)
         vf_results = list(get_virtual_fit_result_nodes(target_id=target_id, session_id=session_id, sort = True))
 
-        # Define Table Headers
-        headers = ["Name", "Approved"] 
-        self.ui.virtualFitResultTable.setColumnCount(len(headers))
-        self.ui.virtualFitResultTable.setHorizontalHeaderLabels(headers)
-
         # Populate the table
         if vf_results:
             self.ui.virtualFitResultTable.setRowCount(len(vf_results)) 
@@ -688,11 +683,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             approved : bool = get_approval_from_virtual_fit_result_node(vf_results[0])
             self.updateApproveButton(approved)
 
-        self.ui.virtualFitResultTable.resizeColumnsToContents()
-        self.ui.virtualFitResultTable.resizeRowsToContents()
-        self.ui.virtualFitResultTable.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
-        self.ui.virtualFitResultTable.setSelectionMode(qt.QAbstractItemView.SingleSelection) # Allow single row selection
-        self.ui.virtualFitResultTable.horizontalHeader().setSectionResizeMode(0, qt.QHeaderView.Stretch)
+            self.ui.virtualFitResultTable.resizeRowsToContents()
 
         # Don't update any of the buttons if manual interaction with a virtual fit result is in progress
         # Approval updates occur through `onDataParamaterNode` modified (through updating the underlying session)

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -223,6 +223,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         }
         """)
         self.ui.addTransformPushButton.clicked.connect(self.onAddVirtualFitResultClicked)
+        self.ui.addTransformPushButton.clicked.connect("Create new virtual fit result")
         self.updateVirtualFitResultsTable()
         # ------------------------------------
 

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -391,7 +391,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         is_approved = get_approval_from_virtual_fit_result_node(node)
         if is_approved:
             set_approval_for_virtual_fit_result_node(
-                approval_state=not is_approved,
+                approval_state= False,
                 vf_result_node = node)
             data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
             data_logic.update_underlying_openlifu_session()
@@ -568,7 +568,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     def onApproveClicked(self):
         
-        most_recent_selection = self.ui.virtualFitResultTable.currentRow()
         selected_vf_result = self.getCurrentVirtualFitSelection()
         if selected_vf_result is None:
             raise RuntimeError("No virtual fit result selected")

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -709,7 +709,9 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             self.ui.approveButton.setText("Approve virtual fit")
             self.ui.approveButton.setToolTip("Please select a virtual fit first")
             self.ui.modifyTransformPushButton.enabled = False
-            slicer.modules.OpenLIFUTransducerTrackerWidget.setVirtualFitResultForTracking(None) # Initialize based on target
+            self.logic.chosen_virtual_fit = None
+        
+        slicer.modules.OpenLIFUTransducerTrackerWidget.setVirtualFitResultForTracking(self.logic.chosen_virtual_fit)
 
     def getCurrentVirtualFitSelection(self):
         """ Returns the virtual fit transform node associated with the current selection."""
@@ -822,7 +824,6 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         
         if selected_vf_result is None:
             # TODO: There should be a separate radio button for indicating the 'chosen' result for tracking
-            self.logic.chosen_virtual_fit = None  #Temporary functionality till radio buttons are added
             return
 
         activeData = self.algorithm_input_widget.get_current_data()

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -812,8 +812,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             self.disable_manual_interaction(selected_transducer, selected_vf_result)
     
     def enable_manual_interaction(self, transducer: SlicerOpenLIFUTransducer, vf_result_node: vtkMRMLTransformNode):
-        self.ui.pushButtonEnableInteraction.text = "Disable transform interaction"
-        self.ui.pushButtonEnableInteraction.setToolTip("Turn off interaction handles on the selected virtual fit result.")
+        self.ui.pushButtonEnableInteraction.text = "Finish"
+        self.ui.pushButtonEnableInteraction.setToolTip("")
         
         self._vf_interaction_in_progress = True # Needed to prevent unwanted update routines
 
@@ -831,8 +831,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.ui.virtualfitButton.enabled = False
     
     def disable_manual_interaction(self, transducer: SlicerOpenLIFUTransducer, vf_result_node: vtkMRMLTransformNode):
-        self.ui.pushButtonEnableInteraction.text = "Enable transform interaction"
-        self.ui.pushButtonEnableInteraction.setToolTip("Turn on interaction handles on the selected virtual fit result.")
+        self.ui.pushButtonEnableInteraction.text = "Modify"
+        self.ui.pushButtonEnableInteraction.setToolTip("Modify virtual fit transform")
         
         self._vf_interaction_in_progress = False # Needed to prevent unwanted update routines
 

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -853,13 +853,10 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
         existing_vf_results = list(get_virtual_fit_result_nodes(target_id=target_id, session_id=session_id, sort = True))
         
         if not existing_vf_results:
-            rank = 101 # Manually created VF results start at rank 101
+            rank = 1
         else:
             current_lowest_rank = int(existing_vf_results[-1].GetAttribute("VF:rank"))
-            if current_lowest_rank < 101:
-                rank = 101
-            else:
-                rank = current_lowest_rank + 1
+            rank = current_lowest_rank + 1
 
         vf_result_node = add_virtual_fit_result(
                 transform_node = transducer.transform_node,
@@ -913,7 +910,12 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
         target_id = fiducial_to_openlifu_point_id(target)
         self.clear_virtual_fit_results(target = target)
 
-        vf_result_nodes = []
+        existing_vf_results = list(get_virtual_fit_result_nodes(target_id=target_id, session_id=session_id, sort = True))
+        
+        if not existing_vf_results:
+            current_lowest_rank = 0
+        else:
+            current_lowest_rank = int(existing_vf_results[-1].GetAttribute("VF:rank"))
 
         for i,vf_transform in zip(range(10), vf_transforms): # We only add the top 10 virtual fit nodes, to not put so many transforms into the scene.
             node = add_virtual_fit_result(
@@ -922,7 +924,7 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
                 session_id = session_id,
                 approval_status = False,
                 clone_node=False,
-                rank = i+1,
+                rank = current_lowest_rank+i+1,
             )
             vf_result_nodes.append(node)
             transducer.move_node_into_transducer_sh_folder(node)

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -284,7 +284,11 @@
              </widget>
             </item>
             <item>
-             <widget class="QTableWidget" name="virtualFitResultTable"/>
+             <widget class="QTableWidget" name="virtualFitResultTable">
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+             </widget>
             </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -306,7 +306,7 @@
             <item row="0" column="2">
              <widget class="QPushButton" name="pushButtonSetTransducerTransform">
               <property name="text">
-               <string>Update transducer position</string>
+               <string>Set</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -319,7 +319,7 @@
             <item row="0" column="3">
              <widget class="QPushButton" name="pushButtonEnableInteraction">
               <property name="text">
-               <string>Enable transform interaction</string>
+               <string>Modify</string>
               </property>
               <property name="checkable">
                <bool>true</bool>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
-    <height>943</height>
+    <width>570</width>
+    <height>954</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -218,7 +218,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="3,1">
+          <layout class="QHBoxLayout" name="runVirtualFit" stretch="3,0,1">
            <item>
             <widget class="QPushButton" name="virtualfitButton">
              <property name="sizePolicy">
@@ -228,7 +228,17 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Virtual fit</string>
+              <string>Create virtual fit result(s)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="runFittingAlgorithmCheckBox">
+             <property name="text">
+              <string>Run fitting algorithm</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -241,7 +251,7 @@
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Whether to dump debugging information such as skin meshes and search points.</string>
+              <string>Whether to dump debugging information such as skin meshes and search points from fitting algorithm.</string>
              </property>
              <property name="text">
               <string>Debug</string>
@@ -281,52 +291,43 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="virtualFitResultsOptions">
-           <item>
-            <widget class="qMRMLNodeComboBox" name="virtualFitResultComboBox">
-             <property name="nodeTypes">
-              <stringlist notr="true">
-               <string>vtkMRMLTransformNode</string>
-              </stringlist>
-             </property>
-             <property name="hideChildNodeTypes">
-              <stringlist notr="true"/>
-             </property>
-             <property name="baseName">
-              <string>Manual VF</string>
-             </property>
-             <property name="removeEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="interactionNodeSingletonTag">
-              <string notr="true"/>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pushButtonSetTransducerTransform">
-             <property name="text">
-              <string>Update transducer position</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pushButtonEnableManualInteraction">
-             <property name="text">
-              <string>Enable manual interaction</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <widget class="QWidget" name="virtualFitResultsOptions" native="true">
+           <layout class="QGridLayout" name="virtualFitResultsLayout">
+            <item row="0" column="0">
+             <widget class="QComboBox" name="virtualFitResultComboBox">
+              <property name="editable">
+               <bool>false</bool>
+              </property>
+              <property name="insertPolicy">
+               <enum>QComboBox::InsertAtTop</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="pushButtonSetTransducerTransform">
+              <property name="text">
+               <string>Update transducer position</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QPushButton" name="pushButtonEnableInteraction">
+              <property name="text">
+               <string>Enable interaction</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -365,11 +366,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -383,22 +379,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>OpenLIFUPrePlanning</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>virtualFitResultComboBox</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>283</x>
-     <y>471</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>340</x>
-     <y>611</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>404</width>
-    <height>592</height>
+    <width>568</width>
+    <height>943</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -25,11 +25,11 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="targetsCollapsible" native="true">
-     <property name="text" stdset="0">
+    <widget class="ctkCollapsibleButton" name="targetsCollapsible">
+     <property name="text">
       <string>Targets</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -168,11 +168,11 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="virtualfitCollapsible" native="true">
-     <property name="text" stdset="0">
+    <widget class="ctkCollapsibleButton" name="virtualfitCollapsible">
+     <property name="text">
       <string>Virtual Fitting</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -215,13 +215,6 @@
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="approveButton">
-           <property name="text">
-            <string>Approve virtual fit</string>
-           </property>
           </widget>
          </item>
          <item>
@@ -283,6 +276,68 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Select virtual fit result:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="virtualFitResultsOptions">
+        <item>
+         <widget class="qMRMLNodeComboBox" name="virtualFitResultComboBox">
+          <property name="nodeTypes">
+           <stringlist notr="true">
+            <string>vtkMRMLTransformNode</string>
+           </stringlist>
+          </property>
+          <property name="hideChildNodeTypes">
+           <stringlist notr="true"/>
+          </property>
+          <property name="baseName">
+           <string>Manual VF</string>
+          </property>
+          <property name="removeEnabled">
+           <bool>false</bool>
+          </property>
+          <property name="interactionNodeSingletonTag">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonSetTransducerTransform">
+          <property name="text">
+           <string>Update transducer position</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonEnableManualInteraction">
+          <property name="text">
+           <string>Enable manual interaction</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QPushButton" name="approveButton">
+        <property name="text">
+         <string>Approve virtual fit</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -310,6 +365,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
@@ -323,5 +383,22 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>OpenLIFUPrePlanning</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>virtualFitResultComboBox</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>283</x>
+     <y>471</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>340</x>
+     <y>611</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -319,7 +319,7 @@
             <item row="0" column="3">
              <widget class="QPushButton" name="pushButtonEnableInteraction">
               <property name="text">
-               <string>Enable interaction</string>
+               <string>Enable transform interaction</string>
               </property>
               <property name="checkable">
                <bool>true</bool>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
+    <width>412</width>
     <height>943</height>
    </rect>
   </property>
@@ -218,7 +218,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="runVirtualFit" stretch="3,0,1">
+          <layout class="QHBoxLayout" name="runVirtualFit" stretch="3,1">
            <item>
             <widget class="QPushButton" name="virtualfitButton">
              <property name="sizePolicy">
@@ -228,17 +228,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Create virtual fit result(s)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="runFittingAlgorithmCheckBox">
-             <property name="text">
-              <string>Run fitting algorithm</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
+              <string>Run auto-fitting algorithm</string>
              </property>
             </widget>
            </item>
@@ -284,45 +274,43 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Select virtual fit result:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QWidget" name="virtualFitResultsOptions" native="true">
-           <layout class="QGridLayout" name="virtualFitResultsLayout">
-            <item row="0" column="0">
-             <widget class="QComboBox" name="virtualFitResultComboBox">
-              <property name="editable">
-               <bool>false</bool>
-              </property>
-              <property name="insertPolicy">
-               <enum>QComboBox::InsertAtTop</enum>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QLabel" name="selectVFResultLabel">
+              <property name="text">
+               <string>Select virtual fit result:</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="pushButtonSetTransducerTransform">
-              <property name="text">
-               <string>Set</string>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
+            <item>
+             <widget class="QTableWidget" name="virtualFitResultTable"/>
             </item>
-            <item row="0" column="3">
-             <widget class="QPushButton" name="pushButtonEnableInteraction">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QPushButton" name="addTransformPushButton">
+                <property name="text">
+                 <string>Add</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="modifyTransformPushButton">
+                <property name="text">
+                 <string>Modify</string>
+                </property>
+                <property name="checkable">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QPushButton" name="approveButton">
               <property name="text">
-               <string>Modify</string>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
+               <string>Approve virtual fit</string>
               </property>
              </widget>
             </item>
@@ -330,13 +318,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="approveButton">
-        <property name="text">
-         <string>Approve virtual fit</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -288,6 +288,31 @@
               <property name="editTriggers">
                <set>QAbstractItemView::NoEditTriggers</set>
               </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::SingleSelection</enum>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+              <property name="columnCount">
+               <number>2</number>
+              </property>
+              <attribute name="horizontalHeaderDefaultSectionSize">
+               <number>200</number>
+              </attribute>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <column>
+               <property name="text">
+                <string>Name</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Approved</string>
+               </property>
+              </column>
              </widget>
             </item>
             <item>

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>570</width>
-    <height>954</height>
+    <width>568</width>
+    <height>943</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">

--- a/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
+++ b/OpenLIFUPrePlanning/Resources/UI/OpenLIFUPrePlanning.ui
@@ -273,63 +273,63 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Select virtual fit result:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="virtualFitResultsOptions">
+           <item>
+            <widget class="qMRMLNodeComboBox" name="virtualFitResultComboBox">
+             <property name="nodeTypes">
+              <stringlist notr="true">
+               <string>vtkMRMLTransformNode</string>
+              </stringlist>
+             </property>
+             <property name="hideChildNodeTypes">
+              <stringlist notr="true"/>
+             </property>
+             <property name="baseName">
+              <string>Manual VF</string>
+             </property>
+             <property name="removeEnabled">
+              <bool>false</bool>
+             </property>
+             <property name="interactionNodeSingletonTag">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonSetTransducerTransform">
+             <property name="text">
+              <string>Update transducer position</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonEnableManualInteraction">
+             <property name="text">
+              <string>Enable manual interaction</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
         </layout>
        </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Select virtual fit result:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="virtualFitResultsOptions">
-        <item>
-         <widget class="qMRMLNodeComboBox" name="virtualFitResultComboBox">
-          <property name="nodeTypes">
-           <stringlist notr="true">
-            <string>vtkMRMLTransformNode</string>
-           </stringlist>
-          </property>
-          <property name="hideChildNodeTypes">
-           <stringlist notr="true"/>
-          </property>
-          <property name="baseName">
-           <string>Manual VF</string>
-          </property>
-          <property name="removeEnabled">
-           <bool>false</bool>
-          </property>
-          <property name="interactionNodeSingletonTag">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonSetTransducerTransform">
-          <property name="text">
-           <string>Update transducer position</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonEnableManualInteraction">
-          <property name="text">
-           <string>Enable manual interaction</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
       <item>
        <widget class="QPushButton" name="approveButton">

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1759,7 +1759,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         self.checkCanRunTracking() # Determine whether transducer tracking can be run
         self.checkCanPreviewPhotoscan()
-        self.updateVirtualFitResultDisplay() # virtual fit rendering checkbox
+        self.checkCanDisplayVirtualFitResult() # virtual fit rendering checkbox
         self.updateModelRenderingSettings() #model rendering options
         self.updateDistanceFromVFLabel()
 
@@ -2011,6 +2011,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updateWorkflowControls()
 
             self.updateDistanceFromVFLabel()
+            self.checkCanDisplayVirtualFitResult()
         
             # Enable photoscan rendering options if tracking was run successfully and display the skin segmentation
             slicer.modules.OpenLIFUPrePlanningWidget.showSkin(activeData["Volume"])
@@ -2160,10 +2161,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                     target_id = fiducial_to_openlifu_point_id(selected_target))
                 self._virtual_fit_transform_for_tracking = best_virtual_fit_result_node # Could be None
         
-        # If the transform node has chanfed
-        # if current_result is None or \
-        #     self._virtual_fit_transform_for_tracking.GetID() != current_result.GetID():
-        self.updateVirtualFitResultDisplay()
+        self.checkCanDisplayVirtualFitResult()
         self.updateVirtualFitStatus()
 
     def showVirtualFitResult(self):
@@ -2181,13 +2179,10 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         if selected_transducer.cloned_virtual_fit_model.GetDisplayVisibility() != is_visible:
             selected_transducer.cloned_virtual_fit_model.SetDisplayVisibility(is_visible)
 
-
-    def updateVirtualFitResultDisplay(self):
+    def checkCanDisplayVirtualFitResult(self):
         """
-        Updates the virtual fit result displayed when the `View virtual fit result` checkbox is toggled. 
-        It clones the virtual fit result, sets its opacity, and stores it for potential further use.
-        If no target is selected or no virtual fit result is found for the selected target, the 
-        visibility of the virtual fit checkbox is disabled.
+        Enables or disables the `View virtual fit result` checkbox depending on the current transducer position 
+        and whether a valid transducer is currently selected.
         """
 
         # Prevents a recursive loop when NodeAdded/Removed (when cloning VF result)
@@ -2217,11 +2212,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         self.ui.viewVirtualFitCheckBox.enabled = True
         self.ui.viewVirtualFitCheckBox.setToolTip("")
-
-        # # Control visibility based on the checkbox state
-        # is_visible = self.ui.viewVirtualFitCheckBox.isChecked()
-        # if selected_transducer.cloned_virtual_fit_model.GetDisplayVisibility() != is_visible:
-        #     self.showVirtualFitResult()
 
     def updateWorkflowControls(self):
         session = get_openlifu_data_parameter_node().loaded_session

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -2150,7 +2150,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
         if self._running_wizard:
             return
-        current_result = self._virtual_fit_transform_for_tracking
         # If there is a virtual fit result selected in the pre-planning module
         if vf_result:
             self._virtual_fit_transform_for_tracking = vf_result

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -850,8 +850,8 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
             # Initialize transform with identity matrix
             self.transducer_to_volume_transform_node = transducer_transform_node_from_openlifu(
                 openlifu_transform_matrix = np.eye(4) ,
-                transducer = transducer.transducer.transducer,
-                transform_units = transducer.transducer.transducer.units)
+                transducer = self.wizard().transducer.transducer.transducer,
+                transform_units = self.wizard().transducer.transducer.transducer.units)
         
         self.transducer_to_volume_transform_node.CreateDefaultDisplayNodes()
         self.setupTransformNode()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1058,6 +1058,7 @@ class TransducerTrackingWizard(qt.QWizard):
             self.photoscan.model_node.GetDisplayNode().SetVisibility(False)
             self.transducer_surface.GetDisplayNode().SetVisibility(False)
             self.transducer_body.GetDisplayNode().SetVisibility(False)
+            self.transducer.cloned_virtual_fit_model.GetDisplayNode().SetVisibility(False)
 
             if self.photoscanMarkupPage.facial_landmarks_fiducial_node:
                 self.photoscanMarkupPage.facial_landmarks_fiducial_node.GetDisplayNode().SetVisibility(False)
@@ -1074,6 +1075,7 @@ class TransducerTrackingWizard(qt.QWizard):
             self.photoscan.model_node.GetDisplayNode().SetVisibility(True)
             self.transducer_surface.GetDisplayNode().SetVisibility(False)
             self.transducer_body.GetDisplayNode().SetVisibility(False)
+            self.transducer.cloned_virtual_fit_model.GetDisplayNode().SetVisibility(False)
 
             self.photoscan.model_node.SetDisplayVisibility(self.photoscanVolumeTrackingPage.ui.photoscanVisibilityCheckBox.isChecked())
             self.photoscan.model_node.GetDisplayNode().SetOpacity(self.photoscanVolumeTrackingPage.ui.photoscanOpacitySlider.value)

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -138,6 +138,22 @@
        </widget>
       </item>
       <item>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_7">
+         <item>
+          <widget class="QLabel" name="approvalWarningLabel">
+           <property name="text">
+            <string>(approval warnings here)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="previewPhotoscanButton">
         <property name="text">
          <string>Preview Photoscan</string>
@@ -170,13 +186,6 @@
        <widget class="QLabel" name="approvalStatusLabel">
         <property name="text">
          <string>(approval status label)</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="approvalWarningLabel">
-        <property name="text">
-         <string>(approval warnings here)</string>
         </property>
        </widget>
       </item>

--- a/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/TransducerTrackingWizard.ui
@@ -286,11 +286,15 @@
         <widget class="QWidget" name="TransducerPhotoscanTracking">
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
-           <widget class="QPushButton" name="initializeTPRegistration">
-            <property name="text">
-             <string>Initialize transducer-photoscan transform</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="initialization">
+            <item>
+             <widget class="QPushButton" name="initializeTPRegistration">
+              <property name="text">
+               <string>Initialize transducer-photoscan transform</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="runICPRegistrationTP">


### PR DESCRIPTION
Closes #357 

- In the pre-planning module, the user is now able to see all of the computed virtual fit results.
- Multiple virtual fit results can be approved for a target
- The user can manually edit the transforms
- The user can `Add` a new transform node and manually perform virtual fit

A big change is that I have now removed the target option from the transducer tracking module. The target and virtual fit used for tracking is now based on what is selected in the Pre-planning module. I have added a `setVirtualFitResultForTracking` function to the transducer tracking module, which updates a `self._virtual_fit_transform_for_tracking` variable. This keeps track of the currently selected virtual fit result, and is used by the wizard, distance calculator, display etc.. This variable depends on the currently selected target and virtual result in the pre-planning module and the function is triggered by the pre-planning module everytime a different virtual fit result is selected in the table.

### For Review

This ended up being quite a massive change to the virtual fit workflow and how it interacts with the transducer tracking module. Please play around with different sessions and virtual fit/tracking interactions and note any bugs/weird behavior. 

