### PR TITLE
Broadcast adb intents during photo transfer (#537)

### DIFF
--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -3135,13 +3135,18 @@ class OpenLIFUTransducerLocalizationLogic(ScriptedLoadableModuleLogic):
 
             # Pull all files from scan directory
             pulled_files = []
+            all_pulls_succeeded = True
             for file in scan_files:
                 filename = os.path.basename(file)
                 dest_path = os.path.join(temp_path, filename)
-                subprocess.run(["adb", "pull", f"{scan_dir}/{filename}", dest_path])
-                pulled_files.append(dest_path)
+                pull_result = subprocess.run(["adb", "pull", f"{scan_dir}/{filename}", dest_path])
+                if pull_result.returncode != 0:
+                    all_pulls_succeeded = False
+                else:
+                    pulled_files.append(dest_path)
 
-            self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_COMPLETE", reference_number)
+            if all_pulls_succeeded:
+                self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_COMPLETE", reference_number)
             return ('photoscan', pulled_files)
         else:
             # Pull photo files from base directory (offline mode)
@@ -3150,15 +3155,20 @@ class OpenLIFUTransducerLocalizationLogic(ScriptedLoadableModuleLogic):
                               '.webp', '.heic', '.heif', '.raw', '.cr2', '.nef', '.arw', '.dng'}
 
             pulled_files = []
+            all_pulls_succeeded = True
             for file in files:
                 filename = os.path.basename(file)
                 # Only pull files with image extensions
                 if any(filename.lower().endswith(ext) for ext in image_extensions):
                     dest_path = os.path.join(temp_path, filename)
-                    subprocess.run(["adb", "pull", f"{android_dir}/{filename}", dest_path])
-                    pulled_files.append(dest_path)
+                    pull_result = subprocess.run(["adb", "pull", f"{android_dir}/{filename}", dest_path])
+                    if pull_result.returncode != 0:
+                        all_pulls_succeeded = False
+                    else:
+                        pulled_files.append(dest_path)
 
-            self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_COMPLETE", reference_number)
+            if all_pulls_succeeded:
+                self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_COMPLETE", reference_number)
             return ('photos', pulled_files)
 
     def generate_photoscan(self,


### PR DESCRIPTION
Closes #537 

Broadcast TRANSFER_STARTED and TRANSFER_COMPLETE to the scanner app during pull_photo_data_from_android.
- TRANSFER_STARTED is sent only after verifying the scan ID directory exists and is non-empty on the device.
- TRANSFER_COMPLETE is sent after a successful pull in **both the photoscan and photos code paths**. We do not broadcast these in the legacy fallback. I can add these broadcasts in the legacy fallback case like this:

```diff
diff --git a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
index e1feb0a..4cb8523 100644
--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -2981,6 +2981,9 @@     def _pull_photos_from_legacy_location(self, reference_number: str, temp_path
                 f"on the android device."
             )
 
+        self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_STARTED", reference_number)
+
         pulled_files = []
         for file in files:
             filename = os.path.basename(file)
@@ -2988,6 +2991,8 @@     def _pull_photos_from_legacy_location(self, reference_number: str, temp_path
             subprocess.run(["adb", "pull", f"{legacy_android_dir}/{filename}", dest_path])
             pulled_files.append(dest_path)
 
+        self._send_adb_broadcast("health.openwater.openlifu3dscanner.TRANSFER_COMPLETE", reference_number)
         return ('photos', pulled_files)
 
     @staticmethod
```

@ipyanin was this the correct move, not to broadcast when falling back to the legacy path?