### PR TITLE
Speed up virtual fitting

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,2 +1,3 @@
-openlifu==v0.9.0
+openlifu==v0.10.0
 bcrypt
+threadpoolctl

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -1,4 +1,4 @@
-from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz, bcrypt_lz
+from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz, bcrypt_lz, threadpoolctl_lz
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPoint,
     SlicerOpenLIFUXADataset,
@@ -33,6 +33,7 @@ __all__ = [
     "openlifu_lz",
     "xarray_lz",
     "bcrypt_lz",
+    "threadpoolctl_lz"
     "SlicerOpenLIFUSolution",
     "SlicerOpenLIFUProtocol",
     "SlicerOpenLIFUTransducer",

--- a/OpenLIFULib/OpenLIFULib/lazyimport.py
+++ b/OpenLIFULib/OpenLIFULib/lazyimport.py
@@ -18,7 +18,12 @@ def install_python_requirements() -> None:
 
 def python_requirements_exist() -> bool:
     """Check and return whether python requirements are installed."""
-    return importlib.util.find_spec('openlifu') is not None
+    try:
+        import threadpoolctl
+        import bcrypt
+    except ModuleNotFoundError:
+        return False
+    return importlib.util.find_spec('openlifu') is not None # openlifu import causes a delay so we check for it without actually importing yet
 
 def check_and_install_python_requirements(prompt_if_found = False) -> None:
     """Check whether python requirements are installed and prompt to install them if not.
@@ -73,3 +78,10 @@ def bcrypt_lz() -> "bcrypt":
         with BusyCursor():
             import bcrypt
     return sys.modules["bcrypt"]
+
+def threadpoolctl_lz() -> "threadpoolctl":
+    """Import threadpoolctl and return the module, checking that it is installed along the way."""
+    if "threadpoolctl" not in sys.modules:
+        check_and_install_python_requirements(prompt_if_found=False)
+        import threadpoolctl
+    return sys.modules["threadpoolctl"]


### PR DESCRIPTION
This is work towards https://github.com/OpenwaterHealth/OpenLIFU-python/issues/367

---

- Incorporate embree speedups from the work on https://github.com/OpenwaterHealth/OpenLIFU-python/issues/367
- Cap BLAS threads, which seems to help the  pos search when not using embree. I tried this on ubuntu 22.04.

---

Before merging
- [x] replace  hash by versioned OpenLIFU-python requirement