### PR TITLE
Clean up scene when deleting solution analysis on target modified

### DIFF
--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -344,7 +344,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         """
         data_logic : "OpenLIFUDataLogic" = slicer.util.getModuleLogic('OpenLIFUData')
         if self.logic.solution_analysis_exists():
-            data_logic.clear_solution(clean_up_scene=False)
+            data_logic.clear_solution(clean_up_scene=True)
             self._parameterNode.solution_analysis = None
             notify(f"Solution deleted:\n{reason}")
 


### PR DESCRIPTION
Closes #438 

Changes the default setting to clean up the scene when a solution is deleted on target modfication. 

For Review:

- With the example subject/sesssion - I get the notify message multiple times when a solution is deleted after I move the target after computing a solution. I didn't see this happen with the Soren example. Could you confirm if this happens for you?