### PR TITLE
Add openlifu version check and installation button in login module

### DIFF
--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -20,10 +20,6 @@ from OpenLIFULib.util import (
 )
 
 from OpenLIFULib.guided_mode_util import set_guided_mode_state, Workflow
-from OpenLIFULib.lazyimport import (
-    check_and_install_python_requirements,
-    python_requirements_exist,
-)
 
 from OpenLIFUCloudSync import getCloudSyncLogic
 #
@@ -111,9 +107,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
         
         # Buttons
-        self.ui.installPythonReqsButton.connect("clicked()", self.onInstallPythonRequirements)
         self.ui.guidedModePushButton.connect("clicked()", self.onGuidedModeClicked)
-        self.updateInstallButtonText()
         self.updateGuidedModeButton()
 
         # Switch modules
@@ -139,19 +133,6 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             moduleButtonText = moduleButtonText[:-7]  # strip to -Config
 
         slicer.util.selectModule(moduleButtonText)
-
-
-    def updateInstallButtonText(self) -> None:
-        """Update the text of the install button based on whether it's 'install' or 'reinstall'"""
-        if python_requirements_exist():
-            self.ui.installPythonReqsButton.text = 'Reinstall Python Requirements'
-        else:
-            self.ui.installPythonReqsButton.text = 'Install Python Requirements'
-
-    def onInstallPythonRequirements(self) -> None:
-        """Install python requirements button action"""
-        check_and_install_python_requirements(prompt_if_found=True)
-        self.updateInstallButtonText()
 
     def setupCloudSyncToolBar(self):
         mw = slicer.util.mainWindow()

--- a/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
+++ b/OpenLIFUHome/Resources/UI/OpenLIFUHome.ui
@@ -44,7 +44,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <property name="spacing">
-          <number>-1</number>
+          <number>6</number>
          </property>
          <property name="leftMargin">
           <number>0</number>
@@ -108,25 +108,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton">
-     <property name="text">
-      <string>Advanced</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QPushButton" name="installPythonReqsButton">
-        <property name="text">
-         <string>Install Python Requirements</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -1,4 +1,16 @@
-from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz, bcrypt_lz, threadpoolctl_lz, segno_lz, check_and_install_kwave_binaries
+from OpenLIFULib.lazyimport import (
+    openlifu_lz,
+    xarray_lz,
+    bcrypt_lz,
+    threadpoolctl_lz,
+    segno_lz,
+    check_and_install_kwave_binaries,
+    check_and_install_python_requirements,
+    install_python_requirements,
+    python_requirements_exist,
+    get_required_openlifu_version,
+    openlifu_version_matches,
+)
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPoint,
     SlicerOpenLIFUXADataset,
@@ -57,4 +69,9 @@ __all__ = [
     "openlifu_point_to_fiducial",
     "assign_openlifu_metadata_to_volume_node",
     "check_and_install_kwave_binaries",
+    "check_and_install_python_requirements",
+    "install_python_requirements",
+    "python_requirements_exist",
+    "get_required_openlifu_version",
+    "openlifu_version_matches",
 ]

--- a/OpenLIFULib/OpenLIFULib/lazyimport.py
+++ b/OpenLIFULib/OpenLIFULib/lazyimport.py
@@ -65,26 +65,39 @@ def check_and_install_python_requirements(prompt_if_found = False) -> None:
             )
 
 def get_required_openlifu_version() -> "Optional[str]":
-    """Return the required openlifu version pinned in 
+    """Return the required openlifu version pinned in
     python-requirements.txt, or None."""
     requirements_path = Path(__file__).parent / 'Resources/python-requirements.txt'
-    for line in requirements_path.read_text().splitlines():    
+    for line in requirements_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith('#'):
+            continue
         if line.startswith('openlifu=='):
             return line.split('==', 1)[1].strip()
+        if 'OpenLIFU-python.git@' in line:
+            commit_hash = line.split('@')[-1].strip()
+            return f"dev+g{commit_hash[:9]}"
     return None
 
 def openlifu_version_matches() -> bool:
     """Return True if the installed openlifu version matches
-     the required version. Returns False if openlifu is not 
+     the required version. Returns False if openlifu is not
      installed or versions don't match."""
     import importlib.metadata
     try:
-        installed = importlib.metadata.version('openlifu')     
+        installed = importlib.metadata.version('openlifu')
         required = get_required_openlifu_version()
         if required is None:
             return True  # No version constraint
-        # Handle optional 'v' prefix (e.g. 'v0.18.0' vs '0.18.0')
-        return installed == required or installed == required.lstrip('v')
+        if 'dev' in required:
+            if '+g' not in installed:
+                return False
+            required_hash = required.split('+g')[-1]
+            installed_hash = installed.split('+g')[-1]
+            return required_hash.startswith(installed_hash) or installed_hash.startswith(required_hash)
+        else:
+            # Handle optional 'v' prefix (e.g. 'v0.18.0' vs '0.18.0')
+            return installed == required or installed == required.lstrip('v')
     except importlib.metadata.PackageNotFoundError:
         return False
 

