### PR TITLE
Display RMS distance after ICP registration (#554)

### DIFF
--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -746,13 +746,15 @@ class PhotoscanVolumeTrackingPage(qt.QWizardPage):
                 distance_array = distance_map.GetPointData().GetArray('Distance')
                 mean_distance = np.mean(distance_array) 
                 max_distance = np.max(distance_array)
-                # rms_distance = np.sqrt((np.square(distance_array).mean()))
+                rms_distance = np.sqrt((np.square(distance_array).mean()))
 
                 self.ui.PVICPRegistrationMetricLabel.text = (
                     f"ICP  metric: {icp_metric:.5f} mm, "
                     f"Iterations: {num_iter}, "
                     f"Mean distance: {mean_distance:.5f} mm, "
-                    f"Max distance: {max_distance:.5f} mm  "
+                    f"Max distance: {max_distance:.5f} mm,  "
+                    f"RMS distance: {rms_distance:.5f} mm  "
+
                 )
 
                 self.photoscan_to_volume_transform_node.SetAndObserveTransformNodeID(self.photoscan_to_volume_icp_transform_node.GetID())
@@ -1042,7 +1044,7 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
                 distance_array = distance_map.GetPointData().GetArray('Distance')
                 mean_distance = np.mean(distance_array)
                 max_distance = np.max(distance_array)
-                # rms_distance = np.sqrt((np.square(distance_array).mean()))
+                rms_distance = np.sqrt((np.square(distance_array).mean()))
                 
                 self._update_distance_map_visibility(
                     visible=True,
@@ -1054,7 +1056,8 @@ class TransducerPhotoscanTrackingPage(qt.QWizardPage):
                     f"ICP  metric: {icp_metric:.5f} mm, "
                     f"Iterations: {num_iter}, "
                     f"Mean distance: {mean_distance:.5f} mm, "
-                    f"Max distance: {max_distance:.5f} mm  "
+                    f"Max distance: {max_distance:.5f} mm,  "
+                    f"RMS distance: {rms_distance:.5f} mm  "
                 )
 
                 self.transducer_to_volume_transform_node.SetAndObserveTransformNodeID(self.transducer_to_photoscan_icp_transform_node.GetID())

--- a/OpenLIFUTransducerLocalization/Resources/UI/TransducerLocalizationWizard.ui
+++ b/OpenLIFUTransducerLocalization/Resources/UI/TransducerLocalizationWizard.ui
@@ -40,7 +40,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="photoscanMarkup">
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -257,6 +257,9 @@
         <widget class="QLabel" name="PVICPRegistrationMetricLabel">
          <property name="text">
           <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -520,6 +523,9 @@
         <widget class="QLabel" name="TPICPRegistrationMetricLabel">
          <property name="text">
           <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Closes #554 

After ICP registration, the pointwise distance is computed between every point on the moving mesh and the closest point on the fixed reference mesh. In addition to the minimim and maximum distance, we now also show the RMS distance. 

The logic for computing the RMS distance was already added - I just added it to the label display for both skin-segmentation-photoscan and photoscan-transducer registration. 