### PR TITLE
Download kwave and modnet assets when building openlifu app

### DIFF
--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -48,4 +48,7 @@ if(DEFINED Slicer_SOURCE_DIR)
     COMMENT "Downloading kwave and modnet assets using openlifu"
     VERBATIM
   )
+  add_dependencies(download_openlifu_assets python-sliceropenlifu-requirements)
 endif()
+
+


### PR DESCRIPTION
Address https://github.com/OpenwaterHealth/OpenLIFU-app/issues/62

When SlicerOpenLIFU is built within the custom app, download the kwave and modnet assets for offline use. 

## For  Review

Build the OpenLIFU App using this branch of SlicerOpenLIFU and confirm that the modnet and kwave assets are downloaded during build to:

`BUILD_DIR/python-install/Lib/site-packages/kwave/bin/*` and `BUILD_DIR/python-install/Lib/site-packages/openlifu/nav/modnet_checkpoint/*`