### PR TITLE
Fix transducer tracking outside of session context

### DIFF
--- a/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
+++ b/OpenLIFUTransducerTracker/OpenLIFUTransducerTracker.py
@@ -221,13 +221,14 @@ class FacialLandmarksMarkupPageBase(qt.QWizardPage):
         self.currently_placing_node.GetNthControlPointPosition(0, position)
         self.facial_landmarks_fiducial_node.SetNthControlPointPosition(self._currentlyPlacingIndex, position)
         self.facial_landmarks_fiducial_node.SetNthControlPointLabel(self._currentlyPlacingIndex, caller.GetName())
-
+        self.facial_landmarks_fiducial_node.SetLocked(False)
         self.exitPlaceFiducialMode()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore") # if the observer doesn't exist, then no problem we don't need to see the warning.
             self.currently_placing_node.RemoveObserver(self._pointModifiedObserverTag)
             slicer.mrmlScene.RemoveNode(self.currently_placing_node)
         self.temp_markup_fiducials[self.currently_placing_node.GetName()] = None
+        
         if self._checkAllLandmarksDefined():
             self.updateLandmarkPlacementStatus()
 


### PR DESCRIPTION
Closes #457 

### For Review

Confirm that tt workflow functions without errors outside of the session context. You can do this by loading the individual protocol/transducer/volume and photoscan in the data module (I used the objects affiliated with Soren). 

Similar to a session-based workflow, during the manual workflow, if the user loads two photoscans, tracking can only be approved for one photoscan at a time. 

Note: While testing with multiple photoscans, I discovered #469. This is not yet resolved. 
