### PR TITLE
Prettify protocols and subject session dialogs

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -368,6 +368,10 @@ class LoadSubjectDialog(qt.QDialog):
         self.updateSubjectsList()
         self._enforceUserPermissions()
 
+        # Resize according to desktop size
+        screen = qt.QDesktopWidget().screenGeometry()
+        self.resize(int(screen.width() * 0.25), int(screen.height() * 0.25))
+
     def updateSubjectsList(self) -> None:
         self.tableWidget.setSortingEnabled(False) # turn off sorting during edit
 
@@ -557,6 +561,10 @@ class LoadSessionDialog(qt.QDialog):
 
         # ---- Populate Table ----
         self.update_sessions_list()
+
+        # Resize according to desktop size
+        screen = qt.QDesktopWidget().screenGeometry()
+        self.resize(int(screen.width() * 0.50), int(screen.height() * 0.25))
 
     def update_sessions_list(self):
         self.table_widget.setSortingEnabled(False) # turn off sorting during edit

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1101,6 +1101,16 @@ class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFo
         spacing_spinbox = self._field_widgets['spacing']
         self.modify_widget_spinbox(spacing_spinbox, default_value=1.0, min_value=0.1, max_value=2.0)
 
+        # Customize the button names and table size of the simulation options
+        # ('options')
+        options_dicttablewidget = self._field_widgets['options']
+        options_dicttablewidget.key_name = "Simulation Option"
+        options_dicttablewidget.val_name = "Value"
+        options_dicttablewidget.add_button.text = "Add Simulation Option"
+        options_dicttablewidget.remove_button.text = "Remove Simulation Option"
+        options_dicttablewidget.table.setHorizontalHeaderLabels(["Simulation Option", "Value"])
+        options_dicttablewidget.table.horizontalHeader().setSectionResizeMode(qt.QHeaderView.ResizeToContents)
+
 class OpenLIFUAbstractDelayMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
     def __init__(self):
         super().__init__([openlifu_lz().bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1083,7 +1083,7 @@ class OpenLIFUProtocolConfigTest(ScriptedLoadableModuleTest):
 
 class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget):
     def __init__(self, parent: Optional[qt.QWidget] = None):
-        super().__init__(openlifu_lz().sim.SimSetup, parent, is_collapsible=True, collapsible_title="Sim Setup")
+        super().__init__(openlifu_lz().sim.SimSetup, parent, is_collapsible=True, collapsible_title="Simulation Setup")
 
         # Modify the defaults and ranges for x_extent, y_extent, and z_extent
         x_ext_hbox = self._field_widgets['x_extent'].layout()

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1167,6 +1167,17 @@ class OpenLIFUAbstractSegmentationMethodDefinitionFormWidget(OpenLIFUAbstractMul
         """
         Overwrite of __init__ that mimics most of super()'s behavior, except
         accounts for the unique inheritance structure of SegmentationMethod.
+
+        The unique inheritance structure of SegmentationMethod in openlifu
+        suggests that while UniformWater and UniformTissue inherit from
+        UniformSegmentation (i.e. are child classes), they should be mutually
+        exclusive when selecting which implementation of the ABC
+        SegmentationMethod should be chosen. The only tangible difference is
+        that UniformWater and UniformTissue should not let you change the
+        Reference material; everything else should be the same. This means that
+        the implementation of the form widget below, for creating these classes,
+        must account for the immutability of the Reference Material only when
+        those classes are chosen.
         """
         # ---- Begin constructor overwrite ----
 
@@ -1221,6 +1232,18 @@ class OpenLIFUAbstractSegmentationMethodDefinitionFormWidget(OpenLIFUAbstractMul
         ref_material_line_edit = uniformwater_definition_form_widget._field_widgets['ref_material']
         ref_material_line_edit.setEnabled(False)
 
+        # ---- Edit the materials table for *each* ABC form ----
+
+        # Each form has a table for the segmentation materials. We want to
+        # customize the table in the same exact way for each ABC form.
+        for abc_form_widget_index in range(self.forms.count):
+            materials_dicttablewidget = self.forms.widget(abc_form_widget_index)._field_widgets['materials']
+            materials_dicttablewidget.key_name = "Material"
+            materials_dicttablewidget.val_name = "Definition"
+            materials_dicttablewidget.add_button.text = "Add Material"
+            materials_dicttablewidget.remove_button.text = "Remove Material"
+            materials_dicttablewidget.table.setHorizontalHeaderLabels(["Material", "Definition"])
+            materials_dicttablewidget.table.horizontalHeader().setSectionResizeMode(qt.QHeaderView.ResizeToContents)
 
 class OpenLIFUParameterConstraintsWidget(DictTableWidget):
 

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -1387,9 +1387,16 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
     def __init__(self):
         super().__init__(key_name="Parameter", val_name="Parameter Constraint")
 
-    # Override the add dialog to use a special dialog just for the parameter
-    # constraint
+        # Customize the name of the "Add entry" button, which is given by the
+        # super class DictTableWidget
+        self.add_button.text = "Add Parameter Constraint"
+        self.remove_button.text = "Remove Parameter Constraint"
+
     def _open_add_dialog(self):
+        """ Override the add dialog to use a special dialog just for the
+        parameter constraint. This is because parameter constraints are more
+        complex than what DictTableWidget, the parent class, provides as a
+        dialog for entering data"""
         existing_keys = list(self.to_dict().keys())
         createDlg = self.CreateParameterParameterConstraintDialog(existing_keys)
         returncode, param, param_constraint = createDlg.customexec_()


### PR DESCRIPTION
Contributes to #313 

This PR includes some minor changes that like substituting "Key" with "Simulation Option" in the protocol config.

I also added a minor change to the subject/session dialogs which displays them in ratio to desktop size (as opposed to hardcoded pixel values). I think this is marginally more user-friendly than the previous tables.

## For review

Open up the subject/session selector and see if it looks OK. Can you also create and save a protocol with a few custom options and then run it?