### PR TITLE
Improve Android image extraction workflow

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2918,7 +2918,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 f"Photocollection reference_number {photocollection_parameters['reference_number']} already exists in the database for session {session_id}. Overwrite photocollection?",
                 "Photocollection already exists"
             ):
-                return
+                raise RuntimeError("Could not overwrite photocollection because user declined.")
 
         reference_number = photocollection_parameters.get("reference_number")
         photo_abspaths = photocollection_parameters.get("photo_paths")

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -2920,8 +2920,13 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             ):
                 return
 
-        reference_number = photocollection_parameters.pop("reference_number")
-        photo_abspaths = photocollection_parameters.pop("photo_paths")
+        reference_number = photocollection_parameters.get("reference_number")
+        photo_abspaths = photocollection_parameters.get("photo_paths")
+
+        if reference_number is None:
+            raise ValueError("Missing required parameter: 'reference_number'")
+        if photo_abspaths is None:
+            raise ValueError("Missing required parameter: 'photo_paths'")
 
         get_cur_db().write_photocollection(subject_id, session_id, reference_number,
                                       photo_abspaths, on_conflict =

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1223,6 +1223,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         self.ui.loadVolumeButton.clicked.connect(self.onLoadVolumePressed)
         self.ui.loadFiducialsButton.clicked.connect(self.onLoadFiducialsPressed)
         self.ui.loadTransducerButton.clicked.connect(self.onLoadTransducerPressed)
+        self.ui.loadPhotocollectionButton.clicked.connect(self.onLoadPhotocollectionPressed)
         self.ui.loadPhotoscanButton.clicked.connect(self.onLoadPhotoscanPressed)
 
         # Inject guided mode workflows
@@ -1356,21 +1357,6 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         return True
 
     @display_errors
-    def on_import_photocollection_clicked(self, checked:bool):
-        loaded_session = self._parameterNode.loaded_session
-        if loaded_session is None:
-            raise RuntimeError("Cannot import photocollection because a session is not loaded.")
-
-        importDlg = ImportPhotocollectionFromDiskDialog()
-        returncode, photocollection_dict = importDlg.customexec_()
-        if not returncode:
-            return False
-
-        self.logic.add_photocollection_to_database(loaded_session.get_subject_id(), loaded_session.get_session_id(), photocollection_dict.copy())  # logic mutates the dict
-        self._parameterNode.session_photocollections.append(photocollection_dict["reference_number"]) # automatically load as well
-        self.logic.update_photocollections_affiliated_with_loaded_session()
-
-    @display_errors
     def on_capture_photocollection_clicked(self, checked:bool) -> bool:
         loaded_session = self._parameterNode.loaded_session
         if loaded_session is None:
@@ -1462,6 +1448,21 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
         # Instead, using a workaround that directly calls the ioManager with the correct file type name for Markups.
         ioManager = slicer.app.ioManager()
         return ioManager.openDialog("MarkupsFile", slicer.qSlicerFileDialog.Read)
+
+    @display_errors
+    def onLoadPhotocollectionPressed(self, checked:bool):
+        loaded_session = self._parameterNode.loaded_session
+        if loaded_session is None:
+            raise RuntimeError("Cannot import photocollection because a session is not loaded.")
+
+        importDlg = ImportPhotocollectionFromDiskDialog()
+        returncode, photocollection_dict = importDlg.customexec_()
+        if not returncode:
+            return False
+
+        self.logic.add_photocollection_to_database(loaded_session.get_subject_id(), loaded_session.get_session_id(), photocollection_dict.copy())  # logic mutates the dict
+        self._parameterNode.session_photocollections.append(photocollection_dict["reference_number"]) # automatically load as well
+        self.logic.update_photocollections_affiliated_with_loaded_session()
 
     @display_errors
     def onLoadPhotoscanPressed(self, checked:bool) -> None:

--- a/OpenLIFUData/Resources/UI/OpenLIFUData.ui
+++ b/OpenLIFUData/Resources/UI/OpenLIFUData.ui
@@ -446,8 +446,14 @@
    </item>
    <item>
     <widget class="ctkCollapsibleButton" name="objectsCollapsibleButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="text">
       <string>OpenLIFU Objects</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <property name="collapsed">
       <bool>true</bool>
@@ -490,6 +496,13 @@
        <widget class="QPushButton" name="loadFiducialsButton">
         <property name="text">
          <string>Load Fiducial</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="loadPhotocollectionButton">
+        <property name="text">
+         <string>Load Photocollection</string>
         </property>
        </widget>
       </item>

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1669,7 +1669,7 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         data_module = slicer.util.getModuleWidget('OpenLIFUData')
         self.ui.startPhotocollectionCaptureButton.clicked.connect(data_module.on_capture_photocollection_clicked)
         self.ui.startPhotoscanGenerationButton.clicked.connect(self.onStartPhotoscanGenerationButtonClicked)
-        self.ui.importPhotocollectionFromDiskButton.clicked.connect(data_module.on_import_photocollection_clicked)
+        self.ui.importPhotocollectionFromDiskButton.clicked.connect(data_module.onLoadPhotocollectionPressed)
         self.resetPhotoscanGeneratorProgressDisplay()
         # ------------------------------------------
 

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1671,10 +1671,8 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.addObserver(slicer.mrmlScene, slicer.vtkMRMLScene.NodeRemovedEvent, self.onNodeRemoved)
 
         # ---- Photoscan generation connections ----
-        data_module = slicer.util.getModuleWidget('OpenLIFUData')
         self.ui.referenceNumberRefreshButton.clicked.connect(self.on_reference_number_refresh_clicked)
         self.ui.transferPhotocollectionFromAndroidDeviceButton.clicked.connect(self.on_transfer_photocollection_from_android_device_clicked)
-        self.ui.startPhotocollectionCaptureButton.clicked.connect(data_module.on_capture_photocollection_clicked)
         self.ui.startPhotoscanGenerationButton.clicked.connect(self.onStartPhotoscanGenerationButtonClicked)
         self.resetPhotoscanGeneratorProgressDisplay()
 
@@ -2217,14 +2215,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.quantitativeTransducerTrackingMetricLabel.hide()
             return
 
-    def updateStartPhotocollectionCaptureButton(self):
-        if get_openlifu_data_parameter_node().loaded_session is None:
-            self.ui.startPhotocollectionCaptureButton.setEnabled(False)
-            self.ui.startPhotocollectionCaptureButton.setToolTip("Adding a photocollection requires an active session.")
-        else:
-            self.ui.startPhotocollectionCaptureButton.setEnabled(True)
-            self.ui.startPhotocollectionCaptureButton.setToolTip("Add a photocollection to the active session.")
-
     def updateStartPhotoscanGenerationButton(self):
         if get_openlifu_data_parameter_node().loaded_session is None:
             self.ui.startPhotoscanGenerationButton.setEnabled(False)
@@ -2237,7 +2227,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.startPhotoscanGenerationButton.setToolTip("Click to begin photoscan generation from a photocollection of the subject. This process can take up to 20 minutes.")
 
     def updatePhotoscanGenerationButtons(self):
-        self.updateStartPhotocollectionCaptureButton()
         self.updateStartPhotoscanGenerationButton()
 
     def updateApprovalStatusLabel(self):

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1892,7 +1892,11 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             )
             return
 
