### PR TITLE
Fix not caching wip protocols when creating new ones

### DIFF
--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -584,8 +584,6 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     @display_errors
     def onLoadProtocolFromFileClicked(self, checked:bool) -> None:
-        # You could load a non-cached protocol if you edit one, don't change
-        # protocols, then load the same protocol
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
             protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
@@ -611,8 +609,6 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     @display_errors
     def onLoadProtocolFromDatabaseClicked(self, checked:bool) -> None:
-        # You could load a non-cached protocol if you edit one, don't change
-        # protocols, then load the same protocol
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
             protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -448,6 +448,12 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
     @display_errors
     def onNewProtocolClicked(self, checked: bool) -> None:
         """Set the widget fields with default protocol values."""
+
+        # Cache protocol if unsaved changes.
+        if self._cur_save_state == SaveState.UNSAVED_CHANGES:
+            protocol_changed = self.getProtocolFromGUI(post_init=False)
+            self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
+
         protocol = self.logic.get_default_new_protocol()
         
         # Make sure default new protocol initialization has a unique id


### PR DESCRIPTION
Closes #347 

This fixes a bug where wip protocols were not being cached when creating new ones.

Note that there was a discussion about the behavior of the selector when a wip protocol changes the name, and for now we are sticking with the cached protocol being identified by both its old name and ID in the selector until the protocol is saved.  This may be revisited in the future.

## For review

Code review should be enough