### PR TITLE
Don't auto-delete solutions during TT wizard (#431)

### DIFF
--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -337,7 +337,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.updateInputOptions()
         self.updateWorkflowControls()
         data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        if not data_logic.session_loading_unloading_in_progress:
+        if not data_logic.session_loading_unloading_in_progress and not slicer.util.getModuleWidget("OpenLIFUTransducerTracker")._running_wizard:
             reason = "The target was modified."
             self.revokeTargetApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)
@@ -347,7 +347,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.updateTargetPositionInputs()
 
         data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
-        if not data_logic.session_loading_unloading_in_progress:
+        if not data_logic.session_loading_unloading_in_progress and not slicer.util.getModuleWidget("OpenLIFUTransducerTracker")._running_wizard:
             reason = "The target was modified."
             self.revokeTargetApprovalIfAny(node, reason=reason)
             self.clearVirtualFitResultsIfAny(node, reason = reason)


### PR DESCRIPTION
Closed #431 

I took exactly your advice Sadhana

> Regarding #431, I'm not sure if this is what you were planning, but in addition to fixing the notify widget hiding the wizard, I don't think unlocking the fiducials should delete the solution. The solution should only get deleted depending on whether the user actually approves or cancels the tracking wizard and modifies the transform. Not sure if relevant, but in some cases I have used the self._running_wizard flag to ignore certain events when the wizard is running.

That worked perfectly. Indeed the solution deletion was being mis-triggered by the wizard's messing around with fiducial nodes.

I didn't adjust notification widget focus. That actually doesn't reproduce on linux -- I am guessing it's a windows thing. There is already a flag to prevent it from taking focus, but anyway even if it didn't take focus we probably shouldn't be showing notifications on the main window while the user is in the wizard, because they might not see them in that case. Any future notifications that occur during wizard interaction can just be parented to the wizard, if we need that.

**For review:** Code review is suffucient. No need to, but if you want to check that it works: you can load the soren example, compute a sonication solution, then run the TT wizard and unlock fiducials. No notificaiton should pop up about solutions being deleted. Only if you go through the wizard and approve at the end, triggering a movement of the transducer, should the solution get deleted.

