### PR TITLE
Remove all observers added by the wizard

### DIFF
--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -745,6 +745,8 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
+        if not self.photoscan_to_volume_transform_node:
+            return False
         return not self.runningRegistration and self.page_locked
 
 class TransducerPhotoscanTrackingPage(qt.QWizardPage):
@@ -920,6 +922,8 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
 
     def isComplete(self):
         """" Determines if the 'Next' button should be enabled"""
+        if not self.transducer_to_volume_transform_node:
+            return False
         return not self.runningRegistration and self.page_locked
 
 class TransducerTrackingWizard(qt.QWizard):


### PR DESCRIPTION
Closes #272 

As Sam suggested, the debug leaks seems to be caused by vtkObservers remaining after node removal.  I tested building the custom app on Windows using this branch and this seems to fix the issue. 
I also found that simply using `node.RemoveAllObservers()` does not work. I had to tag and remove the individual observers. 

When testing, I found a bug in the wizard workflow which allows the user to click `Next`/`Approve` even if there wasn't a tracking transform defined. So I include a fix for that in this PR. 

### For Review
- Look over the code
- Confirm that this changes resolves the debug leaks error on the custom app built on Linux (git tag: 1e1340c7fa68aae7efaef130a7388d552135d899)

