### PR TITLE
Hide pnp rendering from photoscan preview and tracking wizard

### DIFF
--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -648,6 +648,8 @@ class OpenLIFUSonicationPlannerLogic(ScriptedLoadableModuleLogic):
             displayNode = volRenLogic.CreateDefaultVolumeRenderingNodes(pnp)
         volRenLogic.CopyDisplayToVolumeRenderingDisplayNode(displayNode)
         for view_node in slicer.util.getNodesByClass("vtkMRMLViewNode"):
+            if view_node.GetAttribute("isWizardViewNode") == "true": # Just incase, skip the wizard view nodes
+                continue
             view_node.SetRaycastTechnique(slicer.vtkMRMLViewNode.MaximumIntensityProjection)
         displayNode.SetVisibility(True)
         scalar_opacity_mapping = displayNode.GetVolumePropertyNode().GetVolumeProperty().GetScalarOpacity()


### PR DESCRIPTION
Closes #430 

The issue occured when a photoscan was previewed before a sonication solution was computed and rendered. Subsequent previews of the same photoscan incorrectly displayed the PNP rendering. 
By default, the pnp rendering display node includes the view node associated with the preview/tracking window.  This PR updates the way display nodes are hidden from certain views, by explicitly accounting for the case where a display node is associated with a non-empty list of view node IDs. 

For review:
- Confirm that the issue is fixed when following the sequence of actions described above.
- The second commit's fix is not essential for this issue, but I thought it might be better to exlude the wizard view nodes when `view_node.SetRaycastTechnique(slicer.vtkMRMLViewNode.MaximumIntensityProjection)` is called just incase..