### PR TITLE
Revert version retrieval

### DIFF
--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -36,7 +36,6 @@ from OpenLIFULib.util import add_slicer_log_handler, display_errors, replace_wid
 # but is done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
-    import openlifu.io
 
 #
 # OpenLIFUSonicationControl
@@ -553,7 +552,6 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updateDeviceConnectedState(DeviceConnectedState.CONNECTED)
         else:
             self.updateDeviceConnectedState(DeviceConnectedState.NOT_CONNECTED)
-        self.updateVersionsLabel()
 
     def updateDeviceConnectedState(self, connected_state: DeviceConnectedState):
         self._cur_solution_on_hardware_state = connected_state
@@ -562,22 +560,6 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         elif connected_state == DeviceConnectedState.NOT_CONNECTED:
             self.ui.connectedStateLabel.setProperty("text", "🔴 LIFU Device (not connected)")
         self.updateAllButtonsEnabled()
-
-    def updateVersionsLabel(self):
-        li : "openlifu.io.LIFUInterface" = self.logic.cur_lifu_interface
-
-        tx_version_string = li.txdevice.get_version()
-        try:
-            hvcontroller_version_string = li.hvcontroller.get_version()
-        except ValueError:
-            hvcontroller_version_string = "Error"
-
-        self.ui.versionsLabel.text = (
-            f"Transmit module version: {tx_version_string}"
-            f"\nConsole version: {hvcontroller_version_string}"
-            f"\nopenlifu version: {openlifu_lz().__version__}"
-        )
-
 
     def updateWidgetSolutionOnHardwareState(self, solution_state: SolutionOnHardwareState, hardware_state: "openlifu.io.LIFUInterfaceStatus | None" = None):
         self._cur_solution_on_hardware_state = solution_state

--- a/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
+++ b/OpenLIFUSonicationControl/Resources/UI/OpenLIFUSonicationControl.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>342</width>
+    <width>325</width>
     <height>502</height>
    </rect>
   </property>
@@ -63,13 +63,6 @@
        <widget class="QLabel" name="connectedStateLabel">
         <property name="alignment">
          <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="versionsLabel">
-        <property name="text">
-         <string/>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This reverts #483

The version retrieval causes the application to crash when hardware is connected. It will need to be done more carefully and with hardware-in-the-loop testing.

- [x] Test that this reversion resolves the crash that occurs in the app when hardware is connected.
- [x] Just before merging, re-open #482.