### PR TITLE
Rename extension to OpenLIFU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
-project(SlicerOpenLIFU)
+project(OpenLIFU)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
Close #495 

This is to address the failure in https://github.com/Slicer/ExtensionsIndex/pull/2261 so we can get that merged