### PR TITLE
Update DVC_REPO_DIR for compatability with app build environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(BUILD_TESTING)
     endif()
     
     # Specify directory containing .dvc files
-    set(DVC_REPO_DIR "${CMAKE_SOURCE_DIR}" CACHE INTERNAL "DVC data folder")
+    set(DVC_REPO_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "DVC data folder")
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, integration tests within the custom app build fail because they cannot locate .dvc files using the existing path configuration. It should be CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

## For Review

Build OpenLIFU-App with this SlicerOpenLIFU version (dbcf2d2cb93d196e58e6d45a410786468c25b059) and confirm that the tests run and pull the DVC data. The test fails due to an abnormal exit, after switching to the PrePlanning module. This will be addressed here: https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/545.
