### PR TITLE
Check if a fiducial node has observers  before removal

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1774,6 +1774,8 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
 
     def unwatch_fiducial_node(self, node:vtkMRMLMarkupsFiducialNode):
         """Un-does watch_fiducial_node; see watch_fiducial_node."""
+        if node.GetID() not in self.node_observations:
+            return
         for tag in self.node_observations.pop(node.GetID()):
             node.RemoveObserver(tag)
 


### PR DESCRIPTION
When a fiducial node is added or removed, the node is watched/unwatched in the data module, pre-planning module and transducer tracking widget (#272). When placing fiducials in the wizard, the following error sometimes errors in the data module and pre-planning module. 

```stacktrace
Traceback (most recent call last):
  File "C:/Users/sadhana.ravikumar/AppData/Local/Openwater/OpenLIFU 1.0.0-2025-06-17/bin/../lib/OpenLIFU-5.7/qt-scripted-modules/OpenLIFUData.py", line 1758, in onNodeRemoved
    self.unwatch_fiducial_node(node)
  File "C:/Users/sadhana.ravikumar/AppData/Local/Openwater/OpenLIFU 1.0.0-2025-06-17/bin/../lib/OpenLIFU-5.7/qt-scripted-modules/OpenLIFUData.py", line 1777, in unwatch_fiducial_node
    for tag in self.node_observations.pop(node.GetID()):
KeyError: 'vtkMRMLMarkupsFiducialNode3'
Traceback (most recent call last):
  File "C:/Users/sadhana.ravikumar/AppData/Local/Openwater/OpenLIFU 1.0.0-2025-06-17/bin/../lib/OpenLIFU-5.7/qt-scripted-modules/OpenLIFUData.py", line 1758, in onNodeRemoved
    self.unwatch_fiducial_node(node)
  File "C:/Users/sadhana.ravikumar/AppData/Local/Openwater/OpenLIFU 1.0.0-2025-06-17/bin/../lib/OpenLIFU-5.7/qt-scripted-modules/OpenLIFUData.py", line 1777, in unwatch_fiducial_node
    for tag in self.node_observations.pop(node.GetID()):
KeyError: 'vtkMRMLMarkupsFiducialNode3' 
```