### PR TITLE
Add admin role warning label to user account banner 

### DIFF
--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -46,11 +46,34 @@ class UserAccountBanner(qt.QWidget):
 
         group_box = qt.QGroupBox()
         group_layout = qt.QHBoxLayout(group_box)
+        label_layout = qt.QVBoxLayout()
 
         self.active_user_label = qt.QLabel("Not signed in")
         self.active_user_label.setAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
         self.active_user_label.setFont(qt.QFont("", 14))
-        group_layout.addWidget(self.active_user_label, 1)  # stretch=1 as positional argument
+        label_layout.addWidget(self.active_user_label)
+
+        self.warning_widget = qt.QWidget()
+        warning_layout = qt.QHBoxLayout(self.warning_widget)
+        warning_layout.setContentsMargins(0, 0, 0, 0)
+
+        warning_icon = qt.QLabel()
+        warning_icon.setPixmap(
+            qt.QApplication.style().standardIcon(qt.QStyle.SP_MessageBoxWarning).pixmap(16, 16)
+        )
+        warning_icon.setFixedSize(16, 16)
+        warning_layout.addWidget(warning_icon)
+
+        self.warning_label = qt.QLabel("")
+        self.warning_label.setAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
+        self.warning_label.setStyleSheet("color: #cc7a00;")
+        self.warning_label.setWordWrap(True)
+        warning_layout.addWidget(self.warning_label, 1)
+
+        self.warning_widget.visible = False
+        label_layout.addWidget(self.warning_widget)
+
+        group_layout.addLayout(label_layout, 1)  # stretch=1 as positional argument
 
         self.go_to_login_button = qt.QPushButton("👤")
         self.go_to_login_button.setToolTip("Switch user")
@@ -65,5 +88,11 @@ class UserAccountBanner(qt.QWidget):
     def change_active_user(self, new_active_user: Optional["openlifu.db.User"]):
         if new_active_user is None or new_active_user.id == "anonymous":
             self.active_user_label.setText("Not signed in")
+            self.warning_widget.visible = False
         else:
             self.active_user_label.setText(f"Signed in as {new_active_user.id}")
+            if 'admin' in new_active_user.roles:
+                self.warning_label.setText("You are logged in with admin privileges and have access to high-risk features.")
+                self.warning_widget.visible = True
+            else:
+                self.warning_widget.visible = False


### PR DESCRIPTION
Closes #511 

This PR updates the user account banner to include a warning message when the the logged in user's roles includes "admin"/
This banner is displayed at the top of each module when user account mode is enabled. 