### PR TITLE
Add peak negative pressure window level / opacity threshold controls

### DIFF
--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -419,12 +419,9 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def onPnpColorSliderChanged(self, new_min_val: float, new_max_val: float) -> None:
         """Called when the PNP color slider values are changed."""
-        slicer.app.processEvents() # Ensures slider remains responsive
-
         data_parameter_node = get_openlifu_data_parameter_node()
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
         pnp_volume_node.GetDisplayNode().AutoWindowLevelOff()
-        #pnp_volume_node.GetDisplayNode().SetWindowLevel(new_min_val, new_max_val)
         pnp_volume_node.GetDisplayNode().SetWindowLevelMinMax(new_min_val, new_max_val)
 
         vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
@@ -433,8 +430,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def onPnpOpacitySliderChanged(self, new_min_val: float) -> None:
         """Called when the PNP opacity slider value is changed."""
-        slicer.app.processEvents() # Ensures slider remains responsive
-
         data_parameter_node = get_openlifu_data_parameter_node()
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
         pnp_volume_node.GetDisplayNode().SetThreshold(new_min_val, self.ui.pnpOpacitySlider.maximum)

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -354,7 +354,17 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.pnpColorSlider.blockSignals(False)
         self.ui.pnpOpacitySlider.blockSignals(False)
         self._updating_gui_from_sliders = False
-    
+
+        # Set up thresholding and following volume display node
+        pnp_volume_node.GetDisplayNode().SetAutoWindowLevel(0)
+        pnp_volume_node.GetDisplayNode().SetApplyThreshold(1)
+
+        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
+        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
+          vrDisplayNode.SetFollowVolumeDisplayNode(1)
+        if vrDisplayNode is not None and vrDisplayNode.GetIgnoreVolumeDisplayNodeThreshold():
+          vrDisplayNode.SetIgnoreVolumeDisplayNodeThreshold(0)
+
         # Manually trigger updates to apply the new default values.
         self.onPnpColorSliderChanged(self.ui.pnpColorSlider.minimumValue, self.ui.pnpColorSlider.maximumValue)
         self.onPnpOpacitySliderChanged(self.ui.pnpOpacitySlider.value)
@@ -421,12 +431,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         """Called when the PNP color slider values are changed."""
         data_parameter_node = get_openlifu_data_parameter_node()
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
-        pnp_volume_node.GetDisplayNode().AutoWindowLevelOff()
         pnp_volume_node.GetDisplayNode().SetWindowLevelMinMax(new_min_val, new_max_val)
-
-        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
-        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
-          vrDisplayNode.SetFollowVolumeDisplayNode(1)
 
     def onPnpOpacitySliderChanged(self, new_min_val: float) -> None:
         """Called when the PNP opacity slider value is changed."""
@@ -434,9 +439,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
         pnp_volume_node.GetDisplayNode().SetThreshold(new_min_val, self.ui.pnpOpacitySlider.maximum)
 
