### PR TITLE
Fix android connection issues on windows

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -801,9 +801,9 @@ class StartPhotocollectionCaptureDialog(qt.QDialog):
         # The path /sdcard/DCIM/Camera/ is the standard internal storage path
         # from the Android device’s perspective when accessed via adb, not the
         # computer’s mounted file system like with Android File Transfer.
-        android_dir = Path("/sdcard/DCIM/Camera")
+        android_dir = "/sdcard/DCIM/Camera"
         result = subprocess.run(
-            ["adb", "shell", "ls", android_dir/f"{self.reference_number}_*.jpeg"],
+            ["adb", "shell", "ls", f"{android_dir}/{self.reference_number}_*"],
             capture_output=True, text=True
         ) 
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ sudo apt install android-tools-adb
 
 **Windows (PowerShell):**  
 
+> Make sure not to run PowerShell as admin.
+
 ```powershell
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 irm get.scoop.sh | iex
-scoop install android-platform-tools
+scoop install adb
 ```
 
 Or download from [Google's


### PR DESCRIPTION
Closes #442 

- Don't use pathlib for indexing the Android filesystem
- Accept any file extension in addition to the reference code; useful if phones take `jpg` or `png` as well as `jpeg`.
- Update the installation instructions for `adb` on Windows

## For review

Try to do a runthrough of importing a photocollection **on Windows**.  I did try and confirm that it works, as did the Openwater team.