### PR TITLE
Generate skin mesh when loading a session that has a virtual fit. Also 3D camera reset upon load.

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2302,7 +2302,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 slicer.mrmlScene.RemoveNode(loaded_volumes[idx])
 
         volume_filepath = Path(volume_dir,volume_metadata['data_filename'])
-        loadedVolumeNode = load_volume_and_threshold_background(volume_filepath)
+        loadedVolumeNode, _ = load_volume_and_threshold_background(volume_filepath)
         # Note: OnNodeAdded/updateLoadedObjectsView is called before openLIFU metadata is assigned to the node so need
         # call updateLoadedObjectsView again to display openlifu name/id.
         assign_openlifu_metadata_to_volume_node(loadedVolumeNode, volume_metadata)

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1894,6 +1894,12 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         sliceNode = slicer.util.getFirstNodeByClassByName("vtkMRMLSliceNode", "Yellow")
         sliceNode.SetSliceVisible(True)
 
+        # === Set camera ===
+
+        threeDView = slicer.app.layoutManager().threeDWidget(0).threeDView()
+        threeDView.resetCamera()
+        threeDView.resetFocalPoint()
+
         # === Set the newly created session as the currently active session ===
 
         self.getParameterNode().loaded_session = new_session

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -153,7 +153,10 @@ class SlicerOpenLIFUSession:
         assign_openlifu_metadata_to_volume_node(volume_node, volume_info)
 
         if (
-            any(len(transform_list)>0 for transform_list in session.virtual_fit_results.values()) # if there is a virtual fit result in the session
+            (
+                any(len(transform_list)>0 for transform_list in session.virtual_fit_results.values()) # if there is a virtual fit result in the session
+                or len(session.transducer_tracking_results)>0 # or if there is a transducer tracking result
+            )
             and get_skin_segmentation(volume_node) is None
         ):
             with BusyCursor():

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -158,6 +158,7 @@ class SlicerOpenLIFUSession:
         ):
             with BusyCursor():
                 generate_skin_segmentation(volume_node, foreground_mask) # provide foreground mask so that we don't waste time recomputing it
+            slicer.modules.OpenLIFUPrePlanningWidget.showSkin(volume_node)
 
         # Load targets
         target_nodes = [openlifu_point_to_fiducial(target) for target in session.targets]

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -13,9 +13,11 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode) -> vtkMRMLMo
     """
     volume_array = slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)) # the array indices come in KJI rather than IJK so we permute them
     volume_affine_RAS = get_IJK2RAS(volume_node)
-    skin_mesh = openlifu_lz().virtual_fit.compute_skin_mesh_from_volume(
-        volume_array = volume_array,
-        volume_affine_RAS = volume_affine_RAS)
+
+    foreground_mask_array = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+    foreground_mask_vtk_image = openlifu_lz().seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
+    skin_mesh = openlifu_lz().seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
+
     skin_mesh_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
     skin_mesh_node.SetAndObservePolyData(skin_mesh)
     

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -13,12 +13,17 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode, foreground_m
     skin segmentation is added as a model node attribute. Note, this is different from the openlifu volume id.
 
     An already computed foreground_mask_array may optionally be provided if it's available, to save the time of recomputing it.
+    If the foreground_mask_array is provided, then it is assumed to be in correspondence with (so in the same index order as)
+    the array you would get by applying `slicer.util.arrayFromVolume` to `volume_node`.
     """
     volume_array = slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)) # the array indices come in KJI rather than IJK so we permute them
     volume_affine_RAS = get_IJK2RAS(volume_node)
 
     if foreground_mask_array is None:
         foreground_mask_array = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+    else:
+        # if foreground_mask_array was provided, we assume the same index permutation as above is needed:
+        foreground_mask_array = foreground_mask_array.transpose((2,1,0))
     foreground_mask_vtk_image = openlifu_lz().seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
     skin_mesh = openlifu_lz().seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
 

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -611,6 +611,18 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.updateApprovalStatusLabel()
         self.updateWorkflowControls()
 
+    def showSkin(self, volume_node : vtkMRMLScalarVolumeNode) -> None:
+        """Enable visibility on the skin mesh node associted to a particular volume,
+        and update the associated visibility controls across SlicerOpenLIFU.
+
+        Raises an error if there is no skin mesh node.
+        """
+        skin_mesh_node = get_skin_segmentation(volume_node)
+        if skin_mesh_node is None:
+            raise RuntimeError(f"There is no skin mesh node associated to the volume {volume_node.GetID()}")
+        skin_mesh_node.SetDisplayVisibility(True)
+        slicer.modules.OpenLIFUTransducerTrackerWidget.updateModelRenderingSettings()
+
     def watchVirtualFit(self, virtual_fit_transform_node : vtkMRMLTransformNode):
         """Watch the virtual fit transform node to revoke approval in case the transform node is approved and then modified."""
         target_id = get_target_id_from_virtual_fit_result_node(virtual_fit_transform_node)

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -601,11 +601,9 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             # TODO: Make the virtual fit button both update the transducer transform and populate in the virtual fit results
             activeData["Transducer"].set_current_transform_to_match_transform_node(virtual_fit_result)
             self.watchVirtualFit(virtual_fit_result)
-            skin_mesh_node = get_skin_segmentation(activeData["Volume"])
-            skin_mesh_node.SetDisplayVisibility(True)
             activeData["Transducer"].set_visibility(True)
             slicer.modules.OpenLIFUTransducerTrackerWidget.updateVirtualFitResultForDisplay()
-            slicer.modules.OpenLIFUTransducerTrackerWidget.updateModelRenderingSettings()
+            self.showSkin(activeData["Volume"])
 
         self.updateApproveButton()
         self.updateApprovalStatusLabel()

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1969,9 +1969,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updateDistanceFromVFLabel()
         
             # Enable photoscan rendering options if tracking was run successfully and display the skin segmentation
-            skin_seg = get_skin_segmentation(activeData["Volume"])
-            self.ui.skinMeshVisibilityCheckBox.setChecked(True)
-            self.updateModelRenderingSettings()
+            slicer.modules.OpenLIFUPrePlanningWidget.showSkin(volume_node)
 
     def watchTransducerTrackingNode(self, transducer_tracking_transform_node: vtkMRMLTransformNode):
         """Watch the transducer tracking transform node to revoke approval in case the transform node is approved and then modified."""


### PR DESCRIPTION
Closes #399 

The main thing here is #399.
I threw in one extra thing: resetting the 3D view camera upon session load. It was just bugging me that the soren example always starts off-center.

**For review:** Cursory code review, and optionally test out by loading some sessions that have virtual fit results in them and other sessions that do not have virtual fit results in them. The commits are fairly atomic and could be looked at one by one. The commit "Show skin after generating it upon session load" could use a bit of extra attention to make sure I correctly enable skin mesh visibility after the framework that was recently introduced for #195.