-        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
-        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
-          vrDisplayNode.SetFollowVolumeDisplayNode(1)
 
     def deleteSolutionAndSolutionAnalysisIfAny(self, reason:str):
         """Delete the solution in the data module and the solution analysis in

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -337,15 +337,18 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.pnpOpacitySlider.blockSignals(True)
     
         # Configure the color slider (double-handled).
+        N_STEPS = 200.
         self.ui.pnpColorSlider.minimum = 0
         self.ui.pnpColorSlider.maximum = target_pressure * 1.5
         self.ui.pnpColorSlider.minimumValue = 0
         self.ui.pnpColorSlider.maximumValue = target_pressure
+        self.ui.pnpColorSlider.singleStep = (target_pressure - 0) / N_STEPS
     
         # Configure the opacity slider (single-handled).
         self.ui.pnpOpacitySlider.minimum = 0
         self.ui.pnpOpacitySlider.maximum = max_pnp_in_array
         self.ui.pnpOpacitySlider.value = 0.1 * target_pressure
+        self.ui.pnpOpacitySlider.singleStep = (max_pnp_in_array - 0) / N_STEPS
     
         # Unblock signals.
         self.ui.pnpColorSlider.blockSignals(False)
@@ -413,7 +416,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.logic.render_pnp()
         else:
             self.logic.hide_pnp()
-        self.updatePNPSliders()
 
     def onPnpColorSliderChanged(self, new_min_val: float, new_max_val: float) -> None:
         """Called when the PNP color slider values are changed."""

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -413,20 +413,31 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.logic.hide_pnp()
         self.updatePNPSliders()
 
-    def onPnpColorSliderChanged(self, min_val: float, max_val: float) -> None:
+    def onPnpColorSliderChanged(self, new_min_val: float, new_max_val: float) -> None:
         """Called when the PNP color slider values are changed."""
         slicer.app.processEvents() # Ensures slider remains responsive
-        # TODO: Implement logic to update volume rendering color transfer function
-        print(f"PNP Color Range Changed: Min={min_val:.3f}, Max={max_val:.3f}")
-        pass
 
-    def onPnpOpacitySliderChanged(self, value: float) -> None:
+        data_parameter_node = get_openlifu_data_parameter_node()
+        pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
+        pnp_volume_node.GetDisplayNode().AutoWindowLevelOff()
+        #pnp_volume_node.GetDisplayNode().SetWindowLevel(new_min_val, new_max_val)
+        pnp_volume_node.GetDisplayNode().SetWindowLevelMinMax(new_min_val, new_max_val)
+
+        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
+        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
+          vrDisplayNode.SetFollowVolumeDisplayNode(1)
+
+    def onPnpOpacitySliderChanged(self, new_min_val: float) -> None:
         """Called when the PNP opacity slider value is changed."""
         slicer.app.processEvents() # Ensures slider remains responsive
-        # TODO: Implement logic to update volume rendering opacity transfer function
-        # This will set the cutoff for the opacity ramp.
-        print(f"PNP Opacity Threshold Changed: Value={value:.3f}")
-        pass
+
+        data_parameter_node = get_openlifu_data_parameter_node()
+        pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
+        pnp_volume_node.GetDisplayNode().SetThreshold(new_min_val, self.ui.pnpOpacitySlider.maximum)
+
+        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
+        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
+          vrDisplayNode.SetFollowVolumeDisplayNode(1)
 
     def deleteSolutionAndSolutionAnalysisIfAny(self, reason:str):
         """Delete the solution in the data module and the solution analysis in

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -742,7 +742,7 @@ class OpenLIFUSonicationPlannerLogic(ScriptedLoadableModuleLogic):
     def render_pnp(self) -> None:
         """
         Renders the PNP solution in both the 3D view (as a volume rendering)
-        and all 2D slice views (as a foreground overlay).
+        and all 2D slice views (as a fully opaque foreground overlay).
         """
         pnp = self.get_pnp()
         if pnp is None:
@@ -769,8 +769,8 @@ class OpenLIFUSonicationPlannerLogic(ScriptedLoadableModuleLogic):
         scalar_opacity_mapping.AddPoint(vmax,1.0)
         
         # --- 2D Slice View Logic (Foreground Layer) ---
