### PR TITLE
Improve load database status and function

### DIFF
--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -113,6 +113,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
             "returnPressed()",
             lambda : self.onLoadDatabaseClicked(checked=True)
         )
+        self.ui.connectDatabaseButton.clicked.connect(self.onLoadDatabaseClicked)
         self.ui.databaseDirectoryLineEdit.currentPathChanged.connect(self.on_database_directory_path_changed)
 
         # You do not need to connect databaseDirectoryLineEdit

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -129,7 +129,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         self.initializeParameterNode()
 
         # Call the routine to update from data parameter node
-        self.updateWorkflowControls()
+        self.updateAll()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -139,7 +139,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         """Called each time the user opens this module."""
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
-        self.updateWorkflowControls()
+        self.updateAll()
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
@@ -242,13 +242,19 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         ]:
             self.updateSettingFromParameter(parameter_name)
 
-        # Update workflow controls
-        self.updateWorkflowControls()
+        # Update UI state
+        self.updateAll()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
-        self.updateWorkflowControls()
+        self.updateAll()
         if db is not None:
             self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).setStyleSheet("border: 1px solid green;")
+
+    def updateDatabaseConnectedStateLabel(self):
+        if self.logic.db is None:
+            self.ui.databaseConnectedStateLabel.text = "🔴 Database (not connected)"
+        else:
+            self.ui.databaseConnectedStateLabel.text = "🟢 Database (connected)"
 
     def updateWorkflowControls(self):
         if self.logic.db is None:
@@ -257,6 +263,10 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         else:
             self.workflow_controls.can_proceed = True
             self.workflow_controls.status_text = "Database connected, proceed to the next step."
+
+    def updateAll(self):
+        self.updateDatabaseConnectedStateLabel()
+        self.updateWorkflowControls()
 
     def on_database_directory_path_changed(self, new_path: str):
         """Called every time the ctkPathLineEdit is changed, even a single

--- a/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
+++ b/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
@@ -7,126 +7,98 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>933</height>
+    <height>784</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QWidget" name="permissionsWidget1" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+      </stringlist>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>1</height>
-      </size>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>311</width>
-        <height>111</height>
-       </rect>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QWidget" name="permissionsWidget1" native="true">
-         <property name="slicer.openlifu.allowed-roles" stdset="0">
-          <stringlist>
-           <string>admin</string>
-          </stringlist>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="databaseDirectoryLabel">
-            <property name="text">
-             <string>Database directory:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit">
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs</set>
-            </property>
-            <property name="showBrowseButton">
-             <bool>false</bool>
-            </property>
-            <property name="showHistoryButton">
-             <bool>false</bool>
-            </property>
-            <property name="SlicerParameterName" stdset="0">
-             <string>databaseDirectory</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="permissionsWidget2" native="true">
-         <property name="slicer.openlifu.allowed-roles" stdset="0">
-          <stringlist>
-           <string>admin</string>
-          </stringlist>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QPushButton" name="chooseDatabaseLocationButton">
-            <property name="text">
-             <string>Choose Database Location</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="databaseDirectoryLabel">
+        <property name="text">
+         <string>Database directory:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkPathLineEdit" name="databaseDirectoryLineEdit">
+        <property name="filters">
+         <set>ctkPathLineEdit::Dirs</set>
+        </property>
+        <property name="showBrowseButton">
+         <bool>false</bool>
+        </property>
+        <property name="showHistoryButton">
+         <bool>false</bool>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>databaseDirectory</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="ctkDynamicSpacer" name="DynamicSpacer">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QWidget" name="permissionsWidget2" native="true">
+     <property name="slicer.openlifu.allowed-roles" stdset="0">
+      <stringlist>
+       <string>admin</string>
+      </stringlist>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="chooseDatabaseLocationButton">
+        <property name="text">
+         <string>Choose Database Location</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QWidget" name="workflowControlsPlaceholder" native="true">
@@ -138,11 +110,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ctkDynamicSpacer</class>
-   <extends>QWidget</extends>
-   <header>ctkDynamicSpacer.h</header>
-  </customwidget>
   <customwidget>
    <class>ctkPathLineEdit</class>
    <extends>QWidget</extends>

--- a/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
+++ b/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
@@ -88,10 +88,47 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="connectDatabaseLocationButton">
+    <widget class="QPushButton" name="connectDatabaseButton">
      <property name="text">
       <string>Connect Database</string>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="databaseConnectedStateFrame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QLabel" name="databaseConnectedStateFrameTitle">
+        <property name="text">
+         <string>&lt;html&gt;
+  &lt;head/&gt;
+  &lt;body&gt;
+    &lt;p&gt;&lt;span style=&quot;font-weight:600; font-size:120%;&quot;&gt;Connection Status:&lt;/span&gt;&lt;/p&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="databaseConnectedStateLabel">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
+++ b/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
@@ -92,6 +92,9 @@
      <property name="text">
       <string>Connect Database</string>
      </property>
+     <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>
@@ -101,6 +104,9 @@
      </property>
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
+     </property>
+     <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
+      <bool>true</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>

--- a/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
+++ b/OpenLIFUDatabase/Resources/UI/OpenLIFUDatabase.ui
@@ -88,6 +88,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="connectDatabaseLocationButton">
+     <property name="text">
+      <string>Connect Database</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Closes #423 

While this doesn't load the database automatically in the extension, this PR adds an indicator similar to the status check used for connected transducer hardware (a77b7d1), as well as adds back in the connect database button.

Both are hidden in guided mode.  

## For review

Feel free to check out and connect a database. What do you think?