### PR TITLE
Add starter database initialization options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,221 @@
+# AGENTS.md
+
+This file provides guidance for AI coding agents and other automated development assistants working with code in this repository.
+
+## Project Overview
+
+SlicerOpenLIFU is a 3D Slicer extension for Openwater's OpenLIFU (Low Intensity Focused Ultrasound) research platform. It provides a GUI for focused ultrasound treatment planning, simulation, and hardware control. Licensed under AGPL.
+
+The extension depends on the `openlifu` Python library from the [`openlifu-python`](https://github.com/OpenwaterHealth/openlifu-python) repository (formerly named `OpenLIFU-python`), which provides the core computational engine (beamforming, simulation via k-Wave, data model classes). SlicerOpenLIFU wraps `openlifu` objects with Slicer UI, visualization, and persistence.
+
+## Build and Test Commands
+
+### Building
+
+The extension is built against a 3D Slicer superbuild. Let `<slicer-superbuild>` denote the superbuild directory. Key paths within it:
+- Slicer build: `<slicer-superbuild>/Slicer-build/`
+- Slicer's bundled Python: `<slicer-superbuild>/python-install/bin/PythonSlicer`
+- Run Python in Slicer env: `<slicer-superbuild>/Slicer-build/Slicer --python-code "..." --no-splash --no-main-window --exit-after-startup`
+
+```bash
+# Configure (from the repo root)
+cmake -DSlicer_DIR=<slicer-superbuild>/Slicer-build \
+      -DBUILD_TESTING=ON \
+      -DDVC_GDRIVE_KEY_PATH=/path/to/gdrive-service-account.json \
+      -B build
+
+# Build
+cmake --build build
+```
+
+`BUILD_TESTING=ON` requires `DVC_GDRIVE_KEY_PATH` pointing to a Google Drive service account JSON key (used for downloading test data via DVC).
+
+### Running Slicer with the Extension
+
+```bash
+<slicer-superbuild>/Slicer-build/Slicer
+```
+
+The extension modules are automatically loaded from the build directory.
+
+### Running Tests
+
+Tests are integration tests that run inside Slicer's environment using CTest. They use Slicer's `ScriptedLoadableModuleTest` framework (not pytest).
+
+```bash
+# Run all tests
+cd build && ctest --verbose
+
+# Run a single module's test
+cd build && ctest -R py_OpenLIFUHome --verbose
+
+# Run just one module test (e.g. sonication planner)
+cd build && ctest -R py_OpenLIFUSonicationPlanner --verbose
+```
+
+Test names follow the pattern `py_<ModuleName>`. The main integration test is `py_OpenLIFUHome`, which orchestrates a full workflow through all modules sequentially.
+
+Test data is downloaded at runtime from Google Drive via DVC. The CMake config passes `GDRIVE_CREDENTIALS_DATA` and `DVC_REPO_DIR` as environment variables to CTest.
+
+### Python Version
+
+Slicer 5.10 embeds Python 3.12. This means PEP 701 f-string syntax (nested quotes) is valid, but the project has not yet adopted it widely.
+
+### No Linter/Formatter Configuration
+
+There is currently no configured linter or formatter (no flake8, ruff, black, or pre-commit setup).
+
+## Architecture
+
+### Module Structure
+
+The extension has 9 feature modules plus a shared library, all as Slicer scripted (Python) modules:
+
+| Module | Purpose |
+|--------|---------|
+| **OpenLIFUHome** | Entry point, guided workflow orchestration, python dependency installation |
+| **OpenLIFUDatabase** | Connect to/create local file-based openlifu databases |
+| **OpenLIFULogin** | User authentication, role-based access (operator/admin) |
+| **OpenLIFUData** | Load subjects, sessions, protocols, transducers, volumes |
+| **OpenLIFUPrePlanning** | Target placement, skin segmentation, virtual fit validation |
+| **OpenLIFUTransducerLocalization** | Photogrammetry-based transducer tracking |
+| **OpenLIFUSonicationPlanner** | Solution computation (beamforming + k-Wave simulation) |
+| **OpenLIFUSonicationControl** | Hardware interface, run execution and recording |
+| **OpenLIFUProtocolConfig** | Protocol creation/editing (admin only) |
+| **OpenLIFULib** | Shared utility library (not a UI module) |
+
+### Workflow Data Flow
+
+```
+Home → Database → Login → Data → PrePlanning → TransducerLocalization → SonicationPlanner → SonicationControl
+                                       ↕
+                                 ProtocolConfig
+```
+
+Each module can operate standalone, but in guided mode they follow this sequence.
+
+### Standard Module Pattern (Slicer Convention)
+
+Every module Python file contains four classes:
+
+```python
+class OpenLIFU<Name>(ScriptedLoadableModule):           # Module registration/metadata
+class OpenLIFU<Name>ParameterNode(@parameterNodeWrapper): # Persistent state via MRML
+class OpenLIFU<Name>Widget(ScriptedLoadableModuleWidget): # Qt UI
+class OpenLIFU<Name>Logic(ScriptedLoadableModuleLogic):   # Business logic
+class OpenLIFU<Name>Test(ScriptedLoadableModuleTest):     # Integration test
+```
+
+UI is defined in `Resources/UI/<ModuleName>.ui` (Qt Designer XML) and loaded in the Widget class.
+
+### OpenLIFULib Key Patterns
+
+**Lazy importing** (`lazyimport.py`): The `openlifu` library and its dependencies are heavy and may not be installed yet. All imports go through lazy-import functions:
+- `openlifu_lz()` — returns the `openlifu` module, installing it first if needed
+- `xarray_lz()`, `bcrypt_lz()`, `threadpoolctl_lz()` — same pattern
+- For IDE type-checking, real imports are guarded under `if TYPE_CHECKING:`
+
+**Parameter node wrappers** (`parameter_node_utils.py`): Thin wrapper classes (`SlicerOpenLIFUProtocol`, `SlicerOpenLIFUTransducer`, `SlicerOpenLIFUSession`, etc.) exist solely to enable Slicer's `@parameterNodeWrapper` serialization of `openlifu` types without importing `openlifu` at module load time. Each wrapper has a corresponding `@parameterNodeSerializer` class that serializes to/from JSON via the wrapped object's `to_json()`/`from_json()` methods.
+
+**`@parameterNodeWrapper` internals**: The wrapper stores each parameter via `_CachedParameterWrapper` or `_ParameterWrapper`. `_CachedParameterWrapper` adds its own `ModifiedEvent` observer on the MRML node to invalidate its cache when the node changes. This means the MRML parameter node can have multiple `ModifiedEvent` observers from different subsystems (connectGui, cached params, cross-module observers). Never blindly remove all `ModifiedEvent` observers from a parameter MRML node.
+
+**`SlicerOpenLIFUTransducer`** (`transducer.py`): A `@parameterPack` with fields `name`, `transducer` (a `SlicerOpenLIFUTransducerWrapper`), `model_node`, `transform_node`, etc. Access the underlying `openlifu.Transducer` via `slicer_transducer.transducer.transducer` (three levels: parameterPack → thin wrapper → openlifu object).
+
+**Cross-module communication**: Modules access each other's state through:
+- `get_openlifu_data_parameter_node()` / `get_openlifu_database_parameter_node()` — access parameter nodes from other modules
+- `get_cur_db()` — get the currently loaded `openlifu.db.Database`
+- Callback registration: `logic.call_on_db_changed(callback)`, `logic.call_on_active_user_changed(callback)`
+- VTK observers for MRML scene changes
+
+**Guided workflow** (`guided_mode_util.py`): `GuidedWorkflowMixin` provides Back/Next/Jump navigation. Modules implement this mixin to participate in the guided workflow.
+
+**User account mode** (`user_account_mode_util.py`): Widgets can be tagged with `slicer.openlifu.allowed-roles` Qt property. The Login module enforces visibility based on the current user's role.
+
+### Relationship to openlifu Library
+
+`openlifu` (installed as the `openlifu` Python package from [`openlifu-python`](https://github.com/OpenwaterHealth/openlifu-python)) provides:
+- **Data model**: `Protocol`, `Transducer`, `Point`, `Session`, `Solution`, `Run`, `SolutionAnalysis`, `Photoscan`
+- **Database**: File-based JSON database (`openlifu.db.Database`)
+- **Beamforming**: Delay/apodization calculation (`openlifu.bf`)
+- **Simulation**: k-Wave acoustic simulation (`openlifu.sim`)
+- **Hardware I/O**: `openlifu.io.LIFUInterface` for device communication
+- **Virtual fit**: `openlifu.vf` for transducer virtual fitting
+
+SlicerOpenLIFU wraps these with Slicer MRML nodes, VTK visualization, Qt widgets, and parameter node persistence. The wrapper classes in `parameter_node_utils.py` bridge between openlifu's data classes and Slicer's parameter node system.
+
+The pinned version is in `OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt`.
+
+### Testing Architecture
+
+Tests are integration tests embedded in each module's main `.py` file as a `Test` class. `OpenLIFUHomeTest.runTest()` is the master test that:
+1. Installs Python requirements if missing
+2. Downloads test database from Google Drive via DVC
+3. Calls each module's test methods sequentially (database → data → preplanning → localization → planning → control)
+
+Individual module tests create state needed by subsequent tests — they are not independent.
+
+## Development Gotchas
+
+### Adding new pip dependencies
+Adding a package to `python-requirements.txt` is not enough. You must also add an `import` check for it in `python_requirements_exist()` in `lazyimport.py`. Otherwise, users who already have the other deps installed will never trigger a reinstall, and the new package won't be found. Follow the existing `bcrypt`/`threadpoolctl` pattern.
+
+### Qt signal slot signatures
+Qt's `clicked` signal always passes a `checked: bool` argument. Button slot handlers must accept it: `def on_foo_clicked(self, checked: bool)`. Omitting it causes a "takes 1 positional argument but 2 were given" error at runtime.
+
+### Displaying dynamic images in Qt
+Generate PNG bytes in memory (`io.BytesIO`), then `qt.QPixmap().loadFromData(buf.getvalue())` → `QLabel.setPixmap()`. No temp files needed. Pillow is available in Slicer's bundled Python. `QPixmap.loadFromData()` accepts raw Python `bytes` directly.
+
+### Adding icon resources to scripted modules
+Three steps: (1) place PNG in `<Module>/Resources/Icons/`, (2) list it in `MODULE_PYTHON_RESOURCES` in that module's `CMakeLists.txt`, (3) load at runtime via `self.resourcePath("Icons/foo.png")`. Missing step 2 means the file exists in source but won't be copied to the build tree.
+
+### Reactive widget enable/disable pattern
+`@parameterNodeWrapper` fires a generic `vtkCommand.ModifiedEvent` for any field change — no per-field signals. Modules observe it via `self.addObserver(get_openlifu_data_parameter_node().parameterNode, vtk.vtkCommand.ModifiedEvent, self.onDataParameterNodeModified)`. To add a new reactive widget, write an `updateFoo()` method and hook it into an existing dispatch method (e.g., `updatePhotoscanGenerationButtons()`).
+
+### Session state access
+- Check existence: `get_openlifu_data_parameter_node().loaded_session is None`
+- Get IDs: `loaded_session.get_subject_id()`, `loaded_session.get_session_id()` (methods, not attributes)
+- `get_openlifu_data_parameter_node()` is in `OpenLIFULib/util.py`, calls `slicer.util.getModuleLogic('OpenLIFUData').getParameterNode()`
+
+### Dialogs in module files
+Module dialogs (e.g., `PhotoscanPreviewDialog`, `AddNewPhotoscanDialog`) are `qt.QDialog` subclasses defined in the module's `.py` file. UI is built programmatically in `__init__`, shown with `dialog.exec_()`. No `.ui` files for dialogs.
+
+### `@display_errors` decorator
+All slot handlers should use `@display_errors` so exceptions are displayed to the user rather than silently swallowed by Qt's signal/slot mechanism.
+
+## Custom Application (`openlifu-desktop-application`)
+
+The [`openlifu-desktop-application`](https://github.com/OpenwaterHealth/openlifu-desktop-application) repository builds a custom Slicer-based application that bundles SlicerOpenLIFU as a built-in extension. The checkout and superbuild locations are developer-specific; use placeholders such as `<openlifu-desktop-application>` and `<custom-app-superbuild>` in local notes or commands.
+
+Key differences from the vanilla extension build:
+- **Default home module**: The custom app sets `Slicer_DEFAULT_HOME_MODULE "Home"` (its own Home module, not OpenLIFUHome).
+- **All widgets created at startup**: The custom app's Home module connects to `startupCompleted()` and calls `enforceGuidedModeVisibility()` and Login's `cacheAllLoginRelatedWidgets()`, both of which call `widgetRepresentation()` on ALL OpenLIFU modules. This forces `setup()` (and thus `connectGui()`) to run on every module at startup, unlike vanilla Slicer where widgets are only created when a module is first selected.
+- **Tests**: Run against the custom application's Slicer build, for example `ctest -R py_OpenLIFUHome -VV --test-dir <custom-app-superbuild>/Slicer-build/`. The test executable is `OpenLIFU` not `Slicer`.
+- **File paths**: Installed module files live under the custom application's `lib/OpenLIFU-<version>/qt-scripted-modules/` tree (not a stock `lib/Slicer-<version>/...` tree). The bundled SlicerOpenLIFU source copy is fetched at a pinned revision during the custom application superbuild.
+
+### connectGui/disconnectGui bug (Slicer upstream issue)
+
+`@parameterNodeWrapper.connectGui()` adds a VTK `ModifiedEvent` observer on the underlying MRML parameter node, but `disconnectGui()` never removes it. This is a bug in Slicer's `slicer/parameterNodeWrapper/wrapper.py`. The stale observer's lambda captures the old wrapper instance.
+
+This is harmless in vanilla Slicer (widgets are created after scene clears), but causes segfaults in the custom app where all widgets are pre-created: after `slicer.mrmlScene.Clear()`, singleton parameter nodes survive but lose their `ModuleName` attribute. When `getParameterNode()` re-sets `ModuleName`, `ModifiedEvent` fires, the stale observer calls `_updateGUIFromParameterNode()` with the old wrapper, and it crashes.
+
+**Workaround** (in each module's `setParameterNode`): Track the VTK observer tag from `connectGui` by temporarily monkey-patching `mrml_node.AddObserver`, then `RemoveObserver(tag)` when `disconnectGui` is called. See the `_connectGuiVtkObserverTag` pattern in any module's `setParameterNode`.
+
+**Important constraint**: Do NOT use `parameterNode.RemoveObservers(vtk.vtkCommand.ModifiedEvent)` — it also removes:
+- `_CachedParameterWrapper` observers needed for cached parameter reads
+- Cross-module observers (e.g., PrePlanning/TransducerLocalization/SonicationPlanner/ProtocolConfig all observe Data's parameter node via `onDataParameterNodeModified`)
+
+### Cross-module parameter node observers
+
+Four modules observe the **Data** module's MRML parameter node for `ModifiedEvent` (set up once in `setup()`, never re-added):
+- PrePlanning → `self.onDataParameterNodeModified` → `updateInputOptions()`
+- TransducerLocalization → `self.onDataParameterNodeModified`
+- SonicationPlanner → `self.onDataParameterNodeModified`
+- ProtocolConfig → `self.onDataParameterNodeModified`
+
+These observers are critical for reactive UI updates when data is loaded/changed.
+
+## Commit Guidelines
+
+- **Every commit must reference a relevant GitHub issue number** in the title or body (e.g. `Fix target placement crash (#42)` or with `Fixes #42` / `Relates to #42` in the body).
+- When creating commits, always verify an issue number is included before finalizing.
+- When reviewing code or PRs, check that every commit references an issue number and flag any that don't.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,9 @@ Individual module tests create state needed by subsequent tests — they are not
 ### Adding new pip dependencies
 Adding a package to `python-requirements.txt` is not enough. You must also add an `import` check for it in `python_requirements_exist()` in `lazyimport.py`. Otherwise, users who already have the other deps installed will never trigger a reinstall, and the new package won't be found. Follow the existing `bcrypt`/`threadpoolctl` pattern.
 
+### Updating the pinned openlifu version
+When updating the pinned `openlifu` version in `OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt`, consider whether the sample database tags in `OpenLIFULib/OpenLIFULib/sample_data.py` need to be updated. Remind about this.
+
 ### Qt signal slot signatures
 Qt's `clicked` signal always passes a `checked: bool` argument. Button slot handlers must accept it: `def on_foo_clicked(self, checked: bool)`. Omitting it causes a "takes 1 positional argument but 2 were given" error at runtime.
 

--- a/OpenLIFUCloudSync/CMakeLists.txt
+++ b/OpenLIFUCloudSync/CMakeLists.txt
@@ -26,6 +26,12 @@ add_subdirectory(OpenLIFUCloudSyncEngine)
 #-----------------------------------------------------------------------------
 if(BUILD_TESTING)
 
+  # Judge generic test pass/fail from unittest output instead of exit code.
+  set_tests_properties(py_nomainwindow_qSlicer${MODULE_NAME}ModuleGenericTest PROPERTIES
+    PASS_REGULAR_EXPRESSION "Ran [0-9]+ tests? in [0-9]"
+    FAIL_REGULAR_EXPRESSION "FAILED"
+  )
+
   # Register the unittest subclass in the main script as a ctest.
   # Note that the test will also be available at runtime.
   slicer_add_python_unittest(SCRIPT ${MODULE_NAME}.py)

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -1,10 +1,14 @@
 # Standard library imports
+import json
 import os
 import shutil
 import sys
+import tempfile
+import time
+import zipfile
 import requests
 from pathlib import Path
-from typing import Optional, List, Sequence, Tuple, Callable, TYPE_CHECKING
+from typing import Optional, List, Callable, TYPE_CHECKING
 
 # Third-party imports
 import qt
@@ -20,10 +24,16 @@ from slicer.parameterNodeWrapper import parameterNodeWrapper
 from slicer.util import VTKObservationMixin
 
 # OpenLIFULib imports
+from OpenLIFULib import sample_data
+from OpenLIFULib import sample_data_gui
 from OpenLIFULib import openlifu_lz
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
+from OpenLIFULib.sample_data_gui import (
+    InitializationResult,
+    SampleDatabaseSetupController,
+    initialize_missing_database,
+)
 from OpenLIFULib.util import (
-    ensure_list,
     display_errors,
     add_slicer_log_handler_for_openlifu_object,
 )
@@ -81,6 +91,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         self.logic = None
         self._parameterNode = None
         self._parameterNodeGuiTag = None
+        self.sampleDatabaseSetupController = None
 
     def setup(self) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
@@ -108,6 +119,16 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         # === Connections and UI setup =======
 
         self.logic.call_on_db_changed(self.onDatabaseChanged)
+        self.sampleDatabaseSetupController = SampleDatabaseSetupController(
+            parent=self.parent,
+            path_line_edit=self.ui.databaseDirectoryLineEdit,
+            controls=[
+                self.ui.connectDatabaseButton,
+                self.ui.chooseDatabaseLocationButton,
+            ],
+            clear_database=lambda: setattr(self.logic, "db", None),
+            load_database=self.logic.load_database,
+        )
 
         self.ui.chooseDatabaseLocationButton.clicked.connect(self.on_choose_database_location_clicked)
         self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).connect(
@@ -134,6 +155,8 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
+        if self.sampleDatabaseSetupController is not None:
+            self.sampleDatabaseSetupController.cleanup()
         self.removeObservers()
 
     def enter(self) -> None:
@@ -173,14 +196,18 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
         path = Path(self.ui.databaseDirectoryLineEdit.currentPath)
 
         if not self.logic.path_is_openlifu_database_root(path):
-            if not slicer.util.confirmYesNoDisplay(
-                f"An openlifu database was not found at the entered path ({str(path)}). Do you want to initialize a default one?",
-                "Confirm initialize database"
-            ):
+            initialization_result = initialize_missing_database(
+                parent=self.parent,
+                path=path,
+                create_empty_database=self.logic.copy_preinitialized_database,
+                setup_controller=self.sampleDatabaseSetupController,
+            )
+            if initialization_result == InitializationResult.CANCELED:
                 self.logic.db = None
                 self.ui.databaseDirectoryLineEdit.findChild(qt.QLineEdit).setStyleSheet("border: 1px solid red;")
                 return
-            self.logic.copy_preinitialized_database(path)
+            if initialization_result == InitializationResult.ASYNC_STARTED:
+                return
 
         self.logic.load_database(path)
 
@@ -374,21 +401,7 @@ class OpenLIFUDatabaseLogic(ScriptedLoadableModuleLogic):
 
         Returns True if the required directory and file structure exists, otherwise False.
         """
-        if not path.is_dir():
-            return False
-
-        required_structure = {
-            "protocols/protocols.json",
-            "subjects/subjects.json",
-            "transducers/transducers.json",
-            "users/users.json"
-        }
-
-        for relative_path in required_structure:
-            if not (path / relative_path).exists():
-                return False
-
-        return True
+        return sample_data.path_is_openlifu_database_root(path)
 
     @staticmethod
     def copy_preinitialized_database(destination):
@@ -450,3 +463,336 @@ class OpenLIFUDatabaseTest(ScriptedLoadableModuleTest):
 
         curr_db = get_cur_db()
         assert curr_db is not None, "Database failed to load"
+
+    def _write_minimal_database_fixture(
+        self,
+        database_root: Path,
+        transducer_ids: Optional[List[str]] = None,
+    ) -> None:
+        transducer_ids = transducer_ids if transducer_ids is not None else []
+        index_files = {
+            "protocols/protocols.json": {"protocol_ids": []},
+            "subjects/subjects.json": {"subject_ids": []},
+            "transducers/transducers.json": {"transducer_ids": transducer_ids},
+            "users/users.json": {"user_ids": []},
+        }
+        for relative_path, contents in index_files.items():
+            index_file = database_root / relative_path
+            index_file.parent.mkdir(parents=True, exist_ok=True)
+            index_file.write_text(json.dumps(contents), encoding="utf-8")
+
+    def _write_database_archive(self, database_root: Path, archive_path: Path) -> None:
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            for source_file in database_root.rglob("*"):
+                if source_file.is_file():
+                    archive.write(source_file, source_file.relative_to(database_root.parent))
+
+    def _process_events_until(self, condition: Callable[[], bool], timeout_seconds: float = 10.0) -> bool:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            slicer.app.processEvents()
+            if condition():
+                return True
+            qt.QThread.msleep(10)
+        slicer.app.processEvents()
+        return condition()
+
+    def _python_slicer_or_skip(self) -> str:
+        python_slicer = shutil.which("PythonSlicer")
+        if python_slicer is None:
+            self.skipTest("PythonSlicer was not found.")
+        return python_slicer
+
+    def _run_python_slicer_script(self, script_path: Path, args: List[str], timeout_seconds: float = 120.0):
+        import subprocess
+
+        proc = slicer.util.launchConsoleProcess(
+            [self._python_slicer_or_skip(), str(script_path), *args],
+            useStartupEnvironment=False,
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            self.fail(
+                f"PythonSlicer process timed out after {timeout_seconds} seconds.\n"
+                f"stdout:\n{stdout or ''}\n"
+                f"stderr:\n{stderr or ''}"
+            )
+        return proc.returncode, stdout or "", stderr or ""
+
+    def _make_sample_database_setup_controller_for_test(self):
+        path_widget = qt.QWidget()
+        qt.QLineEdit(path_widget)
+        controls = [qt.QPushButton(), qt.QPushButton()]
+        state = {"db": object(), "loaded_paths": []}
+
+        controller = sample_data_gui.SampleDatabaseSetupController(
+            parent=None,
+            path_line_edit=path_widget,
+            controls=controls,
+            clear_database=lambda: state.__setitem__("db", None),
+            load_database=lambda path: state["loaded_paths"].append(Path(path)),
+            suppress_dialogs_for_testing=True,
+        )
+        return controller, state
+
+    def test_copy_sample_database_from_archive_with_local_archive_and_work_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            source_database = temp_dir_path / "source-database"
+            archive_path = temp_dir_path / "source-database.zip"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            work_dir = temp_dir_path / "work"
+            progress_updates = []
+
+            self._write_minimal_database_fixture(
+                source_database,
+                transducer_ids=["openlifu_2x400_evt1"],
+            )
+            self._write_database_archive(source_database, archive_path)
+
+            sample_data.copy_sample_database_from_archive(
+                destination,
+                progress_callback=lambda message, value, maximum: progress_updates.append((message, value, maximum)),
+                archive_url=archive_path.as_uri(),
+                work_dir=work_dir,
+            )
+
+            self.assertTrue(OpenLIFUDatabaseLogic.path_is_openlifu_database_root(destination))
+            self.assertTrue(any("Downloading" in update[0] for update in progress_updates))
+            self.assertTrue(any("Installing" in update[0] for update in progress_updates))
+            logic = OpenLIFUDatabaseLogic()
+            logic.load_database(destination)
+            self.assertIn("openlifu_2x400_evt1", logic.db.get_transducer_ids())
+
+    def test_copy_sample_database_rejects_non_empty_destination_before_download(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            (destination / "notes.txt").write_text("not an OpenLIFU database\n", encoding="utf-8")
+            work_dir = temp_dir_path / "work"
+            download_calls = []
+
+            original_download = sample_data.download_and_extract_archive_with_progress
+
+            def fail_if_download_starts(*args, **kwargs):
+                download_calls.append((args, kwargs))
+                raise AssertionError("Download should not start for a non-empty destination.")
+
+            sample_data.download_and_extract_archive_with_progress = fail_if_download_starts
+            try:
+                with self.assertRaisesRegex(RuntimeError, "selected folder is not empty"):
+                    sample_data.copy_sample_database_from_archive(
+                        destination,
+                        archive_url="file:///unused-sample-database.zip",
+                        work_dir=work_dir,
+                    )
+            finally:
+                sample_data.download_and_extract_archive_with_progress = original_download
+
+            self.assertEqual([], download_calls)
+            self.assertFalse(work_dir.exists())
+
+    def test_sample_data_cli_installs_local_archive_with_python_slicer(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            source_database = temp_dir_path / "source-database"
+            archive_path = temp_dir_path / "source-database.zip"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            work_dir = temp_dir_path / "work"
+
+            self._write_minimal_database_fixture(
+                source_database,
+                transducer_ids=["openlifu_2x400_evt1"],
+            )
+            self._write_database_archive(source_database, archive_path)
+
+            returncode, stdout, stderr = self._run_python_slicer_script(
+                sample_data_gui.sample_database_cli_path(),
+                [
+                    "--destination",
+                    str(destination),
+                    "--work-dir",
+                    str(work_dir),
+                    "--archive-url",
+                    archive_path.as_uri(),
+                ],
+            )
+
+            self.assertEqual(
+                0,
+                returncode,
+                msg=f"stdout:\n{stdout}\nstderr:\n{stderr}",
+            )
+            progress_events = [
+                json.loads(line[len(sample_data.PROGRESS_LINE_PREFIX):])
+                for line in stdout.splitlines()
+                if line.startswith(sample_data.PROGRESS_LINE_PREFIX)
+            ]
+            self.assertTrue(progress_events)
+            self.assertTrue(progress_events[-1].get("success"))
+            self.assertTrue(OpenLIFUDatabaseLogic.path_is_openlifu_database_root(destination))
+
+    def test_failed_sample_database_subprocess_leaves_destination_empty_and_clears_db(self):
+        self._python_slicer_or_skip()
+        controller, state = self._make_sample_database_setup_controller_for_test()
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir_path = Path(temp_dir)
+                source_database = temp_dir_path / "source-database"
+                archive_path = temp_dir_path / "source-database.zip"
+                destination = temp_dir_path / "destination"
+                destination.mkdir()
+
+                self._write_minimal_database_fixture(source_database)
+                (source_database / "users" / "users.json").unlink()
+                self._write_database_archive(source_database, archive_path)
+
+                self.assertTrue(
+                    controller.start_sample_database_setup(destination, archive_url=archive_path.as_uri())
+                )
+                self.assertTrue(
+                    self._process_events_until(lambda: not controller.is_active(), timeout_seconds=30),
+                    "Sample database setup subprocess did not finish.",
+                )
+                self.assertIsNone(state["db"])
+                self.assertEqual([], state["loaded_paths"])
+                self.assertEqual([], list(destination.iterdir()))
+                self.assertTrue(controller.path_line_edit.enabled)
+                self.assertTrue(all(control.enabled for control in controller.controls))
+        finally:
+            controller.cleanup()
+
+    def test_sample_database_setup_rejects_non_empty_destination_before_subprocess(self):
+        controller, state = self._make_sample_database_setup_controller_for_test()
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir_path = Path(temp_dir)
+                destination = temp_dir_path / "destination"
+                destination.mkdir()
+                (destination / "notes.txt").write_text("not an OpenLIFU database\n", encoding="utf-8")
+
+                self.assertFalse(controller.start_sample_database_setup(destination))
+                self.assertFalse(controller.is_active())
+                self.assertIsNone(controller._destination)
+                self.assertIsNone(controller._work_dir)
+                self.assertIsNone(state["db"])
+                self.assertEqual([], state["loaded_paths"])
+                self.assertTrue(controller.path_line_edit.enabled)
+                self.assertTrue(all(control.enabled for control in controller.controls))
+        finally:
+            controller.cleanup()
+
+    def test_cancel_sample_database_subprocess_leaves_destination_empty_and_clears_db(self):
+        self._python_slicer_or_skip()
+        controller, state = self._make_sample_database_setup_controller_for_test()
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir_path = Path(temp_dir)
+                destination = temp_dir_path / "destination"
+                destination.mkdir()
+                progress_payload = json.dumps(
+                    {
+                        "message": "Waiting for cancellation...",
+                        "value": 0,
+                        "maximum": 0,
+                    }
+                )
+                slow_cli = temp_dir_path / "slow_sample_data_cli.py"
+                slow_cli.write_text(
+                    f"import argparse\n"
+                    f"import time\n"
+                    f"from pathlib import Path\n"
+                    f"parser = argparse.ArgumentParser()\n"
+                    f"parser.add_argument('--destination')\n"
+                    f"parser.add_argument('--work-dir')\n"
+                    f"parser.add_argument('--cancel-file', default='')\n"
+                    f"args = parser.parse_args()\n"
+                    f"print({(sample_data.PROGRESS_LINE_PREFIX + progress_payload)!r}, flush=True)\n"
+                    f"deadline = time.monotonic() + 30\n"
+                    f"while time.monotonic() < deadline:\n"
+                    f"    if args.cancel_file and Path(args.cancel_file).exists():\n"
+                    f"        break\n"
+                    f"    time.sleep(0.05)\n",
+                    encoding="utf-8",
+                )
+
+                self.assertTrue(controller.start_sample_database_setup(destination, cli_path=slow_cli))
+                self.assertTrue(
+                    self._process_events_until(lambda: controller.is_active(), timeout_seconds=10),
+                    "Sample database setup subprocess did not start.",
+                )
+                self.assertFalse(controller.path_line_edit.enabled)
+                self.assertTrue(all(not control.enabled for control in controller.controls))
+
+                controller.cancel_sample_database_setup()
+                self.assertFalse(controller.is_active())
+                self.assertTrue(controller.path_line_edit.enabled)
+                self.assertTrue(all(control.enabled for control in controller.controls))
+                self.assertTrue(
+                    self._process_events_until(
+                        lambda: controller._background_canceled_process is None,
+                        timeout_seconds=10,
+                    ),
+                    "Canceled sample database setup subprocess did not exit after cancellation.",
+                )
+                self.assertIsNone(state["db"])
+                self.assertEqual([], state["loaded_paths"])
+                self.assertEqual([], list(destination.iterdir()))
+        finally:
+            controller.cleanup()
+
+    def test_move_sample_database_rejects_git_lfs_pointer_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            sample_database = temp_dir_path / "sample-database"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            self._write_minimal_database_fixture(sample_database)
+            pointer_file = sample_database / "subjects" / "unresolved-volume.nii.gz"
+            pointer_file.write_text(
+                "version https://git-lfs.github.com/spec/v1\n"
+                "oid sha256:0000000000000000000000000000000000000000000000000000000000000000\n"
+                "size 123\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "Git LFS pointer"):
+                sample_data.move_sample_database_into_place(sample_database, destination)
+
+            self.assertEqual([], list(destination.iterdir()))
+
+    def test_move_sample_database_rejects_missing_required_index_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            sample_database = temp_dir_path / "sample-database"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            self._write_minimal_database_fixture(sample_database)
+            (sample_database / "users" / "users.json").unlink()
+
+            with self.assertRaisesRegex(RuntimeError, "missing required database index files"):
+                sample_data.move_sample_database_into_place(sample_database, destination)
+
+            self.assertEqual([], list(destination.iterdir()))
+
+    def test_copy_preinitialized_database_still_creates_empty_database(self):
+        slicer.util.selectModule("OpenLIFUDatabase")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "empty-database"
+
+            OpenLIFUDatabaseLogic.copy_preinitialized_database(destination)
+
+            self.assertTrue(OpenLIFUDatabaseLogic.path_is_openlifu_database_root(destination))
+            logic = OpenLIFUDatabaseLogic()
+            logic.load_database(destination)
+            self.assertIsNotNone(logic.db)
+            self.assertEqual([], logic.db.get_transducer_ids())

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -27,6 +27,9 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/notifications.py
   OpenLIFULib/volume_thresholding.py
   OpenLIFULib/install_asset_dialog.py
+  OpenLIFULib/sample_data.py
+  OpenLIFULib/sample_data_gui.py
+  OpenLIFULib/sample_data_cli.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/sample_data.py
+++ b/OpenLIFULib/OpenLIFULib/sample_data.py
@@ -1,0 +1,323 @@
+# Standard library imports
+import os
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Callable, List, Optional
+
+SAMPLE_DATABASE_REPOSITORY_URL = "https://github.com/OpenwaterHealth/openlifu-sample-database"
+SAMPLE_DATABASE_TAG = "openlifu-v0.20.0"
+STARTER_DATABASE_TAG = "openlifu-v0.20.0-no-subjects"
+
+
+def archive_url_for_tag(tag: str) -> str:
+    return f"{SAMPLE_DATABASE_REPOSITORY_URL}/archive/refs/tags/{tag}.zip"
+
+
+def readme_url_for_tag(tag: str) -> str:
+    return f"{SAMPLE_DATABASE_REPOSITORY_URL}/blob/{tag}/README.md"
+
+
+SAMPLE_DATABASE_ARCHIVE_URL = archive_url_for_tag(SAMPLE_DATABASE_TAG)
+STARTER_DATABASE_ARCHIVE_URL = archive_url_for_tag(STARTER_DATABASE_TAG)
+SAMPLE_DATABASE_BUTTON_HELP_TEXT = (
+    "Create a database in the selected folder containing Openwater sample data."
+)
+STARTER_DATABASE_BUTTON_HELP_TEXT = (
+    "Create a database in the selected folder containing Openwater sample data, excluding any sample subjects. Sample transducers and protocols are provided."
+)
+SAMPLE_DATABASE_README_URL = readme_url_for_tag(SAMPLE_DATABASE_TAG)
+STARTER_DATABASE_README_URL = readme_url_for_tag(STARTER_DATABASE_TAG)
+
+REQUIRED_OPENLIFU_DATABASE_INDEX_FILES = (
+    "protocols/protocols.json",
+    "subjects/subjects.json",
+    "transducers/transducers.json",
+    "users/users.json",
+)
+
+PROGRESS_LINE_PREFIX = "OPENLIFU_SAMPLE_DATA_PROGRESS "
+GIT_LFS_POINTER_SIGNATURE = b"version https://git-lfs.github.com/spec/v1"
+BYTES_PER_MB = 1024 * 1024
+DOWNLOAD_SOCKET_TIMEOUT_SECONDS = 45
+
+
+class SampleDatabaseSetupCanceled(Exception):
+    """Raised when sample database setup is canceled by the caller."""
+
+
+def raise_if_canceled(cancel_callback: Optional[Callable[[], bool]]) -> None:
+    if cancel_callback is not None and cancel_callback():
+        raise SampleDatabaseSetupCanceled("Sample database setup canceled.")
+
+
+def path_is_openlifu_database_root(path: Path) -> bool:
+    """Check if a path has the required OpenLIFU database index files."""
+    path = Path(path)
+    if not path.is_dir():
+        return False
+
+    for relative_path in REQUIRED_OPENLIFU_DATABASE_INDEX_FILES:
+        if not (path / relative_path).is_file():
+            return False
+
+    return True
+
+
+def validate_openlifu_database_root(path: Path) -> None:
+    path = Path(path)
+    if not path.is_dir():
+        raise RuntimeError(f"Sample database source is not a directory: {path}")
+
+    missing_paths = [
+        relative_path
+        for relative_path in REQUIRED_OPENLIFU_DATABASE_INDEX_FILES
+        if not (path / relative_path).is_file()
+    ]
+    if missing_paths:
+        raise RuntimeError(
+            "Sample database is missing required database index files: "
+            + ", ".join(missing_paths)
+        )
+
+
+def find_git_lfs_pointer_files(path: Path) -> List[Path]:
+    path = Path(path)
+    pointer_files = []
+    for candidate in path.rglob("*"):
+        if not candidate.is_file():
+            continue
+        with candidate.open("rb") as candidate_file:
+            header = candidate_file.read(1024)
+        if GIT_LFS_POINTER_SIGNATURE in header:
+            pointer_files.append(candidate)
+    return pointer_files
+
+
+def find_extracted_sample_database_root(extraction_dir: Path) -> Path:
+    extraction_dir = Path(extraction_dir)
+    candidates = [extraction_dir]
+    candidates.extend(child for child in extraction_dir.iterdir() if child.is_dir())
+
+    for candidate in candidates:
+        if path_is_openlifu_database_root(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "Downloaded sample database archive did not contain an OpenLIFU database root."
+    )
+
+
+def validate_sample_database_destination_can_install(destination: Path) -> None:
+    destination = Path(destination)
+
+    if destination.exists():
+        if not destination.is_dir():
+            raise RuntimeError(f"Sample database destination is not a directory: {destination}")
+        if any(destination.iterdir()):
+            raise RuntimeError(
+                "Sample data can only be created in an empty folder. "
+                f"The selected folder is not empty: {destination}"
+            )
+
+
+def validate_sample_database_can_install(source: Path, destination: Path) -> None:
+    source = Path(source)
+
+    validate_openlifu_database_root(source)
+    pointer_files = find_git_lfs_pointer_files(source)
+    if pointer_files:
+        rel_pointer_files = [
+            str(pointer_file.relative_to(source))
+            for pointer_file in pointer_files[:5]
+        ]
+        more_files = len(pointer_files) - len(rel_pointer_files)
+        more_suffix = f", and {more_files} more" if more_files else ""
+        raise RuntimeError(
+            "Sample database contains unresolved Git LFS pointer files: "
+            + ", ".join(rel_pointer_files)
+            + more_suffix
+        )
+
+    validate_sample_database_destination_can_install(destination)
+
+
+def move_sample_database_into_place(
+    source: Path,
+    destination: Path,
+    progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    cancel_callback: Optional[Callable[[], bool]] = None,
+) -> None:
+    source = Path(source)
+    destination = Path(destination)
+
+    raise_if_canceled(cancel_callback)
+    if progress_callback is not None:
+        progress_callback("Validating sample database contents...", 0, 0)
+
+    validate_sample_database_can_install(source, destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination_existed = destination.exists()
+
+    raise_if_canceled(cancel_callback)
+    if progress_callback is not None:
+        progress_callback("Installing sample database into the selected folder...", 0, 0)
+
+    raise_if_canceled(cancel_callback)
+    try:
+        if destination_existed:
+            destination.rmdir()
+        source.rename(destination)
+    except Exception:
+        if destination_existed and not destination.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+        raise
+
+
+def copy_sample_database_from_archive(
+    destination: Path,
+    progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    archive_url: Optional[str] = None,
+    work_dir: Optional[Path] = None,
+    cancel_callback: Optional[Callable[[], bool]] = None,
+) -> None:
+    destination = Path(destination)
+    raise_if_canceled(cancel_callback)
+    validate_sample_database_destination_can_install(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    archive_url = archive_url or SAMPLE_DATABASE_ARCHIVE_URL
+
+    if work_dir is None:
+        with tempfile.TemporaryDirectory(prefix=f".{destination.name}-sample-download-", dir=destination.parent) as temp_dir:
+            _copy_sample_database_from_archive_in_work_dir(
+                destination,
+                Path(temp_dir),
+                archive_url,
+                progress_callback,
+                cancel_callback,
+            )
+    else:
+        _copy_sample_database_from_archive_in_work_dir(
+            destination,
+            Path(work_dir),
+            archive_url,
+            progress_callback,
+            cancel_callback,
+        )
+
+
+def _copy_sample_database_from_archive_in_work_dir(
+    destination: Path,
+    work_dir: Path,
+    archive_url: str,
+    progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    cancel_callback: Optional[Callable[[], bool]] = None,
+) -> None:
+    destination = Path(destination)
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    raise_if_canceled(cancel_callback)
+    if any(work_dir.iterdir()):
+        raise RuntimeError(f"Sample database work directory is not empty: {work_dir}")
+
+    archive_path = work_dir / f"openlifu-sample-database-{SAMPLE_DATABASE_TAG}.zip"
+    extraction_dir = work_dir / "extracted"
+    extraction_dir.mkdir()
+
+    download_and_extract_archive_with_progress(
+        archive_url,
+        archive_path,
+        extraction_dir,
+        progress_callback or (lambda message, value, maximum: None),
+        cancel_callback=cancel_callback,
+    )
+
+    raise_if_canceled(cancel_callback)
+    sample_database_root = find_extracted_sample_database_root(extraction_dir)
+    move_sample_database_into_place(
+        sample_database_root,
+        destination,
+        progress_callback=progress_callback,
+        cancel_callback=cancel_callback,
+    )
+
+
+def download_and_extract_archive_with_progress(
+    url: str,
+    archive_path: Path,
+    extraction_dir: Path,
+    progress_callback: Callable[[str, int, int], None],
+    cancel_callback: Optional[Callable[[], bool]] = None,
+) -> None:
+    archive_path = Path(archive_path)
+    extraction_dir = Path(extraction_dir)
+
+    raise_if_canceled(cancel_callback)
+    progress_callback(
+        "Downloading OpenLIFU sample data. This is a large download and may take several minutes.",
+        0,
+        0,
+    )
+
+    with urllib.request.urlopen(url, timeout=DOWNLOAD_SOCKET_TIMEOUT_SECONDS) as response:
+        total_size = int(response.headers.get("Content-Length") or 0)
+        total_mb = max(1, total_size // BYTES_PER_MB) if total_size else 0
+        downloaded_size = 0
+        last_reported_download_mb = -1
+
+        with archive_path.open("wb") as archive_file:
+            while True:
+                raise_if_canceled(cancel_callback)
+                chunk = response.read(BYTES_PER_MB)
+                if not chunk:
+                    break
+
+                raise_if_canceled(cancel_callback)
+                archive_file.write(chunk)
+                downloaded_size += len(chunk)
+
+                downloaded_mb = downloaded_size // BYTES_PER_MB
+                if downloaded_mb == last_reported_download_mb:
+                    continue
+
+                if total_mb:
+                    reported_download_mb = min(total_mb, downloaded_mb)
+                    progress_callback(
+                        f"Downloading OpenLIFU sample data ({reported_download_mb} of {total_mb} MB)...",
+                        reported_download_mb,
+                        total_mb,
+                    )
+                else:
+                    progress_callback(
+                        f"Downloading OpenLIFU sample data ({downloaded_mb} MB downloaded)...",
+                        0,
+                        0,
+                    )
+                last_reported_download_mb = downloaded_mb
+
+    raise_if_canceled(cancel_callback)
+    progress_callback("Extracting OpenLIFU sample data...", 0, 0)
+
+    extraction_dir_resolved = extraction_dir.resolve()
+    with zipfile.ZipFile(archive_path) as archive:
+        members = archive.infolist()
+        total_members = len(members)
+        report_every = max(1, total_members // 100) if total_members else 1
+
+        for member_index, member in enumerate(members, start=1):
+            raise_if_canceled(cancel_callback)
+            destination_path = (extraction_dir / member.filename).resolve()
+            if os.path.commonpath([str(extraction_dir_resolved), str(destination_path)]) != str(extraction_dir_resolved):
+                raise RuntimeError(
+                    f"Sample database archive contains an unsafe path: {member.filename}"
+                )
+
+            archive.extract(member, extraction_dir)
+            if member_index == total_members or member_index % report_every == 0:
+                progress_callback(
+                    f"Extracting OpenLIFU sample data ({member_index} of {total_members} files)...",
+                    member_index,
+                    total_members,
+                )

--- a/OpenLIFULib/OpenLIFULib/sample_data_cli.py
+++ b/OpenLIFULib/OpenLIFULib/sample_data_cli.py
@@ -1,0 +1,95 @@
+# Standard library imports
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_sample_data_module():
+    sample_data_path = Path(__file__).resolve().with_name("sample_data.py")
+    spec = importlib.util.spec_from_file_location("openlifu_sample_data", sample_data_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sample_data = _load_sample_data_module()
+
+
+def _emit_progress_event(event: dict) -> None:
+    print(sample_data.PROGRESS_LINE_PREFIX + json.dumps(event), flush=True)
+
+
+def _progress_callback(message: str, value: int, maximum: int) -> None:
+    _emit_progress_event(
+        {
+            "message": message,
+            "value": value,
+            "maximum": maximum,
+        }
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Create an OpenLIFU sample database.")
+    parser.add_argument("--destination", required=True, help="Empty folder where the database will be installed.")
+    parser.add_argument("--work-dir", required=True, help="Empty temporary work directory owned by the parent process.")
+    parser.add_argument(
+        "--archive-url",
+        default=sample_data.SAMPLE_DATABASE_ARCHIVE_URL,
+        help="Sample database archive URL. Defaults to the pinned OpenLIFU sample database release.",
+    )
+    parser.add_argument(
+        "--cancel-file",
+        default="",
+        help="Optional sentinel file. If it exists, setup exits as canceled.",
+    )
+    args = parser.parse_args(argv)
+    cancel_file = Path(args.cancel_file) if args.cancel_file else None
+
+    try:
+        sample_data.copy_sample_database_from_archive(
+            Path(args.destination),
+            progress_callback=_progress_callback,
+            archive_url=args.archive_url,
+            work_dir=Path(args.work_dir),
+            cancel_callback=cancel_file.exists if cancel_file is not None else None,
+        )
+    except sample_data.SampleDatabaseSetupCanceled as exc:
+        _emit_progress_event(
+            {
+                "message": str(exc),
+                "value": 0,
+                "maximum": 0,
+                "success": False,
+                "canceled": True,
+            }
+        )
+        return 2
+    except Exception as exc:
+        _emit_progress_event(
+            {
+                "message": str(exc),
+                "value": 0,
+                "maximum": 0,
+                "success": False,
+                "error": str(exc),
+            }
+        )
+        print(str(exc), file=sys.stderr, flush=True)
+        return 1
+
+    _emit_progress_event(
+        {
+            "message": "Sample database created.",
+            "value": 1,
+            "maximum": 1,
+            "success": True,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/OpenLIFULib/OpenLIFULib/sample_data_gui.py
+++ b/OpenLIFULib/OpenLIFULib/sample_data_gui.py
@@ -1,0 +1,557 @@
+# Standard library imports
+import json
+import logging
+import shutil
+import tempfile
+from enum import Enum
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence, Tuple
+
+# Third-party imports
+import qt
+
+# Slicer imports
+import slicer
+
+# OpenLIFULib imports
+from OpenLIFULib import sample_data
+from OpenLIFULib.guided_mode_util import get_guided_mode_state
+
+
+logger = logging.getLogger(__name__)
+
+
+class InitializationResult(Enum):
+    READY_TO_LOAD = "ready_to_load"
+    ASYNC_STARTED = "async_started"
+    CANCELED = "canceled"
+
+
+def initialize_missing_database(
+    parent,
+    path: Path,
+    create_empty_database: Callable[[Path], None],
+    setup_controller: "SampleDatabaseSetupController",
+) -> InitializationResult:
+    initialization_choice = select_database_initialization_option(parent, path)
+    if initialization_choice is None:
+        return InitializationResult.CANCELED
+
+    if initialization_choice in ("sample", "starter"):
+        archive_url, display_name, readme_url = sample_database_setup_info_for_initialization_choice(
+            initialization_choice
+        )
+        if setup_controller.start_sample_database_setup(
+            path,
+            archive_url=archive_url,
+            display_name=display_name,
+            readme_url=readme_url,
+        ):
+            return InitializationResult.ASYNC_STARTED
+        return InitializationResult.CANCELED
+
+    create_empty_database(path)
+    return InitializationResult.READY_TO_LOAD
+
+
+def select_database_initialization_option(parent, path: Path) -> Optional[str]:
+    message_box = qt.QMessageBox(parent)
+    message_box.setIcon(qt.QMessageBox.Question)
+    message_box.setWindowTitle("Initialize OpenLIFU database")
+    message_box.setText(
+        f"An OpenLIFU database was not found at the entered path ({str(path)})."
+    )
+    message_box.setInformativeText("Choose how to initialize the selected folder.")
+
+    sample_button = message_box.addButton("Use Sample Data", qt.QMessageBox.ActionRole)
+    sample_button.setToolTip(sample_data.SAMPLE_DATABASE_BUTTON_HELP_TEXT)
+    starter_button = message_box.addButton("Create Starter Database", qt.QMessageBox.ActionRole)
+    starter_button.setToolTip(sample_data.STARTER_DATABASE_BUTTON_HELP_TEXT)
+    empty_button = message_box.addButton("Create Empty Database", qt.QMessageBox.ActionRole)
+    empty_button.setToolTip("Create a completely empty database in the selected folder.")
+    cancel_button = message_box.addButton(qt.QMessageBox.Cancel)
+    message_box.setDefaultButton(sample_button)
+    message_box.exec_()
+
+    clicked_button = message_box.clickedButton()
+    if clicked_button == sample_button:
+        return "sample"
+    if clicked_button == starter_button:
+        return "starter"
+    if clicked_button == empty_button:
+        return "empty"
+    if clicked_button == cancel_button:
+        return None
+    return None
+
+
+def sample_database_setup_info_for_initialization_choice(initialization_choice: str) -> Tuple[str, str, str]:
+    if initialization_choice == "starter":
+        return (
+            sample_data.STARTER_DATABASE_ARCHIVE_URL,
+            "starter database",
+            sample_data.STARTER_DATABASE_README_URL,
+        )
+    return (
+        sample_data.SAMPLE_DATABASE_ARCHIVE_URL,
+        "sample database",
+        sample_data.SAMPLE_DATABASE_README_URL,
+    )
+
+
+def sample_database_cli_path() -> Path:
+    return Path(sample_data.__file__).resolve().with_name("sample_data_cli.py")
+
+
+class SampleDatabaseSetupController:
+    def __init__(
+        self,
+        parent,
+        path_line_edit,
+        controls: Sequence[object],
+        clear_database: Callable[[], None],
+        load_database: Callable[[Path], None],
+        suppress_dialogs_for_testing: bool = False,
+    ) -> None:
+        self.parent = parent
+        self.path_line_edit = path_line_edit
+        self.controls = list(controls)
+        self.clear_database = clear_database
+        self.load_database = load_database
+        self.suppress_dialogs_for_testing = suppress_dialogs_for_testing
+
+        self._process = None
+        self._dialog = None
+        self._destination = None
+        self._work_dir = None
+        self._cancel_file = None
+        self._background_canceled_process = None
+        self._stdout_buffer = ""
+        self._stderr_buffer = ""
+        self._diagnostics: List[str] = []
+        self._child_succeeded = False
+        self._child_error = ""
+        self._process_error = ""
+        self._was_canceled = False
+        self._display_name = "sample database"
+        self._readme_url = sample_data.SAMPLE_DATABASE_README_URL
+
+    def is_active(self) -> bool:
+        return self._process is not None
+
+    def cleanup(self) -> None:
+        if self._process is None:
+            return
+
+        self.cancel_sample_database_setup()
+
+    def start_sample_database_setup(
+        self,
+        path: Path,
+        archive_url: Optional[str] = None,
+        display_name: str = "sample database",
+        readme_url: str = sample_data.SAMPLE_DATABASE_README_URL,
+        cli_path: Optional[Path] = None,
+    ) -> bool:
+        if self.is_active():
+            slicer.util.warningDisplay("Sample database setup is already in progress.")
+            return True
+        if self._background_canceled_process is not None:
+            self._display_sample_database_setup_warning(
+                "The previous sample database setup is still canceling. Please wait a moment and try again."
+            )
+            return False
+
+        destination = Path(path)
+        try:
+            sample_data.validate_sample_database_destination_can_install(destination)
+        except Exception as exc:
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._display_sample_database_setup_error(
+                f"Failed to create {display_name}:\n{exc}"
+            )
+            return False
+
+        python_slicer = shutil.which("PythonSlicer")
+        if python_slicer is None:
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._display_sample_database_setup_error(
+                f"Failed to create {display_name}:\nPythonSlicer was not found on PATH."
+            )
+            return False
+
+        cli_path = Path(cli_path) if cli_path is not None else sample_database_cli_path()
+        if not cli_path.is_file():
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._display_sample_database_setup_error(
+                f"Failed to create {display_name}:\nSample database helper was not found: {cli_path}"
+            )
+            return False
+
+        self.clear_database()
+        self._destination = destination
+        self._display_name = display_name
+        self._readme_url = readme_url
+        self._destination.parent.mkdir(parents=True, exist_ok=True)
+        self._work_dir = Path(
+            tempfile.mkdtemp(
+                prefix=f".{self._destination.name}-sample-download-",
+                dir=self._destination.parent,
+            )
+        )
+        self._cancel_file = self._work_dir / "cancel-requested"
+        self._reset_output_state()
+        self._set_database_path_border("yellow")
+        self._set_controls_enabled(False)
+
+        progress_dialog = qt.QProgressDialog(
+            f"Downloading OpenLIFU {display_name}. This is a large download and may take several minutes.",
+            "Cancel",
+            0,
+            0,
+            self.parent,
+        )
+        progress_dialog.setWindowTitle(f"Creating OpenLIFU {display_name.title()}")
+        progress_dialog.setAutoClose(False)
+        progress_dialog.setAutoReset(False)
+        progress_dialog.setMinimumDuration(0)
+        progress_dialog.setWindowModality(qt.Qt.ApplicationModal)
+        progress_dialog.setRange(0, 0)
+        progress_dialog.canceled.connect(self.cancel_sample_database_setup)
+        if not self.suppress_dialogs_for_testing:
+            progress_dialog.show()
+            slicer.app.processEvents()
+        self._dialog = progress_dialog
+
+        process = qt.QProcess()
+        process.readyReadStandardOutput.connect(self._on_stdout_ready)
+        process.readyReadStandardError.connect(self._on_stderr_ready)
+        process.finished.connect(self._on_finished)
+        process.errorOccurred.connect(self._on_process_error)
+        self._process = process
+
+        args = [
+            str(cli_path),
+            "--destination",
+            str(self._destination),
+            "--work-dir",
+            str(self._work_dir),
+            "--cancel-file",
+            str(self._cancel_file),
+        ]
+        if archive_url is not None:
+            args.extend(["--archive-url", archive_url])
+
+        process.start(python_slicer, args)
+        if not process.waitForStarted(3000):
+            error_message = process.errorString() or "The sample database helper process failed to start."
+            self._complete_sample_database_setup(False, error_message)
+            return False
+        return True
+
+    def cancel_sample_database_setup(self) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._was_canceled = True
+        self.clear_database()
+        self._request_child_cancel()
+        if self._dialog is not None:
+            self._dialog.setLabelText("Canceling sample database setup...")
+
+        if process.state() == qt.QProcess.NotRunning:
+            self._complete_sample_database_setup(False, canceled=True)
+            return
+
+        self._detach_canceled_process(process, self._work_dir)
+        self._process = None
+        self._work_dir = None
+        self._cancel_file = None
+        self._complete_sample_database_setup(False, canceled=True)
+
+    def _request_child_cancel(self) -> None:
+        cancel_file = self._cancel_file
+        if cancel_file is None:
+            return
+
+        try:
+            cancel_file.parent.mkdir(parents=True, exist_ok=True)
+            cancel_file.write_text("cancel\n", encoding="utf-8")
+        except Exception as exc:
+            self._append_diagnostic(f"Could not write cancel file: {exc}")
+
+    def _detach_canceled_process(self, process, work_dir: Optional[Path]) -> None:
+        self._disconnect_process_signals(process)
+        self._background_canceled_process = process
+
+        def cleanup_detached_process(*args, detached_process=process, detached_work_dir=work_dir):
+            self._cleanup_detached_process(detached_process, detached_work_dir)
+
+        process.finished.connect(cleanup_detached_process)
+        if process.state() == qt.QProcess.NotRunning:
+            cleanup_detached_process()
+
+    def _cleanup_detached_process(self, process, work_dir: Optional[Path]) -> None:
+        try:
+            process.finished.disconnect()
+        except Exception:
+            pass
+
+        if self._background_canceled_process is process:
+            self._background_canceled_process = None
+
+        process.deleteLater()
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def _on_stdout_ready(self) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._stdout_buffer += process.readAllStandardOutput().data().decode("utf-8", errors="replace")
+        self._consume_stdout_lines()
+
+    def _on_stderr_ready(self) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._stderr_buffer += process.readAllStandardError().data().decode("utf-8", errors="replace")
+        self._consume_stderr_lines()
+
+    def _consume_stdout_lines(self, flush: bool = False) -> None:
+        while "\n" in self._stdout_buffer:
+            line, self._stdout_buffer = self._stdout_buffer.split("\n", 1)
+            self._handle_stdout_line(line.rstrip("\r"))
+
+        if flush and self._stdout_buffer:
+            line = self._stdout_buffer
+            self._stdout_buffer = ""
+            self._handle_stdout_line(line.rstrip("\r"))
+
+    def _consume_stderr_lines(self, flush: bool = False) -> None:
+        while "\n" in self._stderr_buffer:
+            line, self._stderr_buffer = self._stderr_buffer.split("\n", 1)
+            self._append_diagnostic(line.rstrip("\r"))
+
+        if flush and self._stderr_buffer:
+            line = self._stderr_buffer
+            self._stderr_buffer = ""
+            self._append_diagnostic(line.rstrip("\r"))
+
+    def _append_diagnostic(self, line: str) -> None:
+        line = line.strip()
+        if not line:
+            return
+
+        logger.info("OpenLIFU sample database setup: %s", line)
+        self._diagnostics.append(line)
+        self._diagnostics = self._diagnostics[-40:]
+
+    def _handle_stdout_line(self, line: str) -> None:
+        line = line.strip()
+        if not line:
+            return
+
+        if not line.startswith(sample_data.PROGRESS_LINE_PREFIX):
+            self._append_diagnostic(line)
+            return
+
+        try:
+            progress_event = json.loads(line[len(sample_data.PROGRESS_LINE_PREFIX):])
+        except json.JSONDecodeError as exc:
+            self._append_diagnostic(f"Could not parse progress line: {exc}: {line}")
+            return
+
+        message = str(progress_event.get("message") or "")
+        value = int(progress_event.get("value") or 0)
+        maximum = int(progress_event.get("maximum") or 0)
+        if message:
+            self._update_progress(message, value, maximum)
+
+        if "success" in progress_event:
+            if progress_event["success"]:
+                self._child_succeeded = True
+            else:
+                self._child_error = str(
+                    progress_event.get("error") or progress_event.get("message") or "Sample database setup failed."
+                )
+
+    def _on_process_error(self, process_error) -> None:
+        process = self._process
+        if process is not None:
+            self._process_error = process.errorString()
+
+    def _update_progress(self, message: str, value: int, maximum: int) -> None:
+        progress_dialog = self._dialog
+        if progress_dialog is None:
+            return
+
+        if maximum <= 0:
+            progress_dialog.setRange(0, 0)
+        else:
+            progress_dialog.setRange(0, maximum)
+            progress_dialog.setValue(value)
+
+        progress_dialog.setLabelText(message)
+
+    def _on_finished(self, *args) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._on_stdout_ready()
+        self._on_stderr_ready()
+        self._consume_stdout_lines(flush=True)
+        self._consume_stderr_lines(flush=True)
+
+        if self._was_canceled:
+            self._complete_sample_database_setup(False, canceled=True)
+            return
+
+        exit_code = args[0] if args else process.exitCode()
+        if self._child_succeeded and not self._child_error and exit_code == 0:
+            self._complete_sample_database_setup(True)
+            return
+
+        self._complete_sample_database_setup(False, self._failure_message(exit_code))
+
+    def _failure_message(self, exit_code: int) -> str:
+        if self._child_error:
+            message = self._child_error
+        elif self._process_error:
+            message = self._process_error
+        elif exit_code != 0:
+            message = f"Sample database setup subprocess failed with exit code {exit_code}."
+        else:
+            message = "Sample database setup subprocess finished without reporting success."
+
+        if self._diagnostics:
+            message += "\n\nChild process output:\n" + "\n".join(self._diagnostics[-10:])
+        return message
+
+    def _complete_sample_database_setup(
+        self,
+        succeeded: bool,
+        error_message: str = "",
+        canceled: bool = False,
+    ) -> None:
+        process = self._process
+        self._process = None
+        if process is not None:
+            process.deleteLater()
+
+        if self._dialog is not None:
+            self._dialog.close()
+            self._dialog = None
+
+        self._set_controls_enabled(True)
+
+        path = self._destination
+        self._destination = None
+
+        work_dir = self._work_dir
+        self._work_dir = None
+        self._cancel_file = None
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+        if canceled:
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._reset_output_state()
+            return
+
+        if not succeeded:
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._display_sample_database_setup_error(
+                f"Failed to create {self._display_name}:\n{error_message}"
+            )
+            self._reset_output_state()
+            return
+
+        try:
+            self.load_database(path)
+        except Exception as exc:
+            self.clear_database()
+            self._set_database_path_border("red")
+            self._display_sample_database_setup_error(
+                f"Failed to load {self._display_name}:\n{exc}"
+            )
+            self._reset_output_state()
+            return
+
+        self._reset_output_state()
+        if not self.suppress_dialogs_for_testing:
+            self.show_sample_database_setup_info()
+
+    def _disconnect_process_signals(self, process) -> None:
+        for signal, slot in (
+            (process.readyReadStandardOutput, self._on_stdout_ready),
+            (process.readyReadStandardError, self._on_stderr_ready),
+            (process.finished, self._on_finished),
+            (process.errorOccurred, self._on_process_error),
+        ):
+            try:
+                signal.disconnect(slot)
+            except Exception:
+                pass
+
+    def _set_controls_enabled(self, enabled: bool) -> None:
+        self.path_line_edit.enabled = enabled
+        for control in self.controls:
+            control.enabled = enabled
+
+    def _set_database_path_border(self, color: str) -> None:
+        line_edit = self.path_line_edit.findChild(qt.QLineEdit)
+        if line_edit is not None:
+            line_edit.setStyleSheet(f"border: 1px solid {color};")
+
+    def _display_sample_database_setup_error(self, message: str) -> None:
+        if not self.suppress_dialogs_for_testing:
+            slicer.util.errorDisplay(message)
+
+    def _display_sample_database_setup_warning(self, message: str) -> None:
+        if not self.suppress_dialogs_for_testing:
+            slicer.util.warningDisplay(message)
+
+    def _reset_output_state(self) -> None:
+        self._stdout_buffer = ""
+        self._stderr_buffer = ""
+        self._diagnostics = []
+        self._child_succeeded = False
+        self._child_error = ""
+        self._process_error = ""
+        self._was_canceled = False
+
+    @staticmethod
+    def open_external_url(url: str) -> bool:
+        return qt.QDesktopServices.openUrl(qt.QUrl(url))
+
+    def show_sample_database_setup_info(self) -> None:
+        title = "Starter Database Ready" if self._display_name == "starter database" else "Sample Database Ready"
+
+        message_box = qt.QMessageBox(self.parent)
+        message_box.setIcon(qt.QMessageBox.Information)
+        message_box.setWindowTitle(title)
+        message_box.setText(f"The OpenLIFU {self._display_name} has been created and connected.")
+        if get_guided_mode_state():
+            message_box.setInformativeText(
+                "To get started, sign in with username <b>example_admin</b> and password <b>example</b>."
+                "<br><br>"
+                "More details are available in the database README."
+            )
+            message_box.setTextFormat(qt.Qt.RichText)
+            message_box.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
+        readme_button = message_box.addButton("Open README", qt.QMessageBox.ActionRole)
+        message_box.addButton(qt.QMessageBox.Ok)
+        message_box.exec_()
+        if message_box.clickedButton() == readme_button:
+            if not self.open_external_url(self._readme_url):
+                slicer.util.errorDisplay(f"Failed to open README URL:\n{self._readme_url}")


### PR DESCRIPTION
Closes #543 

- We use the [openlifu-sample-database](https://github.com/OpenwaterHealth/openlifu-sample-database) repo with its git LFS tracked data to download sample data.
- A **sample database** is obtained from an openlifu-sample-database tag which is hardcoded in sample_data.py: it should always be set to be a tag that consists of data that is compatible with the version of openlifu-python that SlicerOpenLIFU uses.
- A **starter** database is another hard-coded tag, which we should create as a version of the sample database tag that has all the subjects stripped out.

<img width="606" height="133" alt="image" src="https://github.com/user-attachments/assets/e5aeebac-2a60-4884-9be9-7dd1861ff435" />

### For review

Try it out: In the database module, put in a writable path where there isn't already a database. Try connecting and then try "Use Sample Data". It is a large download.

Try again with "Create Starter datatabase". It is a medium sized download.