-        # The best way to SET the foreground layer universally.
-        slicer.util.setSliceViewerLayers(foreground=pnp, foregroundOpacity=0.5)
+        # Set the foreground layer with 100% opacity.
+        slicer.util.setSliceViewerLayers(foreground=pnp, foregroundOpacity=1.0)
 
     def hide_pnp(self) -> None:
         """

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -322,7 +322,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         if not isinstance(target_pressure, (int, float)) or target_pressure <= 0:
             return
 
-        pnp_volume_node: "vtkMRMLScalarVolumeNode" = solution_wrapper.pnp
+        pnp_volume_node: "vtkMRMLScalarVolumeNode" = self.logic.get_pnp()
         max_pnp_in_array = pnp_volume_node.GetImageData().GetPointData().GetScalars().GetRange()[1]
     
         # If all checks passed, enable the UI elements.
@@ -429,14 +429,12 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def onPnpColorSliderChanged(self, new_min_val: float, new_max_val: float) -> None:
         """Called when the PNP color slider values are changed."""
-        data_parameter_node = get_openlifu_data_parameter_node()
-        pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
+        pnp_volume_node: "vtkMRMLScalarVolumeNode" = self.logic.get_pnp()
         pnp_volume_node.GetDisplayNode().SetWindowLevelMinMax(new_min_val, new_max_val)
 
     def onPnpOpacitySliderChanged(self, new_min_val: float) -> None:
         """Called when the PNP opacity slider value is changed."""
-        data_parameter_node = get_openlifu_data_parameter_node()
-        pnp_volume_node: "vtkMRMLScalarVolumeNode" = data_parameter_node.loaded_solution.pnp
+        pnp_volume_node: "vtkMRMLScalarVolumeNode" = self.logic.get_pnp()
         pnp_volume_node.GetDisplayNode().SetThreshold(new_min_val, self.ui.pnpOpacitySlider.maximum)
 
 

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -171,7 +171,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
 
         self.ui.solutionPushButton.clicked.connect(self.onComputeSolutionClicked)
-        self.ui.renderPNPCheckBox.clicked.connect(self.onrenderPNPCheckBoxClicked)
+        self.ui.renderPNPCheckBox.toggled.connect(self.onrenderPNPCheckBoxToggled)
         self.ui.approveButton.clicked.connect(self.onApproveClicked)
 
         # Connect PNP sliders
@@ -404,9 +404,11 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
             finally:
                 self.updateSolutionProgressBar()
 
+        self.ui.renderPNPCheckBox.checked = True
+
         self.updateWorkflowControls()
 
-    def onrenderPNPCheckBoxClicked(self, checked:bool):
+    def onrenderPNPCheckBoxToggled(self, checked:bool):
         if checked:
             self.logic.render_pnp()
         else:

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -359,12 +359,6 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         pnp_volume_node.GetDisplayNode().SetAutoWindowLevel(0)
         pnp_volume_node.GetDisplayNode().SetApplyThreshold(1)
 
-        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
-        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
-          vrDisplayNode.SetFollowVolumeDisplayNode(1)
-        if vrDisplayNode is not None and vrDisplayNode.GetIgnoreVolumeDisplayNodeThreshold():
-          vrDisplayNode.SetIgnoreVolumeDisplayNodeThreshold(0)
-
         # Manually trigger updates to apply the new default values.
         self.onPnpColorSliderChanged(self.ui.pnpColorSlider.minimumValue, self.ui.pnpColorSlider.maximumValue)
         self.onPnpOpacitySliderChanged(self.ui.pnpOpacitySlider.value)
@@ -432,10 +426,23 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = self.logic.get_pnp()
         pnp_volume_node.GetDisplayNode().SetWindowLevelMinMax(new_min_val, new_max_val)
 
+        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
+        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
+          vrDisplayNode.SetFollowVolumeDisplayNode(1)
+        if vrDisplayNode is not None and vrDisplayNode.GetIgnoreVolumeDisplayNodeThreshold():
+          vrDisplayNode.SetIgnoreVolumeDisplayNodeThreshold(0)
+
+
     def onPnpOpacitySliderChanged(self, new_min_val: float) -> None:
         """Called when the PNP opacity slider value is changed."""
         pnp_volume_node: "vtkMRMLScalarVolumeNode" = self.logic.get_pnp()
         pnp_volume_node.GetDisplayNode().SetThreshold(new_min_val, self.ui.pnpOpacitySlider.maximum)
+
+        vrDisplayNode = slicer.modules.volumerendering.logic().GetFirstVolumeRenderingDisplayNode(pnp_volume_node)
+        if vrDisplayNode is not None and not vrDisplayNode.GetFollowVolumeDisplayNode():
+          vrDisplayNode.SetFollowVolumeDisplayNode(1)
+        if vrDisplayNode is not None and vrDisplayNode.GetIgnoreVolumeDisplayNodeThreshold():
+          vrDisplayNode.SetIgnoreVolumeDisplayNodeThreshold(0)
 
 
     def deleteSolutionAndSolutionAnalysisIfAny(self, reason:str):

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
-    <height>640</height>
+    <width>440</width>
+    <height>760</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -187,6 +187,22 @@ analysis.</string>
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="approveButton">
+        <property name="text">
+         <string>Approve solution</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton">
+     <property name="text">
+      <string>Peak Negative Pressure Rendering</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_8">
+      <item>
        <widget class="QCheckBox" name="renderPNPCheckBox">
         <property name="enabled">
          <bool>false</bool>
@@ -200,9 +216,42 @@ analysis.</string>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="approveButton">
+       <widget class="QLabel" name="pnpColorLabel">
         <property name="text">
-         <string>Approve solution</string>
+         <string>PNP Color Intensity Range:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkDoubleRangeSlider" name="pnpColorSlider">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="pnpOpacityLabel">
+        <property name="text">
+         <string>PNP Opacity Threshold:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkDoubleSlider" name="pnpOpacitySlider">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -220,15 +269,25 @@ analysis.</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleRangeSlider</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleRangeSlider.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSlider</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSlider.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -226,21 +226,15 @@ analysis.</string>
        </widget>
       </item>
       <item>
-       <widget class="ctkDoubleRangeSlider" name="pnpColorSlider">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+       <widget class="ctkRangeWidget" name="pnpColorSlider">
         <property name="toolTip">
          <string>Modify the window level</string>
-        </property>
-        <property name="maximum">
-         <double>1.000000000000000</double>
         </property>
         <property name="singleStep">
          <double>0.010000000000000</double>
         </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+        <property name="maximum">
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -255,18 +249,18 @@ analysis.</string>
        </widget>
       </item>
       <item>
-       <widget class="ctkDoubleSlider" name="pnpOpacitySlider">
-        <property name="enabled">
-         <bool>false</bool>
+       <widget class="ctkSliderWidget" name="pnpOpacitySlider">
+        <property name="singleStep">
+         <double>0.010000000000000</double>
         </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+        <property name="pageStep">
+         <double>0.100000000000000</double>
         </property>
-        <property name="handleToolTip">
-         <string>Modify the minimum cutoff for rendering the volume</string>
+        <property name="maximum">
+         <double>1.000000000000000</double>
         </property>
         <property name="invertedAppearance">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -290,14 +284,14 @@ analysis.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ctkDoubleRangeSlider</class>
+   <class>ctkRangeWidget</class>
    <extends>QWidget</extends>
-   <header>ctkDoubleRangeSlider.h</header>
+   <header>ctkRangeWidget.h</header>
   </customwidget>
   <customwidget>
-   <class>ctkDoubleSlider</class>
+   <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
-   <header>ctkDoubleSlider.h</header>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
+++ b/OpenLIFUSonicationPlanner/Resources/UI/OpenLIFUSonicationPlanner.ui
@@ -217,6 +217,9 @@ analysis.</string>
       </item>
       <item>
        <widget class="QLabel" name="pnpColorLabel">
+        <property name="toolTip">
+         <string>Modify the window level</string>
+        </property>
         <property name="text">
          <string>PNP Color Intensity Range:</string>
         </property>
@@ -226,6 +229,9 @@ analysis.</string>
        <widget class="ctkDoubleRangeSlider" name="pnpColorSlider">
         <property name="enabled">
          <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Modify the window level</string>
         </property>
         <property name="maximum">
          <double>1.000000000000000</double>
@@ -240,6 +246,9 @@ analysis.</string>
       </item>
       <item>
        <widget class="QLabel" name="pnpOpacityLabel">
+        <property name="toolTip">
+         <string>Modify the minimum cutoff for rendering the volume</string>
+        </property>
         <property name="text">
          <string>PNP Opacity Threshold:</string>
         </property>
@@ -252,6 +261,12 @@ analysis.</string>
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="handleToolTip">
+         <string>Modify the minimum cutoff for rendering the volume</string>
+        </property>
+        <property name="invertedAppearance">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Closes #433 

The automatic rendering of the Peak Negative Pressure (p_min) volume can obscure the true pressure field distribution due to suboptimal defaults.

This change allows to manually defining the window/level for the color and opacity. This allows for a more precise and accurate visualization of the underlying simulation data.