### PR TITLE
Handle when modify transform is clicked without vf selection

### DIFF
--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -845,7 +845,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
         selected_vf_result = self.getCurrentVirtualFitSelection()
         if selected_vf_result is None:
-            raise RuntimeError("No virtual fit result selected")
+            self.ui.modifyTransformPushButton.checked = False
+            return
         selected_transducer = self.algorithm_input_widget.get_current_data()["Transducer"]
 
         if not selected_vf_result.GetDisplayNode().GetEditorVisibility():


### PR DESCRIPTION
The Modify button is enabled even when no virtal fit result is selected in the results table. Instead of raising an error, the button should `return` and do nothing (#357 )

