### PR TITLE
Improve live transducer hardware connectivity and feedback

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@a5f725a11bde2dea657343bbf7554f7dd113ebf3
+openlifu==v0.8.0
 bcrypt

--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,2 @@
-openlifu==v0.7.1
+git+https://github.com/OpenwaterHealth/OpenLIFU-python.git@a5f725a11bde2dea657343bbf7554f7dd113ebf3
 bcrypt

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -438,6 +438,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             returncode, run_parameters = runCompleteDialog.customexec_()
             if returncode:
                 self.logic.create_openlifu_run(run_parameters)
+        self.updateAllButtonsEnabled()
 
     @display_errors
     def onDeviceConnected(self):        

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -826,12 +826,16 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         for f in self._on_lifu_device_connected_callbacks:
             f()
 
+        slicer.app.processEvents()
+
     def on_lifu_device_disconnected(self, descriptor, port):
         # This would be useful to uncomment if debugging hardware/software integration
         logging.info(f"❌ DISCONNECTED: {descriptor} from port {port}")
         
         for f in self._on_lifu_device_disconnected_callbacks:
             f()
+
+        slicer.app.processEvents()
     
     def on_lifu_data_received(self, descriptor, message):
         """Called when the LIFUInterface receives data from the hardware.
@@ -862,6 +866,8 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
         for f in self._on_lifu_device_data_received_callbacks:
             f(descriptor, message)
+
+        slicer.app.processEvents()
 
     def run(self):
         " Returns True when the sonication control algorithm is done"

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -433,11 +433,13 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         """If the soniction_run_complete variable changes from False to True, then open the RunComplete 
         dialog to determine whether the run should be saved. Saving the run creates a SlicerOpenLIFURun object and 
         writes the run to the database (only if there is an active session)."""
+        self.logic.cur_lifu_interface.stop_sonication()
         if new_sonication_run_complete_state:
             runCompleteDialog = OnRunCompletedDialog(True)
             returncode, run_parameters = runCompleteDialog.customexec_()
             if returncode:
                 self.logic.create_openlifu_run(run_parameters)
+        self.logic.stop()
         self.updateAllButtonsEnabled()
 
     @display_errors
@@ -883,6 +885,13 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         
         # TODO START SONICATION on HARDWARE
         self.cur_lifu_interface.start_sonication()        
+
+    def stop(self):
+        # ---- Start the run ----
+        self.running = False
+        
+        # TODO START SONICATION on HARDWARE
+        self.cur_lifu_interface.stop_sonication()    
 
     def abort(self) -> None:
         # Assumes that the sonication control algorithm will have a callback function to abort run, 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -462,6 +462,12 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     @display_errors
     def onReinitializeLIFUInterfacePushButtonClicked(self, checked=False):
+
+        slicer.util.warningDisplay(
+            text = f"Reinitializing the LIFUInterface in test mode is not fully supported and may result in unexpected application behavior. If this was a mistake, restart the app and use the real transducer hardware.",
+            windowTitle="Test Mode Not Supported", parent = slicer.util.mainWindow()
+        )
+
         new_test_mode_state = not self.logic.cur_lifu_interface._test_mode
         logging.info("Reinitializing LIFUInterface with test_mode =", new_test_mode_state)
         

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -434,6 +434,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         dialog to determine whether the run should be saved. Saving the run creates a SlicerOpenLIFURun object and 
         writes the run to the database (only if there is an active session)."""
         self.logic.cur_lifu_interface.stop_sonication()
+        
+        self.ui.runHardwareStatusLabel.setProperty("text", "Run Completed.")
+        
         if new_sonication_run_complete_state:
             runCompleteDialog = OnRunCompletedDialog(True)
             returncode, run_parameters = runCompleteDialog.customexec_()
@@ -526,7 +529,8 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def updateRunProgressBar(self, new_run_progress_value = None):
         """Update the run progress bar. 0% if there is no existing  run, 100% if there is an existing run."""
         self.ui.runProgressBar.maximum = 100 
-        if new_run_progress_value is not None:
+        if new_run_progress_value is not None:            
+            self.ui.runHardwareStatusLabel.setProperty("text", "Run in progress.")
             self.ui.runProgressBar.value = new_run_progress_value
         else:
             if get_openlifu_data_parameter_node().loaded_run is None:
@@ -611,6 +615,7 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
             self._monitor_loop.run_until_complete(
                 self.cur_lifu_interface.start_monitoring(interval=1)
             )
+            self._monitor_loop.run_forever()
         except Exception as e:
             logging.error(f"[LIFU] Monitor loop error: {e}")
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -605,8 +605,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
 
     def _pumpMonitoringLoop(self):
-        self._monitor_loop.stop()
-        self._monitor_loop.run_forever()
+        if self._monitor_loop.is_running():
+            # Harmless tickle: sends a no-op callback into the loop to keep it alive
+            self._monitor_loop.call_soon_threadsafe(lambda: None)
 
     def _run_monitor_loop(self):
         """Runs the asyncio event loop to monitor USB device status."""
@@ -672,7 +673,7 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         self._monitor_thread.start()
 
         self.monitoring_timer = qt.QTimer()
-        self.monitoring_timer.setInterval(1)
+        self.monitoring_timer.setInterval(100)
         self.monitoring_timer.timeout.connect(self._pumpMonitoringLoop)
         self.monitoring_timer.start()
 


### PR DESCRIPTION
Closes #449 

This PR (most commits were fully authored by @duvitech-llc / @georgevigelette ) addresses several gaps in the main branch related to hardware integration and runtime status handling:

- Fix real-time data callbacks to process hardware status updates during sonication, which were previously missing.
> Note: `on_lifu_data_received` has an implementation that forces some data processing to happen from within the sonication control module. For instance, in addition to the pulse train percent for progress bar updates, we also receive `STOPPED` via the interface signal and then set the hardware status of the interface. This is not preferred, as it exposes Slicer to processing that should happen below the interface abstraction. We should just be able to poll the status via `get_status` and not have to call `set_status` externally.
- Implemented proper stop behavior at the end of sonication, ensuring the interface halts transmission and updates the UI accordingly.
- Restored connect/disconnect signals and UI updates, which were only firing on manual UI interaction before.
- Established UI progress and connection indicators based on actual hardware signals (e.g., trigger pulses detected on oscilloscope now propagate to the UI, and voltage rails are set correctly on “Run”).
- **Added a warning for re-initializing the interface in test mode. Lots of the logic around hardware mocking was removed and not replaced in some of the changes, so it is unlikely to work.** 

## For review:

@peterhollender , make sure that if you have a transducer device that things work as expected. @ebrahimebrahim or @sadhana-r it would be good to have a pass over the code as well.

## Acknowledgement

Most commits in this PR were authored by @duvitech-llc  / @georgevigelette 