### PR TITLE
Push notifications instead of raising dialogs when revoking approvals

### DIFF
--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/skinseg.py
   OpenLIFULib/transducer_tracking_wizard_utils.py
   OpenLIFULib/events.py
+  OpenLIFULib/notifications.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/notifications.py
+++ b/OpenLIFULib/OpenLIFULib/notifications.py
@@ -1,0 +1,85 @@
+from typing import Optional
+import logging
+import slicer
+import qt
+
+LAST_NOTIFICATION = None # globally tracks the last notification that was shown
+
+class Notification(qt.QWidget):
+    """
+    Notification widget that can be shown temporarily on top of its parent.
+    """
+    def __init__(self, message:str, parent=None, previous_notification:"Optional[Notification]"=None):
+        """
+        If parent is not provided then it will be the Slicer layout container that contains the slice and 3D views.
+
+        Another Notification object can optionally be provided as `previous_notification`.
+        If one is provided then this notification will be positioned below `previous_notification`, rather than 
+        being at the top-middle-ish of the parent widget.
+        """
+        if parent is None:
+            parent = slicer.app.layoutManager().parent()
+
+        super().__init__(parent)
+        
+        self.previous_notification = previous_notification
+
+        self.setWindowFlags(
+            qt.Qt.Tool | # tooltip like behavior
+            qt.Qt.FramelessWindowHint |
+            qt.Qt.WindowStaysOnTopHint
+        )
+        self.setAttribute(qt.Qt.WA_ShowWithoutActivating) # prevents widget from grabbing focus
+        self.setAttribute(qt.Qt.WA_TranslucentBackground)
+
+        self.setStyleSheet("""
+            QWidget {
+                background-color: rgba(30, 30, 30, 220);
+                color: white;
+                border-radius: 5px;
+            }
+        """)
+
+        layout = qt.QVBoxLayout(self)
+        self.label = qt.QLabel(message, self)
+        self.label.setContentsMargins(15, 10, 15, 10) # padding
+        layout.addWidget(self.label)
+        
+        self.adjustSize() # adjust size to fit the text
+
+    def move_to_below_previous_notification(self):
+        prev_pos = self.previous_notification.pos
+        target_x = prev_pos.x() + (self.previous_notification.width - self.width) // 2
+        target_y = prev_pos.y() + self.previous_notification.height
+        self.move(target_x, target_y)
+
+    def move_to_top_center_of_parent(self):
+        parent_widget = self.parent()
+        parent_global_pos = parent_widget.mapToGlobal(qt.QPoint(0, 0))
+        target_x = parent_global_pos.x() + (parent_widget.width - self.width) // 2
+        target_y = parent_global_pos.y() + 50 
+        self.move(target_x, target_y)
+
+    def show_temporarily(self, duration_ms=3000):
+
+        if self.previous_notification is not None and self.previous_notification.isVisible():
+            self.move_to_below_previous_notification()
+        else:
+            self.move_to_top_center_of_parent()
+
+        self.show()
+        qt.QTimer.singleShot(duration_ms, self.close)
+
+def notify(message:str) -> None:
+    """Submit push notification, a temporarily but somewhat prominently displayed piece of text that also gets logged"""
+    logging.info(message)
+
+    global LAST_NOTIFICATION
+
+    previous_notification_to_use = None
+    if LAST_NOTIFICATION is not None and LAST_NOTIFICATION.isVisible():
+        previous_notification_to_use = LAST_NOTIFICATION
+    
+    notification = Notification(message=message, previous_notification=previous_notification_to_use)
+    notification.show_temporarily()
+    LAST_NOTIFICATION = notification

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -38,6 +38,7 @@ from OpenLIFULib.util import (
     display_errors,
     replace_widget,
 )
+from OpenLIFULib.notifications import notify
 
 # These imports are deferred at runtime using openlifu_lz, 
 # but are done here for IDE and static analysis purposes
@@ -343,10 +344,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         if self.logic.solution_analysis_exists():
             data_logic.clear_solution(clean_up_scene=False)
             self._parameterNode.solution_analysis = None
-            slicer.util.infoDisplay(
-                text= "Computed solution has been deleted for the following reason:\n"+reason,
-                windowTitle="Solution deleted"
-            )
+            notify(f"Solution deleted:\n{reason}")
 
     def updateVirtualFitApprovalStatus(self) -> None:
         loaded_session = get_openlifu_data_parameter_node().loaded_session
@@ -455,16 +453,10 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             solution_is_approved = get_openlifu_data_parameter_node().loaded_solution.is_approved()
             if solution_is_approved and not self.logic.solution_analysis_exists():
                 self.logic.toggle_solution_approval()
-                slicer.util.infoDisplay(
-                    text= "Solution approval has been revoked due there being no solution analysis.",
-                    windowTitle="Approval revoked"
-                )
+                notify(f"Solution approval revoked: missing solution analysis!")
             elif solution_is_approved and self.logic.solution_analysis_has_errors():
                 self.logic.toggle_solution_approval()
-                slicer.util.infoDisplay(
-                    text= "Solution approval has been revoked due to errors in the solution analysis.",
-                    windowTitle="Approval revoked"
-                )
+                notify(f"Solution approval revoked: errors in solution analysis!")
 
     def updateSolutionAnalysis(self) -> None:
         """Update the solution analysis widgets"""

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -61,6 +61,7 @@ from OpenLIFULib.transducer_tracking_wizard_utils import (
 )
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
 from OpenLIFULib.util import add_slicer_log_handler, BusyCursor, get_cloned_node, replace_widget, display_errors
+from OpenLIFULib.notifications import notify
 from OpenLIFULib.virtual_fit_results import get_virtual_fit_approval_for_target
 
 # These imports are for IDE and static analysis purposes only
@@ -1833,10 +1834,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         and show a message dialog to that effect.
         """
         if self.logic.get_transducer_tracking_approval(photoscan_id):
-            slicer.util.infoDisplay(
-                text= "Transducer tracking approval has been revoked for the following reason:\n"+reason,
-                windowTitle="Approval revoked"
-            )
+            notify(f"Tracking approval revoked:\n{reason}")
             self.logic.revoke_transducer_tracking_approval(photoscan_id = photoscan_id)
             self.updateApprovalStatusLabel()
 


### PR DESCRIPTION
When approvals get revoked or when virtual fit results need to be cleared out, we now just show a notification rather than interrupting the user with a dialog that they have to interact with.

This adds a handy notification system that we can make use of elsewhere too

Closes #335

For review: Try loading the Soren example, which already comes with an approved virtual fit, and then move the target around. Instead of interrupting you, it should show two notifications. Make sure the notifications don't look too ridiculous on your system. They look nice on my system. Give the code changes a cursory look.