-        data_parameter_node.session_photocollections.append(photocollection_dict["reference_number"]) # automatically load as well
+        # Below is done twice because session_photocollections stored in the
+        # data parameter node is not the same as those stored in
+        # SlicerOpenLIFUSession and both must be updated
+        if photocollection_dict["reference_number"] not in data_parameter_node.session_photocollections:
+            data_parameter_node.session_photocollections.append(photocollection_dict["reference_number"]) # automatically load as well
         data_logic.update_photocollections_affiliated_with_loaded_session()
 
         slicer.util.infoDisplay(

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1864,7 +1864,9 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             )
             return
 
-        pulled_files = self.logic.pull_photocollection_from_android(cur_reference_number)
+        with BusyCursor():
+            pulled_files = self.logic.pull_photocollection_from_android(cur_reference_number)
+
         photocollection_dict = {
             "reference_number" : cur_reference_number,
             "photo_paths" : pulled_files,

--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -1669,7 +1669,6 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
         data_module = slicer.util.getModuleWidget('OpenLIFUData')
         self.ui.startPhotocollectionCaptureButton.clicked.connect(data_module.on_capture_photocollection_clicked)
         self.ui.startPhotoscanGenerationButton.clicked.connect(self.onStartPhotoscanGenerationButtonClicked)
-        self.ui.importPhotocollectionFromDiskButton.clicked.connect(data_module.onLoadPhotocollectionPressed)
         self.resetPhotoscanGeneratorProgressDisplay()
         # ------------------------------------------
 
@@ -2164,18 +2163,9 @@ class OpenLIFUTransducerTrackerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.ui.startPhotoscanGenerationButton.setEnabled(True)
             self.ui.startPhotoscanGenerationButton.setToolTip("Click to begin photoscan generation from a photocollection of the subject. This process can take up to 20 minutes.")
 
-    def updateImportPhotocollectionFromDiskButton(self):
-        if get_openlifu_data_parameter_node().loaded_session is None:
-            self.ui.importPhotocollectionFromDiskButton.setEnabled(False)
-            self.ui.importPhotocollectionFromDiskButton.setToolTip("Adding a photocollection requires an active session.")
-        else:
-            self.ui.importPhotocollectionFromDiskButton.setEnabled(True)
-            self.ui.importPhotocollectionFromDiskButton.setToolTip("Add a photocollection to the active session.")
-
     def updatePhotoscanGenerationButtons(self):
         self.updateStartPhotocollectionCaptureButton()
         self.updateStartPhotoscanGenerationButton()
-        self.updateImportPhotocollectionFromDiskButton()
 
     def updateApprovalStatusLabel(self):
         """ Updates the status message that displays which photoscans have been approved or have

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>563</width>
-    <height>722</height>
+    <height>768</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -59,31 +59,14 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="photoscanGeneratorButtons">
-           <item>
-            <widget class="QPushButton" name="startPhotocollectionCaptureButton">
-             <property name="toolTip">
-              <string>Start a photocollection capture from the 3D Open Water app</string>
-             </property>
-             <property name="text">
-              <string>Start Photocollection Capture</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="importPhotocollectionFromDiskButton">
-             <property name="toolTip">
-              <string>Import a photocollection from a directory of photos on disk</string>
-             </property>
-             <property name="text">
-              <string>Import Photocollection From Disk</string>
-             </property>
-             <property name="slicer.openlifu.hide-in-guided-mode" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <widget class="QPushButton" name="startPhotocollectionCaptureButton">
+           <property name="toolTip">
+            <string>Start a photocollection capture from the 3D Open Water app</string>
+           </property>
+           <property name="text">
+            <string>Start Photocollection Capture</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="startPhotoscanGenerationButton">
@@ -230,7 +213,7 @@
               <property name="value">
                <double>0.500000000000000</double>
               </property>
-              <property name="quantity">
+              <property name="quantity" stdset="0">
                <string notr="true"/>
               </property>
              </widget>
@@ -273,7 +256,7 @@
               <property name="value">
                <double>0.500000000000000</double>
               </property>
-              <property name="quantity">
+              <property name="quantity" stdset="0">
                <string notr="true"/>
               </property>
              </widget>
@@ -318,17 +301,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLSliderWidget</class>
-   <extends>ctkSliderWidget</extends>
-   <header>qMRMLSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
@@ -338,6 +310,17 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -102,16 +102,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="startPhotocollectionCaptureButton">
-           <property name="toolTip">
-            <string>Start a photocollection capture from the 3D Open Water app</string>
-           </property>
-           <property name="text">
-            <string>Start Photocollection Capture</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QPushButton" name="startPhotoscanGenerationButton">
            <property name="text">
             <string>Start Photoscan Generation</string>

--- a/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
+++ b/OpenLIFUTransducerTracker/Resources/UI/OpenLIFUTransducerTracker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>563</width>
-    <height>768</height>
+    <height>842</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -55,6 +55,49 @@
            </property>
            <property name="margin">
             <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="photocollectionCaptureLayout">
+           <property name="spacing">
+            <number>12</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="referenceNumberLabel">
+             <property name="text">
+              <string>Photocollection Reference Number:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="referenceNumberLineEdit">
+             <property name="font">
+              <font>
+               <family>Courier New</family>
+              </font>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="referenceNumberRefreshButton">
+             <property name="text">
+              <string>🔄</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QPushButton" name="transferPhotocollectionFromAndroidDeviceButton">
+           <property name="toolTip">
+            <string>Start a photocollection capture from the 3D Open Water app</string>
+           </property>
+           <property name="text">
+            <string>Transfer Photocollection from Android Device</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Closes #445 
Closes #378 

This adds a few changes to the functionality for extracting images taken from the android device, making the functionality more manual and removing the guided approach. Clearer feedback was introduced for errors, such as when the reference number is not found on the Android but it is connected. There was some despaghettification of the code around photocollection reference number conflict warnings, but the existence of loaded data being tracked in two locations (the session wrapper and the data parameter session data) means some of the undesirable parts remain even after this PR.

## For review

A code review should be good. I did a manual test with the Android app, as we do not have any CI/CD implemented for that.