### PR TITLE
Edit extension description to specify AGPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(SlicerOpenLIFU)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/OpenwaterHealth/SlicerOpenLIFU")
 set(EXTENSION_CONTRIBUTORS "Ebrahim Ebrahim (Kitware), Peter Hollender (Openwater), Sam Horvath (Kitware), Andrew Howe (Kitware), Sadhana Ravikumar (Kitware), Brad Moore (Kitware)")
-set(EXTENSION_DESCRIPTION "A 3D Slicer extension for Openwater's OpenLIFU (Low Intensity Focused Ultrasound) research platform.")
+set(EXTENSION_DESCRIPTION "A 3D Slicer extension for Openwater’s OpenLIFU (Low Intensity Focused Ultrasound) research platform. Licensed under AGPL (a strong copyleft license that may limit use in proprietary or clinical products).")
 set(EXTENSION_ICONURL "https://github.com/OpenwaterHealth/SlicerOpenLIFU/blob/main/SlicerOpenLIFU.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/OpenwaterHealth/SlicerOpenLIFU/blob/main/screenshots/1.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Contributes to #266 

Edits to the `EXTENSION_DESCRIPTION` were requested before adding SlicerOpenLIFU to the Slicer extensions index.