### PR TITLE
Set default mesh recon options to be our favorite ones from the meshroom experiments

### DIFF
--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1385,11 +1385,12 @@ class PhotoscanGenerationOptionsDialog(qt.QDialog):
         self.meshroom_pipeline_combobox.setToolTip(
             "Meshroom pipelines are defined in the openlifu python library."
         )
+        self.meshroom_pipeline_combobox.setCurrentText('downsample_1x_pipeline')
 
         self.image_width_line_edit = qt.QLineEdit(self)
         image_width_validator = qt.QIntValidator(256, 16384, self)
         self.image_width_line_edit.setValidator(image_width_validator)
-        self.image_width_line_edit.text = "2048" # default value
+        self.image_width_line_edit.text = "1024" # default value
         form.addRow("Input image width:", self.image_width_line_edit)
         self.image_width_line_edit.setToolTip(
             "The width in pixels to which input photos should be resized before going through mesh reconstruction."
@@ -1419,7 +1420,7 @@ class PhotoscanGenerationOptionsDialog(qt.QDialog):
         self.num_images_line_edit = qt.QLineEdit(selection_group_box)
         num_images_validator = qt.QIntValidator(1, total_number_of_photos, self)
         self.num_images_line_edit.setValidator(num_images_validator)
-        self.default_num_images_value = str(min(50, total_number_of_photos))
+        self.default_num_images_value = str(min(45, total_number_of_photos))
         self.num_images_line_edit.text = self.default_num_images_value # default number of images
         self.num_images_line_edit.setToolTip("Use only every n^th image, setting n such that roughly this many images are used.")
         self.img_count_label = qt.QLabel(f"/ {self.total_number_of_photos}", selection_group_box)
@@ -1871,7 +1872,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
                     photocollection_reference_number = selected_reference_number,
                     meshroom_pipeline = photoscan_generation_options_dialog.get_selected_meshroom_pipeline(),
                     image_width = photoscan_generation_options_dialog.get_entered_image_width(),
-                    window_radius=1 if photoscan_generation_options_dialog.get_sequential_checked() else None,
+                    window_radius = 5 if photoscan_generation_options_dialog.get_sequential_checked() else None,
                     image_selection_settings = photoscan_generation_options_dialog.get_image_selection_settings(),
                     progress_callback = progress_callback,
                 )


### PR DESCRIPTION
Closes #389 

- [x] Before merging, this first needs to be rebased after Sadhana finishes with #357. This is because this requires openlifu v0.7.0 which, besides the needed mesh reconstruction functionality, also changes the virtual fit result format.

**For review:** Cursory code review. I have tested that mesh reconstruction works. Assuming you don't have meshroom, you can test out the dialog and just look it over by loading any session that has a photocollection and hitting "Start photoscan generation" in the TT module. Pressing "Ok" will fail if you haven't set up meshroom, but you can just look at the dialog and see how the radio buttons let you choose between two different modes of specifying the image skip rate.

Note: Until the above mentioned rebase, the only session you can test with this is `example_session`, because it does have some photocollections but it doesn't have a virtual fit result for openlifu to complain about. After the rebase, and before merging,  I will check some of the other examples.

Here is the `example_session` photoscan generated by the new default settings. This ran waaaay faster than our previous defaults

![image](https://github.com/user-attachments/assets/06e06b4e-5468-4d6d-9f88-59f681ec23c2)
