### PR TITLE
Replace lazy imports with enter-time dependency checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,7 @@ UI is defined in `Resources/UI/<ModuleName>.ui` (Qt Designer XML) and loaded in 
 
 ### OpenLIFULib Key Patterns
 
-**Lazy importing** (`lazyimport.py`): The `openlifu` library and its dependencies are heavy and may not be installed yet. All imports go through lazy-import functions:
-- `openlifu_lz()` — returns the `openlifu` module, installing it first if needed
-- `xarray_lz()`, `bcrypt_lz()`, `threadpoolctl_lz()` — same pattern
-- For IDE type-checking, real imports are guarded under `if TYPE_CHECKING:`
+**Dependency checks** (`dependency_utils.py`): The `openlifu` library and its dependencies are required by the extension but may not be installed yet. Each Slicer module checks/install-prompts from `enter()` via `ensure_python_requirements_for_module_enter()`. Runtime code should use normal local imports such as `import openlifu.plan`, `import xarray`, or `import bcrypt` in the function/method where the dependency is used. Do not add new `_lz()` lazy import helpers. For IDE type-checking, imports may still be guarded under `if TYPE_CHECKING:`.
 
 **Parameter node wrappers** (`parameter_node_utils.py`): Thin wrapper classes (`SlicerOpenLIFUProtocol`, `SlicerOpenLIFUTransducer`, `SlicerOpenLIFUSession`, etc.) exist solely to enable Slicer's `@parameterNodeWrapper` serialization of `openlifu` types without importing `openlifu` at module load time. Each wrapper has a corresponding `@parameterNodeSerializer` class that serializes to/from JSON via the wrapped object's `to_json()`/`from_json()` methods.
 
@@ -157,7 +154,7 @@ Individual module tests create state needed by subsequent tests — they are not
 ## Development Gotchas
 
 ### Adding new pip dependencies
-Adding a package to `python-requirements.txt` is not enough. You must also add an `import` check for it in `python_requirements_exist()` in `lazyimport.py`. Otherwise, users who already have the other deps installed will never trigger a reinstall, and the new package won't be found. Follow the existing `bcrypt`/`threadpoolctl` pattern.
+Adding a package to `python-requirements.txt` is not enough. You must also add an `import` or `find_spec` check for it in `python_requirements_exist()` in `dependency_utils.py`. Otherwise, users who already have the other deps installed will never trigger a reinstall, and the new package won't be found. Follow the existing `bcrypt`/`threadpoolctl` pattern.
 
 ### Updating the pinned openlifu version
 When updating the pinned `openlifu` version in `OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt`, consider whether the sample database tags in `OpenLIFULib/OpenLIFULib/sample_data.py` need to be updated. Remind about this.

--- a/OpenLIFUCloudSync/OpenLIFUCloudSync.py
+++ b/OpenLIFUCloudSync/OpenLIFUCloudSync.py
@@ -2,10 +2,10 @@ import qt
 import slicer
 import time
 import os
-import requests
 import signal
 import logging
 from pathlib import Path
+from OpenLIFULib import ensure_python_requirements_for_module_enter
 from OpenLIFULib.util import display_errors
 from slicer.ScriptedLoadableModule import *
 from slicer.i18n import tr as _
@@ -66,6 +66,10 @@ class OpenLIFUCloudSyncWidget(ScriptedLoadableModuleWidget):
         self.logic.statusHelper.statusChanged.connect(
             self.onCloudStatusChanged)
 
+        self.updateGUI()
+
+    def enter(self):
+        ensure_python_requirements_for_module_enter()
         self.updateGUI()
 
     def onCloudStatusChanged(self, message, timestamp):
@@ -239,6 +243,8 @@ class OpenLIFUCloudSyncLogic(ScriptedLoadableModuleLogic):
         return self._cloudTokens.get("idToken") if self._cloudTokens else None
 
     def refreshCloudToken(self):
