### PR TITLE
Mask the background out of loaded MRIs (#387)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -57,7 +57,7 @@ from OpenLIFULib.util import (
     ensure_list,
     replace_widget,
 )
-from OpenLIFULib.skinseg import load_volume_and_threshold_background
+from OpenLIFULib.volume_thresholding import load_volume_and_threshold_background
 from OpenLIFULib.virtual_fit_results import (
     add_virtual_fit_results_from_openlifu_session_format,
     clear_virtual_fit_results,

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/transducer_tracking_wizard_utils.py
   OpenLIFULib/events.py
   OpenLIFULib/notifications.py
+  OpenLIFULib/volume_thresholding.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -8,7 +8,7 @@ from slicer import (
 )
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.util import get_openlifu_data_parameter_node
-from OpenLIFULib.skinseg import load_volume_and_threshold_background
+from OpenLIFULib.volume_thresholding import load_volume_and_threshold_background
 from OpenLIFULib.lazyimport import openlifu_lz
 from OpenLIFULib.parameter_node_utils import SlicerOpenLIFUSessionWrapper, SlicerOpenLIFUPhotoscanWrapper
 from OpenLIFULib.targets import (

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -1,12 +1,9 @@
 """Skin segmentation tools"""
 
-import logging
-import vtk
 from OpenLIFULib.lazyimport import openlifu_lz
 from slicer import vtkMRMLScalarVolumeNode, vtkMRMLModelNode
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.transducer import TRANSDUCER_MODEL_COLORS
-from OpenLIFULib.util import BusyCursor
 import slicer
 from typing import Union
 
@@ -59,43 +56,3 @@ def get_skin_segmentation(volume : Union[vtkMRMLScalarVolumeNode, str]) -> vtkMR
         raise RuntimeError(f"Found multiple skin segmentation models affiliated with volume {volume_id}")
     else:
         return skin_mesh_node[0]
-
-def cast_volume_to_float(volume_node:vtkMRMLScalarVolumeNode) -> None:
-    """Converts a volume node to float, replacing the underlying vtkImageData."""
-    image_cast = vtk.vtkImageCast()
-    image_cast.SetInputData(volume_node.GetImageData())
-    image_cast.SetOutputScalarTypeToDouble()
-    image_cast.Update()
-    volume_node.SetAndObserveImageData(image_cast.GetOutput())
-
-    # I am not certain that the display node will know to update itself to handle the new image data type,
-    # so I hope poking `CreateDefaultDisplayNodes` here makes it do the right thing. If it's not needed then it's harmless anyway:
-    volume_node.CreateDefaultDisplayNodes()
-
-def threshold_volume_by_foreground_mask(volume_node:vtkMRMLScalarVolumeNode) -> None:
-    """Compute the foreground mask for a loaded volume and threshold the volume to strip out the background.
-    This modifies the values of the background region in the volume and sets them to 1 less than the minimum value in the volume.
-    This way we can simply enable volume thresholding to remove
-    It can take a moment to actually compute the foreground mask.
-    """
-    volume_array = slicer.util.arrayFromVolume(volume_node)
-    volume_array_min = volume_array.min()
-
-    background_value = volume_array_min - 1
-    if background_value < volume_node.GetImageData().GetScalarTypeMin(): # e.g. if volume_array_min is 0 and it's an unsigned int type
-        logging.info("Casting volume to float for the sake of `threshold_volume_by_foreground_mask`.")
-        cast_volume_to_float(volume_node)
-
-    foreground_mask = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
-    slicer.util.arrayFromVolume(volume_node)[~foreground_mask] = background_value
-    volume_node.GetDisplayNode().SetThreshold(volume_array_min,volume_array.max())
-    volume_node.GetDisplayNode().SetApplyThreshold(1)
-    volume_node.GetDisplayNode().SetAutoThreshold(0)
-    volume_node.Modified()
-
-def load_volume_and_threshold_background(volume_filepath) -> vtkMRMLScalarVolumeNode:
-    """Load a volume node from file, and also set the background values to a certain value that can be threshoded out, and threshold it out."""
-    volume_node = slicer.util.loadVolume(volume_filepath)
-    with BusyCursor():
-        threshold_volume_by_foreground_mask(volume_node)
-    return volume_node

--- a/OpenLIFULib/OpenLIFULib/volume_thresholding.py
+++ b/OpenLIFULib/OpenLIFULib/volume_thresholding.py
@@ -1,0 +1,48 @@
+"""Volume thresholding tools"""
+
+import logging
+import vtk
+import slicer
+from slicer import vtkMRMLScalarVolumeNode
+from OpenLIFULib.util import BusyCursor
+from OpenLIFULib.lazyimport import openlifu_lz
+
+def cast_volume_to_float(volume_node:vtkMRMLScalarVolumeNode) -> None:
+    """Converts a volume node to float, replacing the underlying vtkImageData."""
+    image_cast = vtk.vtkImageCast()
+    image_cast.SetInputData(volume_node.GetImageData())
+    image_cast.SetOutputScalarTypeToDouble()
+    image_cast.Update()
+    volume_node.SetAndObserveImageData(image_cast.GetOutput())
+
+    # I am not certain that the display node will know to update itself to handle the new image data type,
+    # so I hope poking `CreateDefaultDisplayNodes` here makes it do the right thing. If it's not needed then it's harmless anyway:
+    volume_node.CreateDefaultDisplayNodes()
+
+def threshold_volume_by_foreground_mask(volume_node:vtkMRMLScalarVolumeNode) -> None:
+    """Compute the foreground mask for a loaded volume and threshold the volume to strip out the background.
+    This modifies the values of the background region in the volume and sets them to 1 less than the minimum value in the volume.
+    This way we can simply enable volume thresholding to remove
+    It can take a moment to actually compute the foreground mask.
+    """
+    volume_array = slicer.util.arrayFromVolume(volume_node)
+    volume_array_min = volume_array.min()
+
+    background_value = volume_array_min - 1
+    if background_value < volume_node.GetImageData().GetScalarTypeMin(): # e.g. if volume_array_min is 0 and it's an unsigned int type
+        logging.info("Casting volume to float for the sake of `threshold_volume_by_foreground_mask`.")
+        cast_volume_to_float(volume_node)
+
+    foreground_mask = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+    slicer.util.arrayFromVolume(volume_node)[~foreground_mask] = background_value
+    volume_node.GetDisplayNode().SetThreshold(volume_array_min,volume_array.max())
+    volume_node.GetDisplayNode().SetApplyThreshold(1)
+    volume_node.GetDisplayNode().SetAutoThreshold(0)
+    volume_node.Modified()
+
+def load_volume_and_threshold_background(volume_filepath) -> vtkMRMLScalarVolumeNode:
+    """Load a volume node from file, and also set the background values to a certain value that can be threshoded out, and threshold it out."""
+    volume_node = slicer.util.loadVolume(volume_filepath)
+    with BusyCursor():
+        threshold_volume_by_foreground_mask(volume_node)
+    return volume_node


### PR DESCRIPTION
Closes #387

One thing I slightly dislike about this method is that it modifies the values in the volume array: it makes the background voxels take a value that is 1 less than the minimum value in the volume. This way they can simply be thresholded out. There should be other ways to do this that involve creating a segmentation node out of the foreground mask and then using it as a "cropping ROI" for the volume. This would be nicer but then it's another piece of data to manage. This method  keeps things simple, and it doesn't seem to harm the downstream skin segmentation computation.

Another thing I slightly dislike about this method is that it takes some time to compute the foreground mask, so this makes loading a volume into the scene a slower process. But it isn't too bad, at least on my system, and the result is definitely very pleasing to look at.

For review: Load a volume into the scene by loading a session, or by doing it manually, and observe that it is immediately masked after being loaded in. Give the code a cursory look.