--- a/OpenLIFULib/OpenLIFULib/lazyimport.py
+++ b/OpenLIFULib/OpenLIFULib/lazyimport.py
@@ -29,17 +29,22 @@ def python_requirements_exist() -> bool:
     return importlib.util.find_spec('openlifu') is not None # openlifu import causes a delay so we check for it without actually importing yet
 
 def check_and_install_python_requirements(prompt_if_found = False) -> None:
-    """Check whether python requirements are installed and prompt to install them if not.
+    """Check whether python requirements are installed and at the required version, and prompt to install/update if not.
 
     Args:
-        prompt_if_found: If this is enabled then in the event that python requirements are found,
-            there is a further prompt asking whether to run the install anyway.
+        prompt_if_found: If this is enabled then in the event that python requirements are found
+            and at the correct version, there is a further prompt asking whether to run the install anyway.
     """
     want_install = False
     if not python_requirements_exist():
         want_install = slicer.util.confirmYesNoDisplay(
             text = "Some OpenLIFU python dependencies were not found. Install them now?",
             windowTitle = "Install python dependencies?",
+        )
+    elif not openlifu_version_matches() and prompt_if_found:
+        want_install = slicer.util.confirmYesNoDisplay(
+            text = f"The installed openlifu version does not match the required version ({get_required_openlifu_version()}). Update now?",
+            windowTitle = "Update openlifu?",
         )
     elif prompt_if_found:
         want_install = slicer.util.confirmYesNoDisplay(
@@ -58,6 +63,30 @@ def check_and_install_python_requirements(prompt_if_found = False) -> None:
                 text="OpenLIFU python dependencies are still not found. The install may have failed.",
                 windowTitle="Python dependencies still not found"
             )
+
+def get_required_openlifu_version() -> "Optional[str]":
+    """Return the required openlifu version pinned in 
+    python-requirements.txt, or None."""
+    requirements_path = Path(__file__).parent / 'Resources/python-requirements.txt'
+    for line in requirements_path.read_text().splitlines():    
+        if line.startswith('openlifu=='):
+            return line.split('==', 1)[1].strip()
+    return None
+
+def openlifu_version_matches() -> bool:
+    """Return True if the installed openlifu version matches
+     the required version. Returns False if openlifu is not 
+     installed or versions don't match."""
+    import importlib.metadata
+    try:
+        installed = importlib.metadata.version('openlifu')     
+        required = get_required_openlifu_version()
+        if required is None:
+            return True  # No version constraint
+        # Handle optional 'v' prefix (e.g. 'v0.18.0' vs '0.18.0')
+        return installed == required or installed == required.lstrip('v')
+    except importlib.metadata.PackageNotFoundError:
+        return False
 
 def check_and_install_kwave_binaries() -> bool:
     """Check if the kwave binaries are present, and if not then ask the user how they want to install them.

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -32,7 +32,11 @@ from OpenLIFULib import (
     bcrypt_lz,
     get_cur_db,
     get_current_user,
+    check_and_install_python_requirements,
+    get_required_openlifu_version,
     openlifu_lz,
+    openlifu_version_matches,
+    python_requirements_exist,
 )
 from OpenLIFULib.class_definition_widgets import ListTableWidget
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
@@ -577,20 +581,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self._user_account_banners : List[UserAccountBanner] = []
         self._parameterNode = None
         self._parameterNodeGuiTag = None
-        self._default_anonymous_user = openlifu_lz().db.User(
-                id = "anonymous", 
-                password_hash = "",
-                roles = [],
-                name = "Anonymous",
-                description = "This is the default role set when the app opens, without anyone logged in, with user account mode activated. It has no roles and is therefore the most restricted."
-        )
-        self._default_admin_user = openlifu_lz().db.User(
-                id = "default_admin", 
-                password_hash = "default_admin",
-                roles = ['admin'],
-                name = "default_admin",
-                description = "This is the default admin role automatically assigned if an admin user does not exist in the loaded database or if there is no database loaded at all."
-                )
+        self._default_anonymous_user = None  # initialized in setup() 
+        self._default_admin_user = None # initialized in setup()
         self._last_active_user = self._default_anonymous_user
 
     def setup(self) -> None:
@@ -629,11 +621,14 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
         self.inject_workflow_controls_into_placeholder()
 
+        # ====================================
+        self._initDefaultUsers() # This will install openlifu if not installed
+
         # Install dependencies
+        self.ui.installPythonRequirementsPushButton.clicked.connect(self.onUpdateOpenLIFUClicked)
+        self._checkOpenLIFUVersionStatus()
         self.ui.installADBPushButton.clicked.connect(self.onInstallADBClicked)
         self._checkADBStatus()
-
-        # ====================================
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
@@ -643,6 +638,25 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
         self.onDatabaseChanged() # Call the routine to update from data parameter node
         self.updateWorkflowControls()
+
+    def _initDefaultUsers(self) -> None:
+        """Create default User objects. This will prompt the user
+        to install openlifu if it is not installed. """
+        self._default_anonymous_user = openlifu_lz().db.User(
+            id = "anonymous",
+            password_hash = "",
+            roles = [],
+            name = "Anonymous",
+            description = "This is the default role set when the app opens, without anyone logged in, with user account mode activated. It has no roles and is therefore the most restricted."
+        )
+        self._default_admin_user = openlifu_lz().db.User(
+            id = "default_admin",
+            password_hash = "default_admin",
+            roles = ['admin'],
+            name = "default_admin",
+            description = "This is the default admin role automatically assigned if an admin user does not exist in the loaded database or if there is no database loaded at all."
+        )
+        self._last_active_user = self._default_anonymous_user
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -942,8 +956,38 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         for protocol_id in list(slicer.util.getModuleLogic('OpenLIFUProtocolConfig').cached_protocols.keys()):
             slicer.util.getModuleLogic('OpenLIFUProtocolConfig').delete_protocol_from_cache(protocol_id)
         slicer.util.getModuleWidget('OpenLIFUProtocolConfig').reloadProtocols()
-
         self._last_active_user = new_active_user
+
+    def _checkOpenLIFUVersionStatus(self) -> None:
+        import importlib.metadata
+        has_openlifu = python_requirements_exist()
+        version_ok = openlifu_version_matches() if has_openlifu else False
+
+        icon_name = qt.QStyle.SP_DialogApplyButton if (has_openlifu and version_ok) else qt.QStyle.SP_DialogCancelButton
+        pixmap = slicer.app.style().standardIcon(icon_name).pixmap(qt.QSize(16, 16))
+        self.ui.openlifuStatusIcon.setPixmap(pixmap)
+        self.ui.openlifuStatusIcon.setText("")
+
+        if not has_openlifu:
+            self.ui.installPythonRequirementsPushButton.setText("Install Python Requirements")
+        elif not version_ok:
+            try:
+                installed = importlib.metadata.version('openlifu')
+            except importlib.metadata.PackageNotFoundError:
+                installed = "unknown"
+            required = get_required_openlifu_version() or "unknown"
+            self.ui.installPythonRequirementsPushButton.setText(f"Update Python Requirements (openlifu: {installed} → {required})")
+        else:
+            try:
+                installed = importlib.metadata.version('openlifu')
+            except importlib.metadata.PackageNotFoundError:
+                installed = "unknown"
+            self.ui.installPythonRequirementsPushButton.setText(f"Reinstall Python Requirements (openlifu: {installed})")
+
+    @display_errors
+    def onUpdateOpenLIFUClicked(self, checked: bool = False) -> None:
+        check_and_install_python_requirements(prompt_if_found=True)
+        self._checkOpenLIFUVersionStatus()
 
     def _checkADBStatus(self) -> None:
         try:
@@ -1089,14 +1133,9 @@ class OpenLIFULoginLogic(ScriptedLoadableModuleLogic):
         self._cloudTokens = None # Stores {idToken, refreshToken, expiresAt}
         self._userId = None
 
-        self._active_user: "openlifu.db.User" = openlifu_lz().db.User(
-                id = "anonymous", 
-                password_hash = "",
-                roles = [],
-                name = "Anonymous",
-                description = "This is the default role set when the app opens, without anyone logged in, and when user account mode is deactivated. It has no roles, and therefore is the most restricted."
-        )
-        """The currently active user. Do not set this directly -- use the `active_user` property."""
+        self._active_user: "Optional[openlifu.db.User]" = None
+        """The currently active user. Do not set this directly -- use the `active_user` property.
+        Initialized to None and set from the widget after openlifu is confirmed available."""
 
         self._on_active_user_changed_callbacks: List[Callable[[Optional["openlifu.db.User"]], None]] = []
         """List of functions to call when the `active_user` property is changed."""

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>428</width>
-    <height>347</height>
+    <width>479</width>
+    <height>552</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -45,29 +45,56 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleGroupBox" name="installDependenciesCollapsibleGroupBox">
+    <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Install dependencies (optional)</string>
+      <string>Install dependencies</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="adbStatusIcon">
-        <property name="text">
-         <string>adbStatus</string>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="1">
+         <widget class="QPushButton" name="installPythonRequirementsPushButton">
+          <property name="text">
+           <string>Install Python Requirements</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="openlifuStatusIcon">
+          <property name="text">
+           <string>pythonStatus</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="installADBPushButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>2</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="installDependenciesCollapsibleGroupBox">
+        <property name="title">
+         <string>Optional</string>
         </property>
-        <property name="text">
-         <string>Install Android Platform Tools</string>
-        </property>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="adbStatusIcon">
+           <property name="text">
+            <string>adbStatus</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QPushButton" name="installADBPushButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>2</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install Android Platform Tools</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Closes #544 

- The install python requirements button is always enabled. 
- The button text updates to indicate whether openlifu is installed, and what version is required
- If openlifu is not installed, entering the login module will prompt the user automatically to install openlifu since it is required for initializing default user accounts.
- If openlifu is installed, but is not the latest version, the user is not automatically prompted to update openlifu, but the button and status icon indicate that the latest version is not installed.

Todo:

- [x] Confirm that the changes to the user account settings don't break things in the custom app. 