+        import requests
+
         url = f"https://securetoken.googleapis.com/v1/token?key={self.apiKey}"
         try:
             r = requests.post(url, data={
@@ -257,6 +263,8 @@ class OpenLIFUCloudSyncLogic(ScriptedLoadableModuleLogic):
 
     def login(self, email, password):
         """Authenticates user and saves refresh token."""
+        import requests
+
         url = f"https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key={self.apiKey}"
         try:
             r = requests.post(url, json={

--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -32,9 +32,9 @@ from OpenLIFULib import (
     SlicerOpenLIFUSolution,
     SlicerOpenLIFUTransducer,
     assign_openlifu_metadata_to_volume_node,
+    ensure_python_requirements_for_module_enter,
     get_cur_db,
     get_target_candidates,
-    openlifu_lz,
 )
 from OpenLIFULib.events import SlicerOpenLIFUEvents
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
@@ -58,8 +58,6 @@ from OpenLIFULib.virtual_fit_results import (
     clear_virtual_fit_results,
 )
 
-# These imports are deferred at runtime using openlifu_lz, 
-# but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
     import openlifu.nav.photoscan
@@ -1491,6 +1489,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
         self.updateWorkflowControls()
@@ -1736,7 +1735,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
         session_openlifu = self.update_underlying_openlifu_session()
 
-        OnConflictOpts : "openlifu.db.database.OnConflictOpts" = openlifu_lz().db.database.OnConflictOpts
+        import openlifu.db.database
+
+        OnConflictOpts : "openlifu.db.database.OnConflictOpts" = openlifu.db.database.OnConflictOpts
         get_cur_db().write_session(self.subject,session_openlifu,on_conflict=OnConflictOpts.OVERWRITE)
 
         # Write any affiliated photoscan objects
@@ -2123,7 +2124,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
 
     def load_protocol_from_file(self, filepath:str) -> None:
-        protocol = openlifu_lz().plan.Protocol.from_file(filepath)
+        import openlifu.plan
+
+        protocol = openlifu.plan.Protocol.from_file(filepath)
         self.load_protocol_from_openlifu(protocol)
 
     def load_protocol_from_openlifu(self, protocol:"openlifu.plan.Protocol", replace_confirmed: bool = False) -> None:
@@ -2175,7 +2178,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         protocolConfigLogic.delete_protocol_from_cache(protocol_id)
 
     def load_transducer_from_file(self, filepath:str) -> None:
-        transducer = openlifu_lz().xdc.util.load_transducer_from_file(filepath, convert_array=True)
+        import openlifu.xdc.util
+
+        transducer = openlifu.xdc.util.load_transducer_from_file(filepath, convert_array=True)
         transducer_parent_dir = Path(filepath).parent
 
         transducer_abspaths_info = {
@@ -2399,7 +2404,10 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             subject_id: id of subject to be added (str)
         """
 
-        newOpenLIFUSubject = openlifu_lz().db.subject.Subject(
+        import openlifu.db.database
+        import openlifu.db.subject
+
+        newOpenLIFUSubject = openlifu.db.subject.Subject(
             name = subject_name,
             id = subject_id,
         )
@@ -2413,7 +2421,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             ):
                 return
 
-        get_cur_db().write_subject(newOpenLIFUSubject, on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        get_cur_db().write_subject(newOpenLIFUSubject, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
 
     def get_virtual_fit_approvals_in_session(self) -> List[str]:
         """Get the virtual fit approval state in the current session object, a list of target IDs for which virtual fit
@@ -2510,7 +2518,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
 
         # If the user selects a json file,use the photoscan_metadata included in the json file to load the photoscan. 
         elif Path(model_or_json_filepath).suffix == '.json':
-            photoscan_openlifu = openlifu_lz().nav.photoscan.Photoscan.from_file(model_or_json_filepath)
+            import openlifu.nav.photoscan
+
+            photoscan_openlifu = openlifu.nav.photoscan.Photoscan.from_file(model_or_json_filepath)
             return self.load_photoscan_from_openlifu(photoscan_openlifu, parent_dir = str(Path(model_or_json_filepath).parent))
         else:
             slicer.util.errorDisplay("Invalid photoscan filetype specified")
@@ -2552,7 +2562,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
                 loaded_session = self.getParameterNode().loaded_session
                 _, (model_data, texture_data) = get_cur_db().load_photoscan(loaded_session.get_subject_id(),loaded_session.get_session_id(),photoscan_openlifu.id, load_data = True)
             else:
-                model_data, texture_data = openlifu_lz().nav.photoscan.load_data_from_photoscan(photoscan_openlifu,parent_dir = parent_dir)
+                import openlifu.nav.photoscan
+
+                model_data, texture_data = openlifu.nav.photoscan.load_data_from_photoscan(photoscan_openlifu,parent_dir = parent_dir)
 
         newly_loaded_photoscan = SlicerOpenLIFUPhotoscan.initialize_from_openlifu_photoscan(
             photoscan_openlifu,
@@ -2639,7 +2651,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             ):
                 return
 
-        get_cur_db().write_volume(subject_id, volume_id, volume_name, volume_filepath, on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        import openlifu.db.database
+
+        get_cur_db().write_volume(subject_id, volume_id, volume_name, volume_filepath, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
 
     def add_session_to_database(self, subject_id: str, session_parameters: Dict) -> bool:
         """ Add new session to selected subject in the loaded openlifu database
@@ -2661,7 +2675,10 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             ):
                     return False
 
-        newOpenLIFUSession = openlifu_lz().db.session.Session(
+        import openlifu.db.database
+        import openlifu.db.session
+
+        newOpenLIFUSession = openlifu.db.session.Session(
             name = session_parameters['name'],
             id = session_parameters['id'],
             subject_id = subject_id,
@@ -2669,7 +2686,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             volume_id = session_parameters['volume_id'],
             transducer_id = session_parameters['transducer_id']
         )
-        get_cur_db().write_session(self.get_subject(subject_id), newOpenLIFUSession, on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        get_cur_db().write_session(self.get_subject(subject_id), newOpenLIFUSession, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
         return True
 
     def add_photocollection_to_database(self, subject_id: str, session_id: str, photocollection_parameters: Dict) -> bool:
@@ -2702,9 +2719,11 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         if photo_abspaths is None:
             raise ValueError("Missing required parameter: 'photo_paths'")
 
+        import openlifu.db.database
+
         get_cur_db().write_photocollection(subject_id, session_id, scan_id,
                                       photo_abspaths, on_conflict =
-                                      openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+                                      openlifu.db.database.OnConflictOpts.OVERWRITE)
         return True
 
     def add_photoscan_to_database(self, subject_id: str, session_id: str, photoscan_parameters: Dict) -> "openlifu.nav.photoscan.Photoscan":
@@ -2726,12 +2745,15 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         texture_abspath = photoscan_parameters.pop("texture_abspath")
         mtl_abspath = photoscan_parameters.pop("mtl_abspath")
 
-        newOpenLIFUPhotoscan = openlifu_lz().nav.photoscan.Photoscan().from_dict(photoscan_parameters)
+        import openlifu.db.database
+        import openlifu.nav.photoscan
+
+        newOpenLIFUPhotoscan = openlifu.nav.photoscan.Photoscan().from_dict(photoscan_parameters)
         get_cur_db().write_photoscan(subject_id, session_id, newOpenLIFUPhotoscan,
                                 model_abspath,
                                 texture_abspath,
                                 mtl_abspath,
-                                on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+                                on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
     
         return newOpenLIFUPhotoscan
 
@@ -2752,7 +2774,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
             if session.last_generated_solution_id == solution.solution.solution.id:
                 if get_cur_db() is None: # This shouldn't happen
                     raise RuntimeError("Cannot toggle solution approval because there is a session but no database connection to write the approval.")
-                OnConflictOpts : "openlifu.db.database.OnConflictOpts" = openlifu_lz().db.database.OnConflictOpts
+                import openlifu.db.database
+
+                OnConflictOpts : "openlifu.db.database.OnConflictOpts" = openlifu.db.database.OnConflictOpts
                 get_cur_db().write_solution(session.session.session, solution.solution.solution, on_conflict=OnConflictOpts.OVERWRITE)
             else:
                 # This can happen if, for example, a solution is generated from a session and then a new session is loaded and the user

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 import time
 import zipfile
-import requests
 from pathlib import Path
 from typing import Optional, List, Callable, TYPE_CHECKING
 
@@ -26,7 +25,7 @@ from slicer.util import VTKObservationMixin
 # OpenLIFULib imports
 from OpenLIFULib import sample_data
 from OpenLIFULib import sample_data_gui
-from OpenLIFULib import openlifu_lz
+from OpenLIFULib import ensure_python_requirements_for_module_enter
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 from OpenLIFULib.sample_data_gui import (
     InitializationResult,
@@ -38,8 +37,6 @@ from OpenLIFULib.util import (
     add_slicer_log_handler_for_openlifu_object,
 )
 
-# These imports are deferred at runtime using openlifu_lz, 
-# but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
     import openlifu.db
@@ -161,6 +158,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
         self.updateAll()
@@ -380,7 +378,9 @@ class OpenLIFUDatabaseLogic(ScriptedLoadableModuleLogic):
         Args:
             path: Path to the openlifu database folder on disk.
         """
-        self.db = openlifu_lz().db.Database(path)
+        import openlifu.db
+
+        self.db = openlifu.db.Database(path)
         add_slicer_log_handler_for_openlifu_object(self.db)
     
     @staticmethod
@@ -435,6 +435,8 @@ class OpenLIFUDatabaseLogic(ScriptedLoadableModuleLogic):
                 os.chmod(path, 0o644 if path.is_file() else 0o755)
 
     def performSync(self):
+        import requests
+
         x= requests.get(f'https://api.nvpsoftware.com/users/{slicer.util.getModuleLogic("OpenLIFULogin").getUserId()}', headers={'Authorization': f'Bearer {slicer.util.getModuleLogic("OpenLIFULogin").getValidToken()}'})
         print(x.json())
 

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -15,6 +15,10 @@ from slicer.parameterNodeWrapper import parameterNodeWrapper
 from slicer.util import VTKObservationMixin
 
 # OpenLIFULib imports
+from OpenLIFULib import (
+    check_and_install_kwave_binaries,
+    ensure_python_requirements_for_module_enter,
+)
 from OpenLIFULib.util import (
     get_openlifu_login_parameter_node,
 )
@@ -190,6 +194,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
 
@@ -380,10 +385,8 @@ class OpenLIFUHomeTest(ScriptedLoadableModuleTest):
     def runTest(self):
         """Run as few or as many tests as needed here."""
         
-        # If testing is enabled, openlifu_lz installs
-        # openlifu if not installed and installs the kwave assets
-        from OpenLIFULib import openlifu_lz
-        openlifu_lz()
+        ensure_python_requirements_for_module_enter()
+        check_and_install_kwave_binaries()
 
         self.setUp()
         

--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -8,7 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/util.py
   OpenLIFULib/guided_mode_util.py
   OpenLIFULib/user_account_mode_util.py
-  OpenLIFULib/lazyimport.py
+  OpenLIFULib/dependency_utils.py
   OpenLIFULib/parameter_node_utils.py
   OpenLIFULib/session.py
   OpenLIFULib/transducer.py

--- a/OpenLIFULib/OpenLIFULib/__init__.py
+++ b/OpenLIFULib/OpenLIFULib/__init__.py
@@ -1,12 +1,7 @@
-from OpenLIFULib.lazyimport import (
-    openlifu_lz,
-    openlifu_sdk_lz,
-    xarray_lz,
-    bcrypt_lz,
-    threadpoolctl_lz,
-    segno_lz,
+from OpenLIFULib.dependency_utils import (
     check_and_install_kwave_binaries,
     check_and_install_python_requirements,
+    ensure_python_requirements_for_module_enter,
     install_python_requirements,
     python_requirements_exist,
     get_required_openlifu_version,
@@ -43,12 +38,6 @@ from OpenLIFULib.simulation import (
 from OpenLIFULib.solution import SlicerOpenLIFUSolution
 
 __all__ = [
-    "openlifu_lz",
-    "openlifu_sdk_lz",
-    "xarray_lz",
-    "bcrypt_lz",
-    "threadpoolctl_lz",
-    "segno_lz",
     "SlicerOpenLIFUSolution",
     "SlicerOpenLIFUProtocol",
     "SlicerOpenLIFUTransducer",
@@ -72,6 +61,7 @@ __all__ = [
     "assign_openlifu_metadata_to_volume_node",
     "check_and_install_kwave_binaries",
     "check_and_install_python_requirements",
+    "ensure_python_requirements_for_module_enter",
     "install_python_requirements",
     "python_requirements_exist",
     "get_required_openlifu_version",

--- a/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
+++ b/OpenLIFULib/OpenLIFULib/coordinate_system_utils.py
@@ -4,7 +4,6 @@ from numpy.typing import NDArray
 import vtk
 import slicer
 from slicer import vtkMRMLScalarVolumeNode
-from OpenLIFULib.lazyimport import openlifu_lz
 
 def numpy_to_vtk_4x4(numpy_array_4x4 : NDArray[Any]) -> vtk.vtkMatrix4x4:
             if numpy_array_4x4.shape != (4, 4):
@@ -30,7 +29,8 @@ def get_xxx2ras_matrix(dims:Sequence[str]) -> NDArray[Any]:
     ]).transpose()
 
 def get_xx2mm_scale_factor(length_unit:str) -> float:
-    openlifu = openlifu_lz()
+    import openlifu.util.units
+
     return openlifu.util.units.getsiscale(length_unit, 'distance') / openlifu.util.units.getsiscale('mm', 'distance')
 
 def linear_to_affine(matrix, translation=None):

--- a/OpenLIFULib/OpenLIFULib/dependency_utils.py
+++ b/OpenLIFULib/OpenLIFULib/dependency_utils.py
@@ -5,6 +5,7 @@ from OpenLIFULib.install_asset_dialog import InstallAssetDialog
 import slicer
 import importlib
 import qt
+import re
 from OpenLIFULib.util import BusyCursor
 
 _openlifu_version_mismatch_warning_shown = False
@@ -111,11 +112,12 @@ def get_required_openlifu_version() -> "Optional[str]":
     python-requirements.txt, or None."""
     requirements_path = Path(__file__).parent / 'Resources/python-requirements.txt'
     for line in requirements_path.read_text().splitlines():
-        line = line.strip()
-        if line.startswith('#'):
+        line = line.split('#', 1)[0].strip()
+        if not line:
             continue
-        if line.startswith('openlifu=='):
-            return line.split('==', 1)[1].strip()
+        openlifu_pin = re.match(r'^openlifu(?:\[[^\]]+\])?\s*==\s*(\S+)$', line)
+        if openlifu_pin:
+            return openlifu_pin.group(1).strip()
         if 'OpenLIFU-python.git@' in line:
             commit_hash = line.split('@')[-1].strip()
             return f"dev+g{commit_hash[:9]}"

--- a/OpenLIFULib/OpenLIFULib/dependency_utils.py
+++ b/OpenLIFULib/OpenLIFULib/dependency_utils.py
@@ -1,16 +1,13 @@
-"""Tools for lazy installing and lazy importing of the extension's python requirements"""
+"""Tools for checking and installing the extension's Python requirements."""
 
-from typing import TYPE_CHECKING
 from pathlib import Path
 from OpenLIFULib.install_asset_dialog import InstallAssetDialog
 import slicer
 import importlib
-import sys
 import qt
 from OpenLIFULib.util import BusyCursor
-if TYPE_CHECKING:
-    import openlifu # This import is deferred at runtime, but it is done here for IDE and static analysis purposes
-    import xarray
+
+_openlifu_version_mismatch_warning_shown = False
 
 def install_python_requirements() -> None:
     """Install python requirements"""
@@ -21,12 +18,18 @@ def install_python_requirements() -> None:
 def python_requirements_exist() -> bool:
     """Check and return whether python requirements are installed."""
     try:
-        import threadpoolctl
-        import bcrypt
-        import segno
+        import bcrypt  # noqa: F401
+        import requests  # noqa: F401
+        import segno  # noqa: F401
+        import threadpoolctl  # noqa: F401
+        import xarray  # noqa: F401
     except ModuleNotFoundError:
         return False
-    return importlib.util.find_spec('openlifu') is not None # openlifu import causes a delay so we check for it without actually importing yet
+    # These imports can cause a delay, so check for them without importing.
+    return (
+        importlib.util.find_spec('openlifu') is not None
+        and importlib.util.find_spec('openlifu_sdk') is not None
+    )
 
 def check_and_install_python_requirements(prompt_if_found = False) -> None:
     """Check whether python requirements are installed and at the required version, and prompt to install/update if not.
@@ -63,6 +66,45 @@ def check_and_install_python_requirements(prompt_if_found = False) -> None:
                 text="OpenLIFU python dependencies are still not found. The install may have failed.",
                 windowTitle="Python dependencies still not found"
             )
+
+def ensure_python_requirements_for_module_enter() -> bool:
+    """Check/install Python requirements when a module is entered.
+
+    Returns True when requirements are available after the check. In testing mode,
+    missing requirements are installed automatically. In interactive mode, users are
+    prompted to install missing requirements. Version mismatches are only warned
+    about once per application session.
+    """
+    global _openlifu_version_mismatch_warning_shown
+
+    if slicer.app.testingEnabled():
+        if not python_requirements_exist():
+            install_python_requirements()
+        return python_requirements_exist()
+
+    check_and_install_python_requirements(prompt_if_found=False)
+    requirements_exist = python_requirements_exist()
+    if not requirements_exist:
+        return False
+
+    if not openlifu_version_matches() and not _openlifu_version_mismatch_warning_shown:
+        required = get_required_openlifu_version() or "unknown"
+        try:
+            import importlib.metadata
+            installed = importlib.metadata.version('openlifu')
+        except importlib.metadata.PackageNotFoundError:
+            installed = "unknown"
+        slicer.util.warningDisplay(
+            text=(
+                f"The installed openlifu version ({installed}) does not match "
+                f"the required version ({required}). Use the Login module's "
+                "Python requirements button to update it."
+            ),
+            windowTitle="OpenLIFU version mismatch",
+        )
+        _openlifu_version_mismatch_warning_shown = True
+
+    return True
 
 def get_required_openlifu_version() -> "Optional[str]":
     """Return the required openlifu version pinned in
@@ -106,6 +148,12 @@ def check_and_install_kwave_binaries() -> bool:
     Returns whether they were successfully installed (or just already present).
     This assumes that openlifu can be imported already, so do not call this function until after that is assured.
     """
+    import openlifu.util.assets
+
+    if slicer.app.testingEnabled():
+        openlifu.util.assets.download_and_install_kwave_assets()
+        return True
+
     from openlifu.util.assets import get_kwave_paths
     kwave_paths = get_kwave_paths()
     if all(p.exists() for p,_ in kwave_paths):
@@ -131,73 +179,3 @@ def check_and_install_kwave_binaries() -> bool:
             else:
                 raise RuntimeError("Unrecognized dialog action") # should never happen
     return all(p.exists() for p,_ in kwave_paths)
-
-def openlifu_lz() -> "openlifu":
-    """Import openlifu and return the module, checking that it is installed along the way."""
-    if "openlifu" not in sys.modules:
-        # In testing mode, automatically install missing requirements without prompting
-        if slicer.app.testingEnabled():
-            if not python_requirements_exist():
-                install_python_requirements()
-        else:
-            check_and_install_python_requirements(prompt_if_found=False)
-
-        with BusyCursor():
-            import openlifu
-            import openlifu_sdk
-            import openlifu.bf
-            import openlifu.db
-            import openlifu.geo
-            import openlifu.nav.photoscan
-            import openlifu.plan
-            import openlifu.seg.seg_methods
-            import openlifu.seg.skinseg
-            import openlifu.sim
-            import openlifu.util.assets
-            import openlifu.xdc
-            import openlifu.xdc.util
-
-        if slicer.app.testingEnabled():
-            # Ensure kwave assets are present (no-op if already installed)
-            from openlifu.util.assets import download_and_install_kwave_assets
-            download_and_install_kwave_assets()
-        elif not check_and_install_kwave_binaries():
-            raise RuntimeError("The openlifu library requires kwave binaries to be installed. There may be issues trying to run simulations.")
-
-    return sys.modules["openlifu"]
-
-def xarray_lz() -> "xarray":
-    """Import xarray and return the module, checking that openlifu is installed along the way."""
-    if "openlifu" not in sys.modules:
-        check_and_install_python_requirements(prompt_if_found=False)
-        import xarray
-    return sys.modules["xarray"]
-
-def bcrypt_lz() -> "bcrypt":
-    """Import bcrypt and return the module, checking that it is installed along the way."""
-    if "bcrypt" not in sys.modules:
-        check_and_install_python_requirements(prompt_if_found=False)
-        with BusyCursor():
-            import bcrypt
-    return sys.modules["bcrypt"]
-
-def threadpoolctl_lz() -> "threadpoolctl":
-    """Import threadpoolctl and return the module, checking that it is installed along the way."""
-    if "threadpoolctl" not in sys.modules:
-        check_and_install_python_requirements(prompt_if_found=False)
-        import threadpoolctl
-    return sys.modules["threadpoolctl"]
-
-def segno_lz() -> "segno":
-    """Import segno and return the module, checking that it is installed along the way."""
-    if "segno" not in sys.modules:
-        check_and_install_python_requirements(prompt_if_found=False)
-        import segno
-    return sys.modules["segno"]
-
-def openlifu_sdk_lz() -> "openlifu_sdk":
-    """Import openlifu_sdk and return the module. openlifu_sdk is installed as a dependency
-    of openlifu, so openlifu_lz() must be called first to ensure it is available."""
-    if "openlifu_sdk" not in sys.modules:
-        openlifu_lz()
-    return sys.modules["openlifu_sdk"]

--- a/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
+++ b/OpenLIFULib/OpenLIFULib/parameter_node_utils.py
@@ -13,10 +13,9 @@ from slicer.parameterNodeWrapper.serializers import createSerializerFromAnnotate
 import zlib
 import io
 import base64
-from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz
 
 if TYPE_CHECKING:
-    import openlifu # This import is deferred at runtime, but it is done here for IDE and static analysis purposes
+    import openlifu
     import openlifu.db
     import openlifu.geo
     import openlifu.plan
@@ -25,8 +24,8 @@ if TYPE_CHECKING:
     import xarray
 
 
-# This very thin wrapper around openlifu.plan.Protocol is needed to do our lazy importing of openlifu
-# while still providing type annotations that the parameter node wrapper can use.
+# This very thin wrapper around openlifu.plan.Protocol is needed so parameter node
+# wrappers can keep type annotations without importing openlifu at module load time.
 # If we tried to make openlifu.plan.Protocol directly supported as a type by parameter nodes, we would
 # get errors from parameterNodeWrapper as it tries to use typing.get_type_hints. This fails because
 # get_type_hints tries to *evaluate* the type annotations like "openlifu.plan.Protocol" possibly before
@@ -174,8 +173,10 @@ class OpenLIFUProtocolSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIF
         """
         Reads and returns the value with the given name from the parameterNode.
         """
+        import openlifu.plan
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUProtocol(openlifu_lz().plan.Protocol.from_json(json_string))
+        return SlicerOpenLIFUProtocol(openlifu.plan.Protocol.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUTransducerSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUTransducerWrapper)):
@@ -192,8 +193,10 @@ class OpenLIFUTransducerSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenL
         """
         Reads and returns the value with the given name from the parameterNode.
         """
+        import openlifu.xdc
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUTransducerWrapper(openlifu_lz().xdc.Transducer.from_json(json_string))
+        return SlicerOpenLIFUTransducerWrapper(openlifu.xdc.Transducer.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUSessionSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUSessionWrapper)):
@@ -204,8 +207,10 @@ class OpenLIFUSessionSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFU
         )
 
     def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUSessionWrapper:
+        import openlifu.db
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUSessionWrapper(openlifu_lz().db.Session.from_json(json_string))
+        return SlicerOpenLIFUSessionWrapper(openlifu.db.Session.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUSolutionSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUSolutionWrapper)):
@@ -216,8 +221,10 @@ class OpenLIFUSolutionSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIF
         )
 
     def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUSolutionWrapper:
+        import openlifu.plan
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUSolutionWrapper(openlifu_lz().plan.Solution.from_json(json_string))
+        return SlicerOpenLIFUSolutionWrapper(openlifu.plan.Solution.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUPointSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUPoint)):
@@ -234,8 +241,10 @@ class OpenLIFUPointSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUPo
         """
         Reads and returns the value with the given name from the parameterNode.
         """
+        import openlifu.geo
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUPoint(openlifu_lz().geo.Point.from_json(json_string))
+        return SlicerOpenLIFUPoint(openlifu.geo.Point.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFURunSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFURun)):
@@ -246,8 +255,10 @@ class OpenLIFURunSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFURun)
         )
 
     def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFURun:
+        import openlifu.plan
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFURun(openlifu_lz().plan.Run.from_json(json_string))
+        return SlicerOpenLIFURun(openlifu.plan.Run.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUSolutionAnalysisSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUSolutionAnalysis)):
@@ -258,8 +269,10 @@ class OpenLIFUSolutionAnalysisSerializer(SlicerOpenLIFUSerializerBaseMaker(Slice
         )
 
     def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> SlicerOpenLIFUSolutionAnalysis:
+        import openlifu.plan
+
         json_string = parameterNode.GetParameter(name)
-        return SlicerOpenLIFUSolutionAnalysis(openlifu_lz().plan.SolutionAnalysis.from_json(json_string))
+        return SlicerOpenLIFUSolutionAnalysis(openlifu.plan.SolutionAnalysis.from_json(json_string))
 
 @parameterNodeSerializer
 class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUPhotoscanWrapper)):
@@ -276,8 +289,10 @@ class OpenLIFUPhotoscanSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLI
         """
         Reads and returns the value with the given name from the parameterNode.
         """
+        import openlifu.nav.photoscan
+
         json_string = parameterNode.GetParameter(name)    
-        return SlicerOpenLIFUPhotoscanWrapper(openlifu_lz().nav.photoscan.Photoscan.from_json(json_string))
+        return SlicerOpenLIFUPhotoscanWrapper(openlifu.nav.photoscan.Photoscan.from_json(json_string))
 
 @parameterNodeSerializer
 class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXADataset)):
@@ -296,8 +311,10 @@ class XarraydatasetSerializer(SlicerOpenLIFUSerializerBaseMaker(SlicerOpenLIFUXA
         """
         Reads and returns the value with the given name from the parameterNode.
         """
+        import xarray
+
         ds_serialized = parameterNode.GetParameter(name)
-        ds_deserialized = xarray_lz().open_dataset(base64.b64decode(ds_serialized.encode('utf-8')))
+        ds_deserialized = xarray.open_dataset(base64.b64decode(ds_serialized.encode('utf-8')))
         return SlicerOpenLIFUXADataset(ds_deserialized)
 
 @parameterNodeSerializer

--- a/OpenLIFULib/OpenLIFULib/photoscan.py
+++ b/OpenLIFULib/OpenLIFULib/photoscan.py
@@ -13,12 +13,9 @@ from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUPhotoscanWrapper,
 )
 from OpenLIFULib.util import BusyCursor
-from OpenLIFULib import (
-    openlifu_lz,
-)
 
 if TYPE_CHECKING:
-    import openlifu # This import is deferred at runtime using openlifu_lz, but it is done here for IDE and static analysis purposes
+    import openlifu
     import openlifu.nav.photoscan
 
 @parameterPack
@@ -85,17 +82,19 @@ class SlicerOpenLIFUPhotoscan:
             texture_abspath: Optional absolute path to the texture data file
         Returns: the newly constructed SlicerOpenLIFUPhotoscan object
         """
+        import openlifu.nav.photoscan
 
         with BusyCursor():
-            model_data, texture_data = openlifu_lz().nav.photoscan.load_data_from_filepaths(model_abspath, texture_abspath)
+            model_data, texture_data = openlifu.nav.photoscan.load_data_from_filepaths(model_abspath, texture_abspath)
 
         node_name_prefix = Path(model_abspath).stem
         model_node, texture_node = SlicerOpenLIFUPhotoscan._create_nodes(model_data, texture_data, node_name_prefix)
 
         # Create a dummy photoscan to keep track of metadata to apply to the openlifu object. This photoscan is not associated with the database
-        photoscan_openlifu = openlifu_lz().nav.photoscan.Photoscan(id = model_node.GetID(), 
-                                                                  name = node_name_prefix,
-                                                                  )
+        photoscan_openlifu = openlifu.nav.photoscan.Photoscan(
+            id=model_node.GetID(),
+            name=node_name_prefix,
+        )
         photoscan = SlicerOpenLIFUPhotoscan(SlicerOpenLIFUPhotoscanWrapper(photoscan_openlifu), model_node,texture_node)
         photoscan.set_model_display_settings()
         return photoscan

--- a/OpenLIFULib/OpenLIFULib/session.py
+++ b/OpenLIFULib/OpenLIFULib/session.py
@@ -9,7 +9,6 @@ from slicer import (
 from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.util import get_openlifu_data_parameter_node, BusyCursor
 from OpenLIFULib.volume_thresholding import load_volume_and_threshold_background
-from OpenLIFULib.lazyimport import openlifu_lz
 from OpenLIFULib.parameter_node_utils import SlicerOpenLIFUSessionWrapper, SlicerOpenLIFUPhotoscanWrapper
 from OpenLIFULib.targets import (
     openlifu_point_to_fiducial,

--- a/OpenLIFULib/OpenLIFULib/simulation.py
+++ b/OpenLIFULib/OpenLIFULib/simulation.py
@@ -6,7 +6,6 @@ from vtk.util import numpy_support
 import slicer
 from slicer import vtkMRMLScalarVolumeNode
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
-from OpenLIFULib.lazyimport import xarray_lz
 
 if TYPE_CHECKING:
     import openlifu
@@ -48,6 +47,8 @@ def make_xarray_in_transducer_coords_from_volume(volume_node:vtkMRMLScalarVolume
     """Convert a volume node into a DataArray in the coordinates of a given transducer.
     See also `make_volume_from_xarray_in_transducer_coords`.
     """
+    import xarray
+
     coords = protocol.sim_setup.get_coords()
     origin = np.array([coord_array[0].item() for coord_array in coords.values()])
     spacing = np.array([np.diff(coord_array)[0].item() for coord_array in coords.values()])
@@ -70,7 +71,7 @@ def make_xarray_in_transducer_coords_from_volume(volume_node:vtkMRMLScalarVolume
         mode = 'nearest', # method of sampling beyond input array boundary
         output_shape = coords_shape,
     )
-    volume_resampled_dataarray = xarray_lz().DataArray(
+    volume_resampled_dataarray = xarray.DataArray(
         volume_resampled_array,
         coords=coords,
         name=volume_node.GetName(),

--- a/OpenLIFULib/OpenLIFULib/skinseg.py
+++ b/OpenLIFULib/OpenLIFULib/skinseg.py
@@ -1,6 +1,5 @@
 """Skin segmentation tools"""
 
-from OpenLIFULib.lazyimport import openlifu_lz
 from slicer import vtkMRMLScalarVolumeNode, vtkMRMLModelNode
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.transducer import TRANSDUCER_MODEL_COLORS
@@ -16,16 +15,18 @@ def generate_skin_segmentation(volume_node:vtkMRMLScalarVolumeNode, foreground_m
     If the foreground_mask_array is provided, then it is assumed to be in correspondence with (so in the same index order as)
     the array you would get by applying `slicer.util.arrayFromVolume` to `volume_node`.
     """
+    import openlifu.seg.skinseg
+
     volume_array = slicer.util.arrayFromVolume(volume_node).transpose((2,1,0)) # the array indices come in KJI rather than IJK so we permute them
     volume_affine_RAS = get_IJK2RAS(volume_node)
 
     if foreground_mask_array is None:
-        foreground_mask_array = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+        foreground_mask_array = openlifu.seg.skinseg.compute_foreground_mask(volume_array)
     else:
         # if foreground_mask_array was provided, we assume the same index permutation as above is needed:
         foreground_mask_array = foreground_mask_array.transpose((2,1,0))
-    foreground_mask_vtk_image = openlifu_lz().seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
-    skin_mesh = openlifu_lz().seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
+    foreground_mask_vtk_image = openlifu.seg.skinseg.vtk_img_from_array_and_affine(foreground_mask_array, volume_affine_RAS)
+    skin_mesh = openlifu.seg.skinseg.create_closed_surface_from_labelmap(foreground_mask_vtk_image)
 
     skin_mesh_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
     skin_mesh_node.SetAndObservePolyData(skin_mesh)

--- a/OpenLIFULib/OpenLIFULib/solution.py
+++ b/OpenLIFULib/OpenLIFULib/solution.py
@@ -6,7 +6,6 @@ from slicer.parameterNodeWrapper import parameterPack
 from OpenLIFULib.parameter_node_utils import (
     SlicerOpenLIFUSolutionWrapper,
 )
-from OpenLIFULib.lazyimport import openlifu_lz, xarray_lz
 from OpenLIFULib.simulation import (
     make_volume_from_xarray_in_transducer_coords,
     make_xarray_in_transducer_coords_from_volume,

--- a/OpenLIFULib/OpenLIFULib/targets.py
+++ b/OpenLIFULib/OpenLIFULib/targets.py
@@ -2,7 +2,6 @@ from typing import List, TYPE_CHECKING, Optional
 import numpy as np
 import slicer
 from slicer import vtkMRMLMarkupsFiducialNode
-from OpenLIFULib.lazyimport import openlifu_lz
 from OpenLIFULib.coordinate_system_utils import get_xx2mm_scale_factor, get_xxx2ras_matrix
 
 if TYPE_CHECKING:
@@ -65,10 +64,12 @@ def fiducial_to_openlifu_point_in_transducer_coords(fiducial_node:vtkMRMLMarkups
     """Given a fiducial node with at least one point, return an openlifu Point in the local coordinates of the given transducer.
     If name is provided then it will be used as the name of the openlifu Point. Otherwise we use the label on the control point.
     """
+    import openlifu.geo
+
     if fiducial_node.GetNumberOfControlPoints() < 1:
         raise ValueError(f"Fiducial node {fiducial_node.GetID()} does not have any points.")
     position = (np.linalg.inv(slicer.util.arrayFromTransformMatrix(transducer.transform_node)) @ np.array([*fiducial_node.GetNthControlPointPosition(0),1]))[:3] # TODO handle 4th coord here actually, would need to unprojectivize
-    return openlifu_lz().geo.Point(
+    return openlifu.geo.Point(
         position=position,
         name = name if name is not None else fiducial_node.GetNthControlPointLabel(0),
         id = f"{fiducial_to_openlifu_point_id(fiducial_node)}-in-transducer-coords",
@@ -81,9 +82,11 @@ def fiducial_to_openlifu_point(fiducial_node:vtkMRMLMarkupsFiducialNode) -> "ope
     This tries to be roughly an inverse operation of `openlifu_point_to_fiducial`, but isn't an inverse when it comes to
     for example the coordinates, and units. The opnenlifu point ID is however preserved between this function and
     `openlifu_point_to_fiducial`, because it is used as the node name."""
+    import openlifu.geo
+
     if fiducial_node.GetNumberOfControlPoints() < 1:
         raise ValueError(f"Fiducial node {fiducial_node.GetID()} does not have any points.")
-    return openlifu_lz().geo.Point(
+    return openlifu.geo.Point(
         position = np.array(fiducial_node.GetNthControlPointPosition(0)),
         name = fiducial_node.GetNthControlPointLabel(0),
         id = fiducial_to_openlifu_point_id(fiducial_node),

--- a/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
+++ b/OpenLIFULib/OpenLIFULib/transducer_tracking_results.py
@@ -8,7 +8,6 @@ from OpenLIFULib.transform_conversion import (
     transducer_transform_node_from_openlifu,
     create_openlifu2slicer_matrix
     )
-from OpenLIFULib.lazyimport import openlifu_lz
 import numpy as np
 from OpenLIFULib.coordinate_system_utils import numpy_to_vtk_4x4
 from OpenLIFULib.util import get_cloned_node
@@ -114,6 +113,7 @@ def get_transducer_tracking_results_in_openlifu_session_format(session_id:str, t
 
     See also the reverse function `add_transducer_tracking_results_from_openlifu_session_format`.
     """
+    import openlifu.db.session
     
     photoscan_ids_for_session = get_photoscan_ids_with_results(session_id)
     transducer_tracking_results_openlifu = []
@@ -129,7 +129,7 @@ def get_transducer_tracking_results_in_openlifu_session_format(session_id:str, t
         # Convert photoscan to volume transform to LPS
         transform_array = slicer.util.arrayFromTransformMatrix(photoscan_volume_node, toWorld=True)
         openlifu2slicer_matrix = create_openlifu2slicer_matrix('mm')
-        photoscan_to_volume_transform_openlifu = openlifu_lz().db.session.ArrayTransform(
+        photoscan_to_volume_transform_openlifu = openlifu.db.session.ArrayTransform(
             matrix = np.linalg.inv(openlifu2slicer_matrix) @ transform_array,
             units = 'mm',
         )
@@ -140,7 +140,7 @@ def get_transducer_tracking_results_in_openlifu_session_format(session_id:str, t
 
         photoscan_id = transducer_volume_node.GetAttribute("TT:photoscanID")
         transducer_tracking_results_openlifu.append(
-            openlifu_lz().db.session.TransducerTrackingResult(
+            openlifu.db.session.TransducerTrackingResult(
                     photoscan_id = photoscan_id,
                     transducer_to_volume_transform = transducer_to_volume_transform_openlifu,
                     photoscan_to_volume_transform = photoscan_to_volume_transform_openlifu,

--- a/OpenLIFULib/OpenLIFULib/transform_conversion.py
+++ b/OpenLIFULib/OpenLIFULib/transform_conversion.py
@@ -10,7 +10,6 @@ from OpenLIFULib.coordinate_system_utils import (
     get_xx2mm_scale_factor,
     numpy_to_vtk_4x4,
 )
-from OpenLIFULib.lazyimport import openlifu_lz
 
 if TYPE_CHECKING:
     from openlifu.geo import ArrayTransform
@@ -40,9 +39,11 @@ def transducer_transform_node_to_openlifu(transform_node:vtkMRMLTransformNode, t
 
     See the reverse function `transform_node_from_openlifu`.
     """
+    import openlifu.geo
+
     transform_array = slicer.util.arrayFromTransformMatrix(transform_node, toWorld=True)
     openlifu2slicer_matrix = create_openlifu2slicer_matrix(transducer_units)
-    return openlifu_lz().geo.ArrayTransform(
+    return openlifu.geo.ArrayTransform(
         matrix = np.linalg.inv(openlifu2slicer_matrix) @ transform_array,
         units = transducer_units,
     )

--- a/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
+++ b/OpenLIFULib/OpenLIFULib/user_account_mode_util.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from typing import Optional, TYPE_CHECKING
 
 import qt
@@ -11,11 +12,19 @@ from OpenLIFULib.util import (
 if TYPE_CHECKING:
     import openlifu.db
 
+_restricted_anonymous_user = SimpleNamespace(
+    id="anonymous",
+    password_hash="",
+    roles=[],
+    name="Anonymous",
+    description="Restricted fallback user before OpenLIFU dependencies are available.",
+)
+
 def get_current_user() -> "openlifu.db.User":
     """Get the active openlifu user. If no user is logged in or user account
     mode is off, a default user is returned, with the intention of being the most
     restricted"""
-    return get_openlifu_login_logic().active_user
+    return get_openlifu_login_logic().active_user or _restricted_anonymous_user
 
 def get_user_account_mode_state() -> bool:
     """Get user account mode state from the OpenLIFU Login module's parameter node"""

--- a/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
+++ b/OpenLIFULib/OpenLIFULib/virtual_fit_results.py
@@ -2,7 +2,6 @@ import slicer
 from slicer import vtkMRMLTransformNode
 from typing import Optional, Iterable, List, Tuple, Dict, TYPE_CHECKING, Union
 from OpenLIFULib.transform_conversion import transducer_transform_node_to_openlifu, transducer_transform_node_from_openlifu
-from OpenLIFULib.lazyimport import openlifu_lz
 from OpenLIFULib.util import get_cloned_node
 
 if TYPE_CHECKING:

--- a/OpenLIFULib/OpenLIFULib/volume_thresholding.py
+++ b/OpenLIFULib/OpenLIFULib/volume_thresholding.py
@@ -7,7 +7,6 @@ import vtk
 import slicer
 from slicer import vtkMRMLScalarVolumeNode
 from OpenLIFULib.util import BusyCursor
-from OpenLIFULib.lazyimport import openlifu_lz
 
 def cast_volume_to_float(volume_node:vtkMRMLScalarVolumeNode) -> None:
     """Converts a volume node to float, replacing the underlying vtkImageData."""
@@ -29,6 +28,8 @@ def threshold_volume_by_foreground_mask(volume_node:vtkMRMLScalarVolumeNode) -> 
 
     Returns foreground mask. The array is in correspondence with what you'd get from slicer.util.arrayFromVolume on the volume node.
     """
+    import openlifu.seg.skinseg
+
     volume_array = slicer.util.arrayFromVolume(volume_node)
     volume_array_min = volume_array.min()
 
@@ -37,7 +38,7 @@ def threshold_volume_by_foreground_mask(volume_node:vtkMRMLScalarVolumeNode) -> 
         logging.info("Casting volume to float for the sake of `threshold_volume_by_foreground_mask`.")
         cast_volume_to_float(volume_node)
 
-    foreground_mask = openlifu_lz().seg.skinseg.compute_foreground_mask(volume_array)
+    foreground_mask = openlifu.seg.skinseg.compute_foreground_mask(volume_array)
     slicer.util.arrayFromVolume(volume_node)[~foreground_mask] = background_value
     volume_node.GetDisplayNode().SetThreshold(volume_array_min,volume_array.max())
     volume_node.GetDisplayNode().SetApplyThreshold(1)

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -10,7 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, List, Dict, Callable, TYPE_CHECKING
 import time
-import requests
 
 # Third-party imports
 import qt
@@ -29,12 +28,11 @@ from slicer.util import VTKObservationMixin
 # OpenLIFULib imports
 from OpenLIFULib import (
     BusyCursor,
-    bcrypt_lz,
+    ensure_python_requirements_for_module_enter,
     get_cur_db,
     get_current_user,
     check_and_install_python_requirements,
     get_required_openlifu_version,
-    openlifu_lz,
     openlifu_version_matches,
     python_requirements_exist,
 )
@@ -43,8 +41,6 @@ from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 from OpenLIFULib.user_account_mode_util import UserAccountBanner, set_user_account_mode_state
 from OpenLIFULib.util import display_errors, get_openlifu_data_parameter_node
 
-# These imports are deferred at runtime using openlifu_lz, 
-# but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
     import openlifu.db
@@ -241,14 +237,16 @@ class CreateNewAccountDialog(qt.QDialog):
     def customexec_(self):
         returncode = self.exec_()
         if returncode == qt.QDialog.Accepted:
+            import bcrypt
+
             user_id = self.idField.text
             password_text = self.passwordField.text
             name = self.nameField.text
             description = self.descriptionField.text
             role = self.roleField.currentText
 
-            salt = bcrypt_lz().gensalt()
-            password_hash = bcrypt_lz().hashpw(password_text.encode('utf-8'), salt).decode('utf-8')
+            salt = bcrypt.gensalt()
+            password_hash = bcrypt.hashpw(password_text.encode('utf-8'), salt).decode('utf-8')
 
             user_dict = {
                 "id": user_id,
@@ -341,9 +339,11 @@ class ChangePasswordDialog(qt.QDialog):
     def customexec_(self):
         returncode = self.exec_()
         if returncode == qt.QDialog.Accepted:
+            import bcrypt
+
             password_text = self.createPasswordField.text
-            salt = bcrypt_lz().gensalt()
-            password_hash = bcrypt_lz().hashpw(password_text.encode('utf-8'), salt).decode('utf-8')
+            salt = bcrypt.gensalt()
+            password_hash = bcrypt.hashpw(password_text.encode('utf-8'), salt).decode('utf-8')
 
             user_dict = {
                 "id": self.user.id,
@@ -487,8 +487,10 @@ class ManageAccountsDialog(qt.QDialog):
         self.buttonBox.setStandardButtons(qt.QDialogButtonBox.Ok |
                                           qt.QDialogButtonBox.Cancel)
         def on_accept():
+            import openlifu.db.database
+
             user.roles = roles_widget.to_list()
-            self.db.write_user(user, on_conflict=openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+            self.db.write_user(user, on_conflict=openlifu.db.database.OnConflictOpts.OVERWRITE)
             self.updateUsersList()
             dialog.accept()
 
@@ -553,8 +555,11 @@ class ManageAccountsDialog(qt.QDialog):
         if not returncode or user_dict is None:
             return
 
-        modifiedUser = openlifu_lz().db.User.from_dict(user_dict)
-        self.db.write_user(modifiedUser, on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        import openlifu.db
+        import openlifu.db.database
+
+        modifiedUser = openlifu.db.User.from_dict(user_dict)
+        self.db.write_user(modifiedUser, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
 
         # Update GUI
 
@@ -581,8 +586,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self._user_account_banners : List[UserAccountBanner] = []
         self._parameterNode = None
         self._parameterNodeGuiTag = None
-        self._default_anonymous_user = None  # initialized in setup() 
-        self._default_admin_user = None # initialized in setup()
+        self._default_anonymous_user = None  # initialized after dependency check
+        self._default_admin_user = None  # initialized after dependency check
         self._last_active_user = self._default_anonymous_user
 
     def setup(self) -> None:
@@ -621,9 +626,6 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
         self.inject_workflow_controls_into_placeholder()
 
-        # ====================================
-        self._initDefaultUsers() # This will install openlifu if not installed
-
         # Install dependencies
         self.ui.installPythonRequirementsPushButton.clicked.connect(self.onUpdateOpenLIFUClicked)
         self._checkOpenLIFUVersionStatus()
@@ -634,22 +636,25 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self.initializeParameterNode()
         self.cacheAllLoginRelatedWidgets()
 
-        self.logic.active_user = self._default_anonymous_user
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
         self.onDatabaseChanged() # Call the routine to update from data parameter node
         self.updateWorkflowControls()
 
     def _initDefaultUsers(self) -> None:
-        """Create default User objects. This will prompt the user
-        to install openlifu if it is not installed. """
-        self._default_anonymous_user = openlifu_lz().db.User(
+        """Create default User objects after dependencies are available."""
+        if self._default_anonymous_user is not None and self._default_admin_user is not None:
+            return
+
+        import openlifu.db
+
+        self._default_anonymous_user = openlifu.db.User(
             id = "anonymous",
             password_hash = "",
             roles = [],
             name = "Anonymous",
             description = "This is the default role set when the app opens, without anyone logged in, with user account mode activated. It has no roles and is therefore the most restricted."
         )
-        self._default_admin_user = openlifu_lz().db.User(
+        self._default_admin_user = openlifu.db.User(
             id = "default_admin",
             password_hash = "default_admin",
             roles = ['admin'],
@@ -664,8 +669,15 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        dependencies_available = ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
+        if dependencies_available:
+            self._initDefaultUsers()
+            if self.logic.active_user is None:
+                self.logic.active_user = self._default_anonymous_user
+            self.updateWidgetLoginState(self._cur_login_state)
+            self._checkOpenLIFUVersionStatus()
         self.updateLoginStateNotificationLabel()
 
     def exit(self) -> None:
@@ -735,6 +747,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
             self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.onParameterNodeModified)
 
     def onUserAccountModeClicked(self):
+        self._initDefaultUsers()
         # toggle and propagate to parameter node
         new_user_account_mode_state = not self._parameterNode.user_account_mode
         set_user_account_mode_state(new_user_account_mode_state)
@@ -753,6 +766,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def logout(self) -> None:
         """Log the user out, setting the current user to be the default anonymous user."""
+        self._initDefaultUsers()
         self.logic.active_user = self._default_anonymous_user
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
     
@@ -765,7 +779,9 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
             return
 
         users = get_cur_db().load_all_users()
-        verify_password = lambda text, _hash: bcrypt_lz().checkpw(text.encode('utf-8'), _hash.encode('utf-8'))
+        import bcrypt
+
+        verify_password = lambda text, _hash: bcrypt.checkpw(text.encode('utf-8'), _hash.encode('utf-8'))
 
         matched_user = next((u for u in users if u.id == user_id and verify_password(password_text, u.password_hash)), None)
 
@@ -867,6 +883,16 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         if state is None:
             state = self._cur_login_state # if called with None, we reload with prev state
 
+        if self._default_anonymous_user is None or self._default_admin_user is None:
+            self.logic.active_user = None
+            self._cur_login_state = LoginState.NOT_LOGGED_IN
+            self.updateLoginStateNotificationLabel()
+            self.updateLoginLogoutButton()
+            self.updateAccountManagementButtons()
+            self.enforceUserPermissions()
+            self.updateWorkflowControls()
+            return
+
         if get_cur_db() and not any('admin' in u.roles for u in get_cur_db().load_all_users()):
             # if there is a connected db with no admin users in it, set the user to admin
             self.logic.active_user = self._default_admin_user
@@ -937,7 +963,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
         for widget in self._permissions_widgets:
             allowed_roles = widget.property("slicer.openlifu.allowed-roles")
-            user_roles = self.logic.active_user.roles
+            user_roles = self.logic.active_user.roles if self.logic.active_user is not None else []
             widget.setEnabled(any(role in allowed_roles for role in user_roles))
 
     def onActiveUserChanged(self, new_active_user: Optional["openlifu.db.User"]) -> None:
@@ -1183,6 +1209,8 @@ class OpenLIFULoginLogic(ScriptedLoadableModuleLogic):
             ):
                 return
 
-        newOpenLIFUuser = openlifu_lz().db.User.from_dict(user_parameters)
-        get_cur_db().write_user(newOpenLIFUuser, on_conflict = openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        import openlifu.db
+        import openlifu.db.database
 
+        newOpenLIFUuser = openlifu.db.User.from_dict(user_parameters)
+        get_cur_db().write_user(newOpenLIFUuser, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -26,10 +26,9 @@ from OpenLIFULib import (
     OpenLIFUAlgorithmInputWidget,
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFUTransducer,
+    ensure_python_requirements_for_module_enter,
     get_openlifu_data_parameter_node,
     get_target_candidates,
-    openlifu_lz,
-    threadpoolctl_lz,
 )
 from OpenLIFULib.coordinate_system_utils import get_IJK2RAS
 from OpenLIFULib.events import SlicerOpenLIFUEvents
@@ -244,6 +243,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
         self.updateWorkflowControls()
@@ -1112,13 +1112,16 @@ class OpenLIFUPrePlanningLogic(ScriptedLoadableModuleLogic):
         if skin_mesh_node is None:
             skin_mesh_node = generate_skin_segmentation(volume)
 
-        with threadpoolctl_lz().threadpool_limits(limits=1): # caps BLAS and OpenMP threads
+        import openlifu.seg
+        import threadpoolctl
+
+        with threadpoolctl.threadpool_limits(limits=1): # caps BLAS and OpenMP threads
             # Capping BLAS threads appears to have a performance improvement when running this algorithm in Slicer.
             # This may be because Slicer already occupies BLAS threads with its VTK/ITK stuff and so the virtual fit's many
             # tiny svd calls end up having more overhead than is worth it.
             # For some unknown reason, the improvement is only noticable when we do not use the embree
             # option in virtual fitting, which makes things very fast.
-            vf_transforms = openlifu_lz().seg.run_virtual_fit(
+            vf_transforms = openlifu.seg.run_virtual_fit(
                 units = units,
                 target_RAS = target.GetNthControlPointPosition(0),
                 standoff_transform = transducer_openlifu.get_standoff_transform_in_units(units),

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -22,9 +22,9 @@ from slicer.util import VTKObservationMixin
 
 # OpenLIFULib imports
 from OpenLIFULib import (
+    ensure_python_requirements_for_module_enter,
     get_cur_db,
     get_openlifu_data_parameter_node,
-    openlifu_lz,
 )
 from OpenLIFULib.class_definition_widgets import (
     DictTableWidget,
@@ -39,8 +39,6 @@ from OpenLIFULib.util import (
     replace_widget,
 )
 
-# These imports are deferred at runtime using openlifu_lz, 
-# but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
 
@@ -198,6 +196,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         self._cur_protocol_id: str = ""  # important if WIPs change the ID
         self._cur_save_state = SaveState.NO_CHANGES
         self._editor_is_enabled: bool = False
+        self._protocol_editor_widgets_initialized: bool = False
         self._parameterNode: Optional[OpenLIFUProtocolConfigParameterNode] = None
         self._parameterNodeGuiTag = None
 
@@ -237,43 +236,18 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         replace_widget(self.ui.userAccountBannerPlaceholder, self.user_account_banner, self.ui)
         self.user_account_banner.visible = False
 
-        self.allowed_roles_widget = ListTableWidget(parent=self.ui.allowedRolesWidgetPlaceholder.parentWidget(), object_name="Role", object_type=str)
-        replace_widget(self.ui.allowedRolesWidgetPlaceholder, self.allowed_roles_widget, self.ui)
-
-        self.pulse_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().bf.Pulse, parent=self.ui.pulseDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Pulse")
-        replace_widget(self.ui.pulseDefinitionWidgetPlaceholder, self.pulse_definition_widget, self.ui)
-
-        self.sequence_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().bf.Sequence, parent=self.ui.sequenceDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Sequence")
-        replace_widget(self.ui.sequenceDefinitionWidgetPlaceholder, self.sequence_definition_widget, self.ui)
-
-        self.abstract_focal_pattern_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu_lz().bf.Wheel, openlifu_lz().bf.SinglePoint], is_collapsible=False, collapsible_title="Focal Pattern", custom_abc_title="Focal Pattern")
-        replace_widget(self.ui.abstractFocalPatternDefinitionWidgetPlaceholder, self.abstract_focal_pattern_definition_widget, self.ui)
-
-        self.sim_setup_definition_widget = OpenLIFUSimSetupDefinitionFormWidget(parent=self.ui.simSetupDefinitionWidgetPlaceholder.parentWidget())
-        replace_widget(self.ui.simSetupDefinitionWidgetPlaceholder, self.sim_setup_definition_widget, self.ui)
-        self.sim_setup_definition_widget.collapsible.collapsed = True  # start collapsed
-
-        self.abstract_delay_method_definition_widget = OpenLIFUAbstractDelayMethodDefinitionFormWidget()
-        replace_widget(self.ui.abstractDelayMethodDefinitionWidgetPlaceholder, self.abstract_delay_method_definition_widget, self.ui)
-
-        self.abstract_apodization_method_definition_widget = OpenLIFUAbstractApodizationMethodDefinitionFormWidget()
-        replace_widget(self.ui.abstractApodizationMethodDefinitionWidgetPlaceholder, self.abstract_apodization_method_definition_widget, self.ui)
-
-        self.abstract_segmentation_method_definition_widget = OpenLIFUAbstractSegmentationMethodDefinitionFormWidget()
-        replace_widget(self.ui.abstractSegmentationMethodDefinitionWidgetPlaceholder, self.abstract_segmentation_method_definition_widget, self.ui)
-
-        self.parameter_constraints_widget = OpenLIFUParameterConstraintsWidget()
-        replace_widget(self.ui.parameterConstraintsWidgetPlaceholder, self.parameter_constraints_widget, self.ui)
-
-        self.target_constraints_widget = ListTableWidget(object_name="Target Constraint", object_type=openlifu_lz().plan.TargetConstraints)
-        replace_widget(self.ui.targetConstraintsWidgetPlaceholder, self.target_constraints_widget, self.ui)
-
-        self.solution_analysis_options_definition_widget = OpenLIFUSolutionAnalysisOptionsDefinitionFormWidget()
-        replace_widget(self.ui.solutionAnalysisOptionsDefinitionWidgetPlaceholder, self.solution_analysis_options_definition_widget, self.ui)
-
-        self.virtual_fit_options_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu_lz().seg.virtual_fit.VirtualFitOptions, parent=self.ui.virtualFitOptionsDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Virtual Fit Options")
-        replace_widget(self.ui.virtualFitOptionsDefinitionWidgetPlaceholder, self.virtual_fit_options_definition_widget, self.ui)
-        self.virtual_fit_options_definition_widget.collapsible.collapsed = True  # start collapsed
+        self.allowed_roles_widget = None
+        self.pulse_definition_widget = None
+        self.sequence_definition_widget = None
+        self.abstract_focal_pattern_definition_widget = None
+        self.sim_setup_definition_widget = None
+        self.abstract_delay_method_definition_widget = None
+        self.abstract_apodization_method_definition_widget = None
+        self.abstract_segmentation_method_definition_widget = None
+        self.parameter_constraints_widget = None
+        self.target_constraints_widget = None
+        self.solution_analysis_options_definition_widget = None
+        self.virtual_fit_options_definition_widget = None
 
         # === Connections and UI setup =======
 
@@ -299,18 +273,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
             self.ui.protocolIdLineEdit.textChanged.connect(f)
             self.ui.protocolDescriptionTextEdit.textChanged.connect(f)
 
-            self.allowed_roles_widget.table.itemChanged.connect(lambda *_: f)
-            self.pulse_definition_widget.add_value_changed_signals(f)
-            self.sequence_definition_widget.add_value_changed_signals(f)
-            self.abstract_focal_pattern_definition_widget.add_value_changed_signals(f)
-            self.sim_setup_definition_widget.add_value_changed_signals(f)
-            self.abstract_delay_method_definition_widget.add_value_changed_signals(f)
-            self.abstract_apodization_method_definition_widget.add_value_changed_signals(f)
-            self.abstract_segmentation_method_definition_widget.add_value_changed_signals(f)
-            self.parameter_constraints_widget.table.itemChanged.connect(lambda *_: f)
-            self.target_constraints_widget.table.itemChanged.connect(lambda *_: f)
-            self.solution_analysis_options_definition_widget.add_value_changed_signals(f)
-            self.virtual_fit_options_definition_widget.add_value_changed_signals(f)
+        self._protocol_editor_signal_handlers = [trigger_unsaved_changes, trigger_invalid_protocol_check]
 
         # Connect main widget functions
 
@@ -326,14 +289,85 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
         # === Disable some of the widgets ===
 
-        self.setProtocolEditButtonEnabled(False)
-        self.setProtocolEditorEnabled(False)
-
-        self.onDatabaseChanged()  # might not have queued
-        self.onDataParameterNodeModified()  # might not have queued
+        self.ui.protocolSelector.setEnabled(False)
+        self.ui.loadProtocolFromFileButton.setEnabled(False)
+        self.ui.createNewProtocolButton.setEnabled(False)
+        self.ui.loadProtocolFromDatabaseButton.setEnabled(False)
+        self.ui.protocolEditRevertDiscardButton.setEnabled(False)
+        self.ui.protocolEditorSectionGroupBox.setEnabled(False)
+        self.setAllSaveAndDeleteButtonsEnabled(False)
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
+
+    def initializeProtocolEditorWidgets(self) -> None:
+        if self._protocol_editor_widgets_initialized:
+            return
+
+        import openlifu.bf
+        import openlifu.plan
+        import openlifu.seg.virtual_fit
+
+        self.allowed_roles_widget = ListTableWidget(parent=self.ui.allowedRolesWidgetPlaceholder.parentWidget(), object_name="Role", object_type=str)
+        replace_widget(self.ui.allowedRolesWidgetPlaceholder, self.allowed_roles_widget, self.ui)
+
+        self.pulse_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu.bf.Pulse, parent=self.ui.pulseDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Pulse")
+        replace_widget(self.ui.pulseDefinitionWidgetPlaceholder, self.pulse_definition_widget, self.ui)
+
+        self.sequence_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu.bf.Sequence, parent=self.ui.sequenceDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Parameters for Sequence")
+        replace_widget(self.ui.sequenceDefinitionWidgetPlaceholder, self.sequence_definition_widget, self.ui)
+
+        self.abstract_focal_pattern_definition_widget = OpenLIFUAbstractMultipleABCDefinitionFormWidget([openlifu.bf.Wheel, openlifu.bf.SinglePoint], is_collapsible=False, collapsible_title="Focal Pattern", custom_abc_title="Focal Pattern")
+        replace_widget(self.ui.abstractFocalPatternDefinitionWidgetPlaceholder, self.abstract_focal_pattern_definition_widget, self.ui)
+
+        self.sim_setup_definition_widget = OpenLIFUSimSetupDefinitionFormWidget(parent=self.ui.simSetupDefinitionWidgetPlaceholder.parentWidget())
+        replace_widget(self.ui.simSetupDefinitionWidgetPlaceholder, self.sim_setup_definition_widget, self.ui)
+        self.sim_setup_definition_widget.collapsible.collapsed = True  # start collapsed
+
+        self.abstract_delay_method_definition_widget = OpenLIFUAbstractDelayMethodDefinitionFormWidget()
+        replace_widget(self.ui.abstractDelayMethodDefinitionWidgetPlaceholder, self.abstract_delay_method_definition_widget, self.ui)
+
+        self.abstract_apodization_method_definition_widget = OpenLIFUAbstractApodizationMethodDefinitionFormWidget()
+        replace_widget(self.ui.abstractApodizationMethodDefinitionWidgetPlaceholder, self.abstract_apodization_method_definition_widget, self.ui)
+
+        self.abstract_segmentation_method_definition_widget = OpenLIFUAbstractSegmentationMethodDefinitionFormWidget()
+        replace_widget(self.ui.abstractSegmentationMethodDefinitionWidgetPlaceholder, self.abstract_segmentation_method_definition_widget, self.ui)
+
+        self.parameter_constraints_widget = OpenLIFUParameterConstraintsWidget()
+        replace_widget(self.ui.parameterConstraintsWidgetPlaceholder, self.parameter_constraints_widget, self.ui)
+
+        self.target_constraints_widget = ListTableWidget(object_name="Target Constraint", object_type=openlifu.plan.TargetConstraints)
+        replace_widget(self.ui.targetConstraintsWidgetPlaceholder, self.target_constraints_widget, self.ui)
+
+        self.solution_analysis_options_definition_widget = OpenLIFUSolutionAnalysisOptionsDefinitionFormWidget()
+        replace_widget(self.ui.solutionAnalysisOptionsDefinitionWidgetPlaceholder, self.solution_analysis_options_definition_widget, self.ui)
+
+        self.virtual_fit_options_definition_widget = OpenLIFUAbstractDataclassDefinitionFormWidget(cls=openlifu.seg.virtual_fit.VirtualFitOptions, parent=self.ui.virtualFitOptionsDefinitionWidgetPlaceholder.parentWidget(), collapsible_title="Virtual Fit Options")
+        replace_widget(self.ui.virtualFitOptionsDefinitionWidgetPlaceholder, self.virtual_fit_options_definition_widget, self.ui)
+        self.virtual_fit_options_definition_widget.collapsible.collapsed = True  # start collapsed
+
+        for f in self._protocol_editor_signal_handlers:
+            self.allowed_roles_widget.table.itemChanged.connect(lambda *_args, callback=f: callback())
+            self.pulse_definition_widget.add_value_changed_signals(f)
+            self.sequence_definition_widget.add_value_changed_signals(f)
+            self.abstract_focal_pattern_definition_widget.add_value_changed_signals(f)
+            self.sim_setup_definition_widget.add_value_changed_signals(f)
+            self.abstract_delay_method_definition_widget.add_value_changed_signals(f)
+            self.abstract_apodization_method_definition_widget.add_value_changed_signals(f)
+            self.abstract_segmentation_method_definition_widget.add_value_changed_signals(f)
+            self.parameter_constraints_widget.table.itemChanged.connect(lambda *_args, callback=f: callback())
+            self.target_constraints_widget.table.itemChanged.connect(lambda *_args, callback=f: callback())
+            self.solution_analysis_options_definition_widget.add_value_changed_signals(f)
+            self.virtual_fit_options_definition_widget.add_value_changed_signals(f)
+
+        self._protocol_editor_widgets_initialized = True
+        self.ui.protocolSelector.setEnabled(True)
+        self.ui.loadProtocolFromFileButton.setEnabled(True)
+        self.setCreateNewProtocolButtonEnabled(True)
+        self.setProtocolEditButtonEnabled(False)
+        self.setProtocolEditorEnabled(False)
+        self.onDatabaseChanged()
+        self.onDataParameterNodeModified()
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
@@ -341,14 +375,17 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        dependencies_available = ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
+        if dependencies_available:
+            self.initializeProtocolEditorWidgets()
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
 
         # Cache a WIP (other modules might load one)
-        if self._cur_save_state == SaveState.UNSAVED_CHANGES:
+        if self._protocol_editor_widgets_initialized and self._cur_save_state == SaveState.UNSAVED_CHANGES:
             protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
 
@@ -369,6 +406,11 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
             self.initializeParameterNode()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
+        if not self._protocol_editor_widgets_initialized:
+            self.setDatabaseButtonsEnabled(False)
+            self.reloadProtocols()
+            return
+
         if not get_cur_db():
             self.setDatabaseButtonsEnabled(False)
         else:
@@ -397,6 +439,12 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         Note: The displayed protocol name/id and the underlying protocol data
         are all related to the original protocol data, not any WIP or cached
         data."""
+
+        if not self._protocol_editor_widgets_initialized:
+            self.ui.protocolSelector.clear()
+            self.ui.protocolSelector.setProperty("defaultText", "OpenLIFU Python dependencies are required to edit protocols.")
+            self.setProtocolEditButtonEnabled(False)
+            return
 
         self.ui.protocolSelector.clear()
         if (len(get_openlifu_data_parameter_node().loaded_protocols) + len(self.logic.new_protocol_ids)) == 0:
@@ -431,6 +479,9 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
             self.setNewProtocolWidgets()
 
     def onProtocolSelectorIndexChanged(self):
+        if not self._protocol_editor_widgets_initialized:
+            return
+
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
             protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
@@ -603,6 +654,8 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     @display_errors
     def onLoadProtocolFromFileClicked(self, checked:bool) -> None:
+        self.initializeProtocolEditorWidgets()
+
         if self._cur_save_state == SaveState.UNSAVED_CHANGES:
             protocol_changed = self.getProtocolFromGUI(post_init=False)
             self.logic.cache_protocol(self._cur_protocol_id, protocol_changed)
@@ -618,7 +671,9 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         if not filepath:
             return
 
-        protocol = openlifu_lz().plan.Protocol.from_file(filepath)
+        import openlifu.plan
+
+        protocol = openlifu.plan.Protocol.from_file(filepath)
 
         if not self.load_protocol_from_openlifu(protocol):
             return
@@ -735,6 +790,8 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
         Returns:
             openlifu.plan.Protocol: A fully constructed Protocol instance representing the current GUI state.
         """
+        self.initializeProtocolEditorWidgets()
+
         allowed_roles = self.allowed_roles_widget.to_list()
         pulse = self.pulse_definition_widget.get_form_as_class(post_init=post_init)
         sequence = self.sequence_definition_widget.get_form_as_class(post_init=post_init)
@@ -766,10 +823,12 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
             virtual_fit_options=virtual_fit_options,
         )
 
+        import openlifu.plan
+
         if post_init:
-            return openlifu_lz().plan.Protocol(**protocol_fields)
+            return openlifu.plan.Protocol(**protocol_fields)
         else:
-            return instantiate_without_post_init(openlifu_lz().plan.Protocol, **protocol_fields)
+            return instantiate_without_post_init(openlifu.plan.Protocol, **protocol_fields)
 
     def setNewProtocolWidgets(self) -> None:
         self.setProtocolEditButtonEnabled(True)  # enable edit button (consistency)
@@ -778,7 +837,11 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     def setProtocolEditorEnabled(self, enabled: bool) -> None:
         self._editor_is_enabled = enabled
-        self.ui.protocolEditorSectionGroupBox.setEnabled(enabled)
+        self.ui.protocolEditorSectionGroupBox.setEnabled(enabled and self._protocol_editor_widgets_initialized)
+
+        if not self._protocol_editor_widgets_initialized:
+            self.setAllSaveAndDeleteButtonsEnabled(False)
+            return
 
         # Dynamic widgets
         self.allowed_roles_widget.setEnabled(enabled)
@@ -939,12 +1002,16 @@ class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic):
     def save_protocol_to_database(self, protocol: "openlifu.plan.Protocol") -> None:
         if get_cur_db() is None:
             raise RuntimeError("Cannot save protocol because there is no database connection")
-        get_cur_db().write_protocol(protocol, openlifu_lz().db.database.OnConflictOpts.OVERWRITE)
+        import openlifu.db.database
+
+        get_cur_db().write_protocol(protocol, openlifu.db.database.OnConflictOpts.OVERWRITE)
 
     def delete_protocol_from_database(self, protocol_id: str) -> None:
         if get_cur_db() is None:
             raise RuntimeError("Cannot delete protocol because there is no database connection")
-        get_cur_db().delete_protocol(protocol_id, openlifu_lz().db.database.OnConflictOpts.ERROR)
+        import openlifu.db.database
+
+        get_cur_db().delete_protocol(protocol_id, openlifu.db.database.OnConflictOpts.ERROR)
 
     def cache_protocol(self, protocol_id: str, protocol: "openlifu.plan.Protocol") -> None:
         self.cached_protocols[protocol_id] = protocol
@@ -977,31 +1044,45 @@ class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic):
 
     @classmethod
     def get_default_pulse(cls):
-        return openlifu_lz().bf.Pulse()
+        import openlifu.bf
+
+        return openlifu.bf.Pulse()
 
     @classmethod
     def get_default_sequence(cls):
-        return openlifu_lz().bf.Sequence()
+        import openlifu.bf
+
+        return openlifu.bf.Sequence()
 
     @classmethod
     def get_default_focal_pattern(cls):
-        return openlifu_lz().bf.focal_patterns.SinglePoint()
+        import openlifu.bf.focal_patterns
+
+        return openlifu.bf.focal_patterns.SinglePoint()
 
     @classmethod
     def get_default_sim_setup(cls):
-        return openlifu_lz().sim.SimSetup()
+        import openlifu.sim
+
+        return openlifu.sim.SimSetup()
 
     @classmethod
     def get_default_delay_method(cls):
-        return openlifu_lz().bf.delay_methods.Direct()
+        import openlifu.bf.delay_methods
+
+        return openlifu.bf.delay_methods.Direct()
 
     @classmethod
     def get_default_apodization_method(cls):
-        return openlifu_lz().bf.apod_methods.Uniform()
+        import openlifu.bf.apod_methods
+
+        return openlifu.bf.apod_methods.Uniform()
 
     @classmethod
     def get_default_segmentation_method(cls):
-        return openlifu_lz().seg.seg_methods.UniformWater()
+        import openlifu.seg.seg_methods
+
+        return openlifu.seg.seg_methods.UniformWater()
 
     @classmethod
     def get_default_parameter_constraints(cls):
@@ -1013,15 +1094,21 @@ class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic):
 
     @classmethod
     def get_default_solution_analysis_options(cls):
-        return openlifu_lz().plan.SolutionAnalysisOptions()
+        import openlifu.plan
+
+        return openlifu.plan.SolutionAnalysisOptions()
 
     @classmethod
     def get_default_virtual_fit_options(cls):
-        return openlifu_lz().seg.virtual_fit.VirtualFitOptions()
+        import openlifu.seg.virtual_fit
+
+        return openlifu.seg.virtual_fit.VirtualFitOptions()
 
     @classmethod
     def get_default_protocol(cls):
-        return openlifu_lz().plan.Protocol(
+        import openlifu.plan
+
+        return openlifu.plan.Protocol(
             name=DefaultProtocolValues.NAME.value,
             id=DefaultProtocolValues.ID.value,
             description=DefaultProtocolValues.DESCRIPTION.value,
@@ -1042,7 +1129,9 @@ class OpenLIFUProtocolConfigLogic(ScriptedLoadableModuleLogic):
 
     @classmethod
     def get_default_new_protocol(cls):
-        return openlifu_lz().plan.Protocol(
+        import openlifu.plan
+
+        return openlifu.plan.Protocol(
             name=DefaultNewProtocolValues.NAME.value,
             id=DefaultNewProtocolValues.ID.value,
             description=DefaultNewProtocolValues.DESCRIPTION.value,
@@ -1086,7 +1175,9 @@ class OpenLIFUProtocolConfigTest(ScriptedLoadableModuleTest):
 
 class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget):
     def __init__(self, parent: Optional[qt.QWidget] = None):
-        super().__init__(openlifu_lz().sim.SimSetup, parent, is_collapsible=True, collapsible_title="Simulation Setup")
+        import openlifu.sim
+
+        super().__init__(openlifu.sim.SimSetup, parent, is_collapsible=True, collapsible_title="Simulation Setup")
 
         # Modify the defaults and ranges for x_extent, y_extent, and z_extent
         x_ext_hbox = self._field_widgets['x_extent'].layout()
@@ -1116,7 +1207,9 @@ class OpenLIFUSimSetupDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFo
 
 class OpenLIFUAbstractDelayMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
     def __init__(self):
-        super().__init__([openlifu_lz().bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")
+        import openlifu.bf.delay_methods
+
+        super().__init__([openlifu.bf.delay_methods.Direct], is_collapsible=False, collapsible_title="Delay Method", custom_abc_title="Delay Method")
 
         # Select Direct as the default. Note: `get_default_delay_method` should
         # make sure Direct is also set.
@@ -1132,7 +1225,9 @@ class OpenLIFUAbstractDelayMethodDefinitionFormWidget(OpenLIFUAbstractMultipleAB
 
 class OpenLIFUAbstractApodizationMethodDefinitionFormWidget(OpenLIFUAbstractMultipleABCDefinitionFormWidget):
     def __init__(self):
-        super().__init__([openlifu_lz().bf.apod_methods.MaxAngle, openlifu_lz().bf.apod_methods.PiecewiseLinear, openlifu_lz().bf.apod_methods.Uniform], is_collapsible=False, collapsible_title="Apodization Method", custom_abc_title="Apodization Method")
+        import openlifu.bf.apod_methods
+
+        super().__init__([openlifu.bf.apod_methods.MaxAngle, openlifu.bf.apod_methods.PiecewiseLinear, openlifu.bf.apod_methods.Uniform], is_collapsible=False, collapsible_title="Apodization Method", custom_abc_title="Apodization Method")
 
         # Select Uniform as the default. Note: `get_default_apodization_method`
         # should make sure Uniform also set.
@@ -1184,7 +1279,9 @@ class OpenLIFUAbstractSegmentationMethodDefinitionFormWidget(OpenLIFUAbstractMul
         """
         # ---- Begin constructor overwrite ----
 
-        cls_list = [openlifu_lz().seg.seg_methods.UniformSegmentation, openlifu_lz().seg.seg_methods.UniformTissue, openlifu_lz().seg.seg_methods.UniformWater]
+        import openlifu.seg.seg_methods
+
+        cls_list = [openlifu.seg.seg_methods.UniformSegmentation, openlifu.seg.seg_methods.UniformTissue, openlifu.seg.seg_methods.UniformWater]
         is_collapsible = False
         parent: Optional[qt.QWidget] = None
         collapsible_title = "Segmentation Method"
@@ -1387,7 +1484,9 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
                 if is_range_operator else self.error_spinboxes[0].value
             )
 
-            return openlifu_lz().plan.ParameterConstraint(operator, warning_value, error_value)
+            import openlifu.plan
+
+            return openlifu.plan.ParameterConstraint(operator, warning_value, error_value)
 
         def _on_accept(self):
             display_name = self.parameter_name_input.currentText
@@ -1433,7 +1532,9 @@ class OpenLIFUParameterConstraintsWidget(DictTableWidget):
 
 class OpenLIFUSolutionAnalysisOptionsDefinitionFormWidget(OpenLIFUAbstractDataclassDefinitionFormWidget):
     def __init__(self, parent: Optional[qt.QWidget] = None):
-        super().__init__(openlifu_lz().plan.SolutionAnalysisOptions, parent, collapsible_title="Solution Analysis Options")
+        import openlifu.plan
+
+        super().__init__(openlifu.plan.SolutionAnalysisOptions, parent, collapsible_title="Solution Analysis Options")
 
         # Modify the widget for configuring SolutionAnalysis.param_constraints
         # so that it uses the OpenLIFUParameterConstraintsWidget

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -22,17 +22,14 @@ from slicer.util import VTKObservationMixin
 # OpenLIFULib imports
 from OpenLIFULib import (
     SlicerOpenLIFURun,
+    ensure_python_requirements_for_module_enter,
     get_openlifu_data_parameter_node,
-    openlifu_lz,
-    openlifu_sdk_lz,
 )
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
 from OpenLIFULib.util import add_slicer_log_handler, display_errors, replace_widget
 
 
-# This import is deferred at runtime using openlifu_lz, 
-# but is done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
     import openlifu_sdk
@@ -46,8 +43,6 @@ def _lifu_exceptions():
     :class:`LIFUNoTriggerStatusError`, ...). Each carries a stable numeric
     ``code`` attribute and a human-readable message.
     """
-    # openlifu_sdk_lz() guarantees the package is imported.
-    openlifu_sdk_lz()
     import importlib
     return importlib.import_module("openlifu_sdk.io.exceptions")
 
@@ -342,8 +337,12 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def enter(self) -> None:
         """Called each time the user opens this module."""
         logging.debug("OpenLIFUSonicationControlWidget.enter() called")
+        dependencies_available = ensure_python_requirements_for_module_enter()
+        if dependencies_available:
+            self.logic.initialize_lifu_interface()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
+        self.updateDeviceConnectedStateFromDevice()
         self.updateVersionLabels()
         self.updateWorkflowControls()
 
@@ -478,7 +477,9 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.updateAbortEnabled()
 
     def updateReinitializeLIFUInterfacePushButton(self):
-        if self.logic.cur_lifu_interface._test_mode:
+        if self.logic.cur_lifu_interface is None:
+            self.ui.reinitializeLIFUInterfacePushButton.setText("Initialize LIFUInterface")
+        elif self.logic.cur_lifu_interface._test_mode:
             self.ui.reinitializeLIFUInterfacePushButton.setText("Reinitialize LIFUInterface not in test_mode")
         else:
             self.ui.reinitializeLIFUInterfacePushButton.setText("Reinitialize LIFUInterface in test_mode")
@@ -533,6 +534,8 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onReinitializeLIFUInterfacePushButtonClicked(self, checked=False):
         logging.debug("onReinitializeLIFUInterfacePushButtonClicked() called")
 
+        self.logic.initialize_lifu_interface()
+
         slicer.util.warningDisplay(
             text = f"Reinitializing the LIFUInterface in test mode is not fully supported and may result in unexpected application behavior. If this was a mistake, restart the app and use the real transducer hardware.",
             windowTitle="Test Mode Not Supported", parent = slicer.util.mainWindow()
@@ -551,6 +554,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onSendSonicationSolutionToDevicePushButtonClicked(self, checked=False):
         logging.debug("onSendSonicationSolutionToDevicePushButtonClicked() called")
 
+        self.logic.initialize_lifu_interface()
         LIFUError = _lifu_exceptions().LIFUError
         # Reflect the in-progress state immediately and flush the event loop so
         # the user gets visual feedback while the (synchronous) device call runs.
@@ -560,8 +564,10 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         success = False
         lifu_error_detail: str | None = None
         try:
+            import openlifu_sdk
+
             self.logic.cur_lifu_interface.set_solution(get_openlifu_data_parameter_node().loaded_solution.solution.solution.to_dict())
-            if self.logic.cur_lifu_interface.get_status() != openlifu_sdk_lz().LIFUInterfaceStatus.STATUS_READY:
+            if self.logic.cur_lifu_interface.get_status() != openlifu_sdk.LIFUInterfaceStatus.STATUS_READY:
                 raise RuntimeError("Interface not ready")
             self.logic.cur_solution_on_hardware = get_openlifu_data_parameter_node().loaded_solution.solution.solution
             logging.debug("Solution successfully sent to device")
@@ -585,6 +591,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self.updateWorkflowControls()
 
     def onManuallyGetDeviceStatusPushButtonClicked(self, checked=False):
+        self.logic.initialize_lifu_interface()
         slicer.util.infoDisplay(text=f"{self.logic.cur_lifu_interface.get_status().name}", windowTitle="Device Status")
 
     def onRunningChanged(self, new_running_state:bool):
@@ -672,9 +679,10 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         """Populate SDK / console / TX firmware version labels when both devices are connected."""
         if self._cur_device_connected_state == DeviceConnectedState.CONNECTED:
             import importlib.metadata
+            import openlifu_sdk
             LIFUError = _lifu_exceptions().LIFUError
             try:
-                sdk_ver = openlifu_sdk_lz().LIFUInterface.get_sdk_version()
+                sdk_ver = openlifu_sdk.LIFUInterface.get_sdk_version()
             except importlib.metadata.PackageNotFoundError as e:
                 logging.warning("Could not read SDK version: %s", e)
                 sdk_ver = "unknown"
@@ -868,23 +876,10 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         # ---- LIFU Interface Connection ----
 
         self._create_lifu_interface_bridge()
-        self.cur_lifu_interface = openlifu_sdk_lz().LIFUInterface(run_async=True, TX_test_mode=False, HV_test_mode=False)
-        # Connect signals before starting the monitor thread to avoid missing early events
-        self._connect_owsignals()
-
-        # Set up asyncio event loop and monitoring thread
-        self._monitor_loop = asyncio.new_event_loop()
-        self._monitor_thread = threading.Thread(
-            target=self._run_monitor_loop,
-            daemon=True
-        )
-        self._monitor_thread.start()
-
-        self.monitoring_timer = qt.QTimer()
-        self.monitoring_timer.setInterval(100)
-        self.monitoring_timer.timeout.connect(self._pumpMonitoringLoop)
-        self.monitoring_timer.start()
-
+        self.cur_lifu_interface = None
+        self._monitor_loop = None
+        self._monitor_thread = None
+        self.monitoring_timer = None
         self.cur_solution_on_hardware: Optional[openlifu.plan.Solution] = None
         """The active Solution object last sent to the ultrasound hardware."""
 
@@ -903,11 +898,39 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
     def _connect_owsignals(self):
         """Wire the current interface's OWSignals into the bridge. Call from __init__ and reinitialize_lifu_interface."""
+        if self.cur_lifu_interface is None:
+            return
         for device in (self.cur_lifu_interface.hvcontroller, self.cur_lifu_interface.txdevice):
             device.signal_connected.connect(self.qt_signals.signal_connected.emit)
             device.signal_disconnected.connect(self.qt_signals.signal_disconnected.emit)
             device.signal_data_received.connect(self.qt_signals.signal_data_received.emit)
             device.signal_error.connect(self.qt_signals.signal_error.emit)
+
+    def initialize_lifu_interface(self, test_mode: bool = False) -> None:
+        if self.cur_lifu_interface is not None:
+            return
+
+        import openlifu_sdk
+
+        self.cur_lifu_interface = openlifu_sdk.LIFUInterface(
+            run_async=True,
+            TX_test_mode=test_mode,
+            HV_test_mode=test_mode,
+        )
+        # Connect signals before starting the monitor thread to avoid missing early events.
+        self._connect_owsignals()
+
+        self._monitor_loop = asyncio.new_event_loop()
+        self._monitor_thread = threading.Thread(
+            target=self._run_monitor_loop,
+            daemon=True
+        )
+        self._monitor_thread.start()
+
+        self.monitoring_timer = qt.QTimer()
+        self.monitoring_timer.setInterval(100)
+        self.monitoring_timer.timeout.connect(self._pumpMonitoringLoop)
+        self.monitoring_timer.start()
 
     def stop_monitoring(self):
         if self.cur_lifu_interface:
@@ -936,7 +959,8 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
         LIFUError = _lifu_exceptions().LIFUError
         try:
-            self.monitoring_timer.stop()
+            if self.monitoring_timer is not None:
+                self.monitoring_timer.stop()
             self.stop_monitoring()
 
             if self.cur_lifu_interface:
@@ -945,25 +969,8 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         except (LIFUError, RuntimeError, OSError) as e:
             logging.warning("[LIFU] Error during interface cleanup: %s", e)
 
-        # Recreate interface
-        self.cur_lifu_interface = openlifu_sdk_lz().LIFUInterface(
-            run_async=True,
-            TX_test_mode=test_mode,
-            HV_test_mode=test_mode
-        )
-
-        # Connect the bridge to signals from the new interface
-        self._connect_owsignals()
-
-        # Create fresh loop + thread
-        self._monitor_loop = asyncio.new_event_loop()
-        self._monitor_thread = threading.Thread(
-            target=self._run_monitor_loop,
-            daemon=True
-        )
-        self._monitor_thread.start()
-
-        self.monitoring_timer.start()
+        self.cur_lifu_interface = None
+        self.initialize_lifu_interface(test_mode=test_mode)
 
     def __del__(self):
         print("OpenLIFUSonicationControlLogic.__del__ called")
@@ -1171,11 +1178,15 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
                     # Update internal trigger state and notify QML
                     if parsed["status"] == "STOPPED":
                         logging.info("Trigger is stopped.")
-                        self.cur_lifu_interface.set_status(openlifu_sdk_lz().LIFUInterfaceStatus.STATUS_FINISHED)
+                        import openlifu_sdk
+
+                        self.cur_lifu_interface.set_status(openlifu_sdk.LIFUInterfaceStatus.STATUS_FINISHED)
                         self.qt_signals.finishScanning.emit(True)  # Signal that scanning is finished
                     else:
                         #update status
-                        self.cur_lifu_interface.set_status(openlifu_sdk_lz().LIFUInterfaceStatus.STATUS_RUNNING)
+                        import openlifu_sdk
+
+                        self.cur_lifu_interface.set_status(openlifu_sdk.LIFUInterfaceStatus.STATUS_RUNNING)
 
             except (LIFUError, KeyError, TypeError) as e:
                 logging.error(f"Failed to parse and update trigger state: {e}")
@@ -1186,6 +1197,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
     def run(self):
         " Returns True when the sonication control algorithm is done"
         logging.debug("Logic.run() called")
+
+        if self.cur_lifu_interface is None:
+            raise RuntimeError("LIFUInterface has not been initialized. Enter the module before running sonication.")
 
         if get_openlifu_data_parameter_node().loaded_solution is None:
             raise RuntimeError("No solution loaded; cannot run sonication.")
@@ -1211,6 +1225,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
     def stop(self):
         logging.debug("Logic.stop() called")
+        if self.cur_lifu_interface is None:
+            raise RuntimeError("LIFUInterface has not been initialized. Enter the module before stopping sonication.")
+
         # ---- Start the run ----
         self.running = False
         
@@ -1219,6 +1236,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
 
     def abort(self) -> None:
         logging.debug("Logic.abort() called")
+        if self.cur_lifu_interface is None:
+            raise RuntimeError("LIFUInterface has not been initialized. Enter the module before aborting sonication.")
+
         # Assumes that the sonication control algorithm will have a callback function to abort run, 
         # that callback can be called here. 
         
@@ -1249,7 +1269,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         else:
             raise RuntimeError("No loaded solution -- this run should not have been possible!")
              
-        run_openlifu = openlifu_lz().plan.run.Run(
+        import openlifu.plan.run
+
+        run_openlifu = openlifu.plan.run.Run(
             id = run_id,
             name = f"Run_{timestamp}",
             success_flag = run_parameters["success_flag"],
@@ -1266,6 +1288,9 @@ class OpenLIFUSonicationControlLogic(ScriptedLoadableModuleLogic):
         return run
 
     def get_lifu_device_connected(self) -> bool:
+        if self.cur_lifu_interface is None:
+            return False
+
         tx_connected = self.cur_lifu_interface.txdevice.is_connected()
         hv_connected = self.cur_lifu_interface.hvcontroller.is_connected()
         logging.debug(f" get_lifu_device_connected(): tx={tx_connected}, hv={hv_connected}")

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -21,7 +21,7 @@ from slicer.util import VTKObservationMixin
 from OpenLIFULib import (
     BusyCursor,
     check_and_install_kwave_binaries,
-    openlifu_lz,
+    ensure_python_requirements_for_module_enter,
     OpenLIFUAlgorithmInputWidget,
     SlicerOpenLIFUProtocol,
     SlicerOpenLIFUSolution,
@@ -41,8 +41,6 @@ from OpenLIFULib.util import (
 )
 from OpenLIFULib.notifications import notify
 
-# These imports are deferred at runtime using openlifu_lz,
-# but are done here for IDE and static analysis purposes
 if TYPE_CHECKING:
     import openlifu
     import openlifu.plan
@@ -194,6 +192,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
         self.updateWorkflowControls()
@@ -665,8 +664,10 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.ui.globalAnalysisTableView.setMinimumHeight(400)  # adjust as needed
 
         # Populate the model
+        import openlifu.plan.param_constraint
+
         for _, row in df.iterrows():
-            row["Status"] = row["Status"] if row["Status"] else openlifu_lz().plan.param_constraint.PARAM_STATUS_SYMBOLS["ok"]
+            row["Status"] = row["Status"] if row["Status"] else openlifu.plan.param_constraint.PARAM_STATUS_SYMBOLS["ok"]
             items = [create_noneditable_QStandardItem(format_value(cell)) for cell in row]
             self.globalAnalysisTableModel.appendRow(items)#
 

--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -40,10 +40,9 @@ from OpenLIFULib import (
     OpenLIFUAlgorithmInputWidget,
     SlicerOpenLIFUPhotoscan,
     SlicerOpenLIFUTransducer,
+    ensure_python_requirements_for_module_enter,
     get_cur_db,
     get_openlifu_data_parameter_node,
-    openlifu_lz,
-    segno_lz,
 )
 from OpenLIFULib.coordinate_system_utils import numpy_to_vtk_4x4
 from OpenLIFULib.events import SlicerOpenLIFUEvents
@@ -1986,7 +1985,8 @@ class SessionQRCodeDialog(qt.QDialog):
 
         uri = f"openlifu://{subject_id}|{session_id}|{photocollection_id}"
 
-        segno = segno_lz()
+        import segno
+
         qr = segno.make(uri)
         buf = io.BytesIO()
         qr.save(buf, kind="png", scale=8, border=2, dark="#000", light="#fff")
@@ -2135,6 +2135,7 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
         self.updateWorkflowControls()
@@ -2486,8 +2487,11 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
             )
         )
 
+        import openlifu.nav.photoscan
+        import openlifu.util.assets
+
         # We set download_masking_model=False when we call run_reconstruction in generate_photoscan, so that we can manage getting the model here:
-        modnet_path : Path = openlifu_lz().util.assets.get_modnet_path()
+        modnet_path : Path = openlifu.util.assets.get_modnet_path()
         if not modnet_path.exists():
             install_dialog = InstallAssetDialog(modnet_path.name, parent = slicer.util.mainWindow())
             if install_dialog.exec_() != qt.QDialog.Accepted:
@@ -2495,7 +2499,7 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
             action, path = install_dialog.get_result()
             if action == "download":
                 try:
-                    openlifu_lz().util.assets.download_and_install_modnet()
+                    openlifu.util.assets.download_and_install_modnet()
                 except Exception as e:
                     slicer.util.errorDisplay(
                         text = f"An error occurred while downloading {modnet_path.name}: {e}",
@@ -2503,12 +2507,12 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
                     )
                     raise e
             elif action =="browse":
-                openlifu_lz().util.assets.install_modnet_from_file(path)
+                openlifu.util.assets.install_modnet_from_file(path)
             else:
                 raise RuntimeError("Unrecognized dialog action") # should never happen
 
         photoscan_generation_options_dialog = PhotoscanGenerationOptionsDialog(
-            meshroom_pipeline_names = openlifu_lz().nav.photoscan.get_meshroom_pipeline_names(),
+            meshroom_pipeline_names = openlifu.nav.photoscan.get_meshroom_pipeline_names(),
             total_number_of_photos = total_number_of_photos,
         )
         
@@ -3301,13 +3305,15 @@ class OpenLIFUTransducerLocalizationLogic(ScriptedLoadableModuleLogic):
             f", matching_mode = {matching_mode}"
         )
 
-        photocollection_filepaths = openlifu_lz().nav.photoscan.preprocess_image_paths(
+        import openlifu.nav.photoscan
+
+        photocollection_filepaths = openlifu.nav.photoscan.preprocess_image_paths(
             paths = photocollection_filepaths,
             sort_by = "filename",
             sampling_rate = sampling_rate,
         )
         with BusyCursor():
-            photoscan_openlifu, data_dir = openlifu_lz().nav.photoscan.run_reconstruction(
+            photoscan_openlifu, data_dir = openlifu.nav.photoscan.run_reconstruction(
                 images = photocollection_filepaths,
                 pipeline_name = meshroom_pipeline,
                 input_resize_width = image_width,


### PR DESCRIPTION
- Rename `lazyimport.py` to `dependency_utils.py` and remove the `*_lz()` import helpers.
- Add `ensure_python_requirements_for_module_enter()` and use it from module `enter()` methods to run dependency checks/install prompts before OpenLIFU-dependent behavior.
- Warn once per session when the installed openlifu version does not match the pinned requirements version.
  - (In a separate commit, also fix a bug in the version checker where it trips up over the brackets in openlifu[app])
- Replace `*_lz()` call sites with direct local imports for openlifu, openlifu_sdk, and related packages.
- Defer setup-time OpenLIFU-dependent initialization where needed:
  - `OpenLIFUProtocolConfig`: build dynamic protocol editor widgets after dependencies are available on module enter.
  - `OpenLIFUSonicationControl`: create LIFUInterface after dependencies are available on module enter.
  - `OpenLIFULogin`: initialize default users after dependencies are available instead of during setup.
  - `OpenLIFUCloudSync`: move cloud SDK/request imports into dependency-checked runtime paths.

I tested the behavior of different modules when openlifu is installed, isn't installed, or is installed at the wrong version.

@sadhana-r For review either a quick test of workflow or a look over the code is sufficient, no need for both. I've tested behavior and looked over the code carefully.

@peterhollender adding you for visibility since this is something you were requesting, but also it is somehting you did in a separate branch. It is re-done more completely here and may clobber some of what was in your other branch, but I'm guessing not more than it was already clobbered by the import overhaul we just merged. Hopefully this is okay and along the lines of what you were looking to get, but let me know and we can be flexible.