### PR TITLE
Add button to check and install Meshroom dependency

### DIFF
--- a/OpenLIFULib/CMakeLists.txt
+++ b/OpenLIFULib/CMakeLists.txt
@@ -30,6 +30,8 @@ set(MODULE_PYTHON_SCRIPTS
   OpenLIFULib/sample_data.py
   OpenLIFULib/sample_data_gui.py
   OpenLIFULib/sample_data_cli.py
+  OpenLIFULib/meshroom_install_gui.py
+  OpenLIFULib/meshroom_install_cli.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
@@ -1,0 +1,151 @@
+import argparse
+import json
+import os
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+PROGRESS_LINE_PREFIX = "OPENLIFU_MESHROOM_INSTALL_PROGRESS "
+BYTES_PER_MB = 1024 * 1024
+DOWNLOAD_SOCKET_TIMEOUT_SECONDS = 45
+
+
+class MeshroomInstallCanceled(Exception):
+    pass
+
+
+def _emit_progress_event(event: dict) -> None:
+    print(PROGRESS_LINE_PREFIX + json.dumps(event), flush=True)
+
+
+def _progress_callback(message: str, value: int, maximum: int) -> None:
+    _emit_progress_event({"message": message, "value": value, "maximum": maximum})
+
+
+def _raise_if_canceled(cancel_callback):
+    if cancel_callback is not None and cancel_callback():
+        raise MeshroomInstallCanceled("Meshroom installation canceled.")
+
+
+def _download_archive(url: str, archive_path: Path, cancel_callback) -> None:
+    _raise_if_canceled(cancel_callback)
+    _progress_callback("Downloading Meshroom. This is a large download and may take several minutes.", 0, 0)
+
+    with urllib.request.urlopen(url, timeout=DOWNLOAD_SOCKET_TIMEOUT_SECONDS) as response:
+        total_size = int(response.headers.get("Content-Length") or 0)
+        total_mb = max(1, total_size // BYTES_PER_MB) if total_size else 0
+        downloaded_size = 0
+        last_reported_mb = -1
+
+        with archive_path.open("wb") as f:
+            while True:
+                _raise_if_canceled(cancel_callback)
+                chunk = response.read(BYTES_PER_MB)
+                if not chunk:
+                    break
+                _raise_if_canceled(cancel_callback)
+                f.write(chunk)
+                downloaded_size += len(chunk)
+                downloaded_mb = downloaded_size // BYTES_PER_MB
+                if downloaded_mb == last_reported_mb:
+                    continue
+                if total_mb:
+                    reported_mb = min(total_mb, downloaded_mb)
+                    _progress_callback(
+                        f"Downloading Meshroom ({reported_mb} of {total_mb} MB)...",
+                        reported_mb,
+                        total_mb,
+                    )
+                else:
+                    _progress_callback(
+                        f"Downloading Meshroom ({downloaded_mb} MB downloaded)...",
+                        0,
+                        0,
+                    )
+                last_reported_mb = downloaded_mb
+
+
+def _extract_zip(archive_path: Path, extraction_dir: Path, cancel_callback) -> None:
+    _raise_if_canceled(cancel_callback)
+    _progress_callback("Extracting Meshroom...", 0, 0)
+    extraction_dir_resolved = extraction_dir.resolve()
+    with zipfile.ZipFile(archive_path) as archive:
+        members = archive.infolist()
+        total_members = len(members)
+        report_every = max(1, total_members // 100)
+        for i, member in enumerate(members, start=1):
+            _raise_if_canceled(cancel_callback)
+            destination_path = (extraction_dir / member.filename).resolve()
+            if os.path.commonpath([str(extraction_dir_resolved), str(destination_path)]) != str(extraction_dir_resolved):
+                raise RuntimeError(f"Archive contains an unsafe path: {member.filename}")
+            archive.extract(member, extraction_dir)
+            if i == total_members or i % report_every == 0:
+                _progress_callback(
+                    f"Extracting Meshroom ({i} of {total_members} files)...",
+                    i,
+                    total_members,
+                )
+
+
+def _extract_tarball(archive_path: Path, extraction_dir: Path, cancel_callback) -> None:
+    _raise_if_canceled(cancel_callback)
+    _progress_callback("Extracting Meshroom...", 0, 0)
+    extraction_dir_resolved = extraction_dir.resolve()
+    with tarfile.open(archive_path, "r:gz") as archive:
+        members = archive.getmembers()
+        total_members = len(members)
+        report_every = max(1, total_members // 100)
+        for i, member in enumerate(members, start=1):
+            _raise_if_canceled(cancel_callback)
+            destination_path = (extraction_dir / member.name).resolve()
+            if os.path.commonpath([str(extraction_dir_resolved), str(destination_path)]) != str(extraction_dir_resolved):
+                raise RuntimeError(f"Archive contains an unsafe path: {member.name}")
+            archive.extract(member, extraction_dir, filter="data")
+            if i == total_members or i % report_every == 0:
+                _progress_callback(
+                    f"Extracting Meshroom ({i} of {total_members} files)...",
+                    i,
+                    total_members,
+                )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Download and extract Meshroom.")
+    parser.add_argument("--destination", required=True, help="Directory where Meshroom will be extracted.")
+    parser.add_argument("--work-dir", required=True, help="Temporary work directory for the archive download.")
+    parser.add_argument("--archive-url", required=True, help="URL of the Meshroom archive to download.")
+    parser.add_argument("--cancel-file", default="", help="Sentinel file; if it exists, installation exits as canceled.")
+    args = parser.parse_args(argv)
+
+    cancel_file = Path(args.cancel_file) if args.cancel_file else None
+    cancel_callback = cancel_file.exists if cancel_file is not None else None
+
+    destination = Path(args.destination)
+    work_dir = Path(args.work_dir)
+    url = args.archive_url
+
+    archive_name = url.rsplit("/", 1)[-1]
+    archive_path = work_dir / archive_name
+
+    try:
+        _download_archive(url, archive_path, cancel_callback)
+        if archive_name.endswith(".tar.gz") or archive_name.endswith(".tgz"):
+            _extract_tarball(archive_path, destination, cancel_callback)
+        else:
+            _extract_zip(archive_path, destination, cancel_callback)
+    except MeshroomInstallCanceled as exc:
+        _emit_progress_event({"message": str(exc), "value": 0, "maximum": 0, "success": False, "canceled": True})
+        return 2
+    except Exception as exc:
+        _emit_progress_event({"message": str(exc), "value": 0, "maximum": 0, "success": False, "error": str(exc)})
+        print(str(exc), file=sys.stderr, flush=True)
+        return 1
+
+    _emit_progress_event({"message": "Meshroom installed.", "value": 1, "maximum": 1, "success": True})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
@@ -35,7 +35,7 @@ def _download_archive(url: str, archive_path: Path, cancel_callback) -> None:
 
     with urllib.request.urlopen(url, timeout=DOWNLOAD_SOCKET_TIMEOUT_SECONDS) as response:
         total_size = int(response.headers.get("Content-Length") or 0)
-        total_mb = max(1, total_size // BYTES_PER_MB) if total_size else 0
+        total_mb = max(1, (total_size + BYTES_PER_MB - 1) // BYTES_PER_MB) if total_size else 0
         downloaded_size = 0
         last_reported_mb = -1
 

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_cli.py
@@ -102,7 +102,7 @@ def _extract_tarball(archive_path: Path, extraction_dir: Path, cancel_callback) 
             destination_path = (extraction_dir / member.name).resolve()
             if os.path.commonpath([str(extraction_dir_resolved), str(destination_path)]) != str(extraction_dir_resolved):
                 raise RuntimeError(f"Archive contains an unsafe path: {member.name}")
-            archive.extract(member, extraction_dir, filter="data")
+            archive.extract(member, extraction_dir, filter="tar")
             if i == total_members or i % report_every == 0:
                 _progress_callback(
                     f"Extracting Meshroom ({i} of {total_members} files)...",

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
@@ -1,0 +1,345 @@
+import json
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import qt
+import slicer
+
+from OpenLIFULib.meshroom_install_cli import PROGRESS_LINE_PREFIX
+
+logger = logging.getLogger(__name__)
+
+MESHROOM_VERSION = "2025.1.0"
+MESHROOM_WINDOWS_URL = "https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Windows.zip"
+MESHROOM_LINUX_URL = "https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Linux.tar.gz"
+MESHROOM_EXTRACTED_DIR_NAME = "Meshroom-2025.1.0"
+
+
+def meshroom_install_cli_path() -> Path:
+    return Path(__file__).resolve().with_name("meshroom_install_cli.py")
+
+
+class MeshroomInstallController:
+    def __init__(
+        self,
+        parent,
+        on_finished: Callable[[bool], None],
+    ) -> None:
+        self.parent = parent
+        self._on_finished_callback = on_finished
+
+        self._process: Optional[qt.QProcess] = None
+        self._dialog: Optional[qt.QProgressDialog] = None
+        self._destination: Optional[Path] = None
+        self._work_dir: Optional[Path] = None
+        self._cancel_file: Optional[Path] = None
+        self._background_canceled_process: Optional[qt.QProcess] = None
+        self._reset_output_state()
+
+    def is_active(self) -> bool:
+        return self._process is not None
+
+    def cleanup(self) -> None:
+        if self._process is not None:
+            self.cancel_install()
+
+    def start_install(self, destination: Path, archive_url: str) -> bool:
+        if self.is_active():
+            slicer.util.warningDisplay("Meshroom installation is already in progress.")
+            return False
+        if self._background_canceled_process is not None:
+            slicer.util.warningDisplay(
+                "The previous Meshroom installation is still canceling. Please wait a moment and try again."
+            )
+            return False
+
+        python_slicer = shutil.which("PythonSlicer")
+        if python_slicer is None:
+            slicer.util.errorDisplay("PythonSlicer was not found on PATH.")
+            return False
+
+        cli_path = meshroom_install_cli_path()
+        if not cli_path.is_file():
+            slicer.util.errorDisplay(f"Meshroom install helper was not found: {cli_path}")
+            return False
+
+        self._destination = destination
+        self._destination.mkdir(parents=True, exist_ok=True)
+        self._work_dir = Path(
+            tempfile.mkdtemp(
+                prefix=".meshroom-install-",
+                dir=self._destination,
+            )
+        )
+        self._cancel_file = self._work_dir / "cancel-requested"
+        self._reset_output_state()
+
+        progress_dialog = qt.QProgressDialog(
+            "Downloading Meshroom. This is a large download and may take several minutes.",
+            "Cancel",
+            0,
+            0,
+            self.parent,
+        )
+        progress_dialog.setWindowTitle("Installing Meshroom")
+        progress_dialog.setAutoClose(False)
+        progress_dialog.setAutoReset(False)
+        progress_dialog.setMinimumDuration(0)
+        progress_dialog.setWindowModality(qt.Qt.ApplicationModal)
+        progress_dialog.setRange(0, 0)
+        progress_dialog.canceled.connect(self.cancel_install)
+        progress_dialog.show()
+        slicer.app.processEvents()
+        self._dialog = progress_dialog
+
+        process = qt.QProcess()
+        process.readyReadStandardOutput.connect(self._on_stdout_ready)
+        process.readyReadStandardError.connect(self._on_stderr_ready)
+        process.finished.connect(self._on_finished)
+        process.errorOccurred.connect(self._on_process_error)
+        self._process = process
+
+        args = [
+            str(cli_path),
+            "--destination", str(self._destination),
+            "--work-dir", str(self._work_dir),
+            "--archive-url", archive_url,
+            "--cancel-file", str(self._cancel_file),
+        ]
+
+        process.start(python_slicer, args)
+        if not process.waitForStarted(3000):
+            error_message = process.errorString() or "The Meshroom install helper process failed to start."
+            self._complete_install(False, error_message)
+            return False
+        return True
+
+    def cancel_install(self) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._was_canceled = True
+        self._request_child_cancel()
+        if self._dialog is not None:
+            self._dialog.setLabelText("Canceling Meshroom installation...")
+
+        if process.state() == qt.QProcess.NotRunning:
+            self._complete_install(False, canceled=True)
+            return
+
+        self._detach_canceled_process(process, self._work_dir)
+        self._process = None
+        self._work_dir = None
+        self._cancel_file = None
+        self._complete_install(False, canceled=True)
+
+    def _request_child_cancel(self) -> None:
+        cancel_file = self._cancel_file
+        if cancel_file is None:
+            return
+        try:
+            cancel_file.parent.mkdir(parents=True, exist_ok=True)
+            cancel_file.write_text("cancel\n", encoding="utf-8")
+        except Exception as exc:
+            self._append_diagnostic(f"Could not write cancel file: {exc}")
+
+    def _detach_canceled_process(self, process, work_dir: Optional[Path]) -> None:
+        self._disconnect_process_signals(process)
+        self._background_canceled_process = process
+
+        def cleanup_detached_process(*args, detached_process=process, detached_work_dir=work_dir):
+            self._cleanup_detached_process(detached_process, detached_work_dir)
+
+        process.finished.connect(cleanup_detached_process)
+        if process.state() == qt.QProcess.NotRunning:
+            cleanup_detached_process()
+
+    def _cleanup_detached_process(self, process, work_dir: Optional[Path]) -> None:
+        try:
+            process.finished.disconnect()
+        except Exception:
+            pass
+        if self._background_canceled_process is process:
+            self._background_canceled_process = None
+        process.deleteLater()
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def _on_stdout_ready(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        self._stdout_buffer += process.readAllStandardOutput().data().decode("utf-8", errors="replace")
+        self._consume_stdout_lines()
+
+    def _on_stderr_ready(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        self._stderr_buffer += process.readAllStandardError().data().decode("utf-8", errors="replace")
+        self._consume_stderr_lines()
+
+    def _consume_stdout_lines(self, flush: bool = False) -> None:
+        while "\n" in self._stdout_buffer:
+            line, self._stdout_buffer = self._stdout_buffer.split("\n", 1)
+            self._handle_stdout_line(line.rstrip("\r"))
+        if flush and self._stdout_buffer:
+            line = self._stdout_buffer
+            self._stdout_buffer = ""
+            self._handle_stdout_line(line.rstrip("\r"))
+
+    def _consume_stderr_lines(self, flush: bool = False) -> None:
+        while "\n" in self._stderr_buffer:
+            line, self._stderr_buffer = self._stderr_buffer.split("\n", 1)
+            self._append_diagnostic(line.rstrip("\r"))
+        if flush and self._stderr_buffer:
+            line = self._stderr_buffer
+            self._stderr_buffer = ""
+            self._append_diagnostic(line.rstrip("\r"))
+
+    def _append_diagnostic(self, line: str) -> None:
+        line = line.strip()
+        if not line:
+            return
+        logger.info("Meshroom install: %s", line)
+        self._diagnostics.append(line)
+        self._diagnostics = self._diagnostics[-40:]
+
+    def _handle_stdout_line(self, line: str) -> None:
+        line = line.strip()
+        if not line:
+            return
+        if not line.startswith(PROGRESS_LINE_PREFIX):
+            self._append_diagnostic(line)
+            return
+        try:
+            progress_event = json.loads(line[len(PROGRESS_LINE_PREFIX):])
+        except json.JSONDecodeError as exc:
+            self._append_diagnostic(f"Could not parse progress line: {exc}: {line}")
+            return
+
+        message = str(progress_event.get("message") or "")
+        value = int(progress_event.get("value") or 0)
+        maximum = int(progress_event.get("maximum") or 0)
+        if message:
+            self._update_progress(message, value, maximum)
+
+        if "success" in progress_event:
+            if progress_event["success"]:
+                self._child_succeeded = True
+            else:
+                self._child_error = str(
+                    progress_event.get("error") or progress_event.get("message") or "Meshroom installation failed."
+                )
+
+    def _on_process_error(self, process_error) -> None:
+        process = self._process
+        if process is not None:
+            self._process_error = process.errorString()
+
+    def _update_progress(self, message: str, value: int, maximum: int) -> None:
+        progress_dialog = self._dialog
+        if progress_dialog is None:
+            return
+        if maximum <= 0:
+            progress_dialog.setRange(0, 0)
+        else:
+            progress_dialog.setRange(0, maximum)
+            progress_dialog.setValue(value)
+        progress_dialog.setLabelText(message)
+
+    def _on_finished(self, *args) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        self._on_stdout_ready()
+        self._on_stderr_ready()
+        self._consume_stdout_lines(flush=True)
+        self._consume_stderr_lines(flush=True)
+
+        if self._was_canceled:
+            self._complete_install(False, canceled=True)
+            return
+
+        exit_code = args[0] if args else process.exitCode()
+        if self._child_succeeded and not self._child_error and exit_code == 0:
+            self._complete_install(True)
+            return
+
+        self._complete_install(False, self._failure_message(exit_code))
+
+    def _failure_message(self, exit_code: int) -> str:
+        if self._child_error:
+            message = self._child_error
+        elif self._process_error:
+            message = self._process_error
+        elif exit_code != 0:
+            message = f"Meshroom install subprocess failed with exit code {exit_code}."
+        else:
+            message = "Meshroom install subprocess finished without reporting success."
+        if self._diagnostics:
+            message += "\n\nChild process output:\n" + "\n".join(self._diagnostics[-10:])
+        return message
+
+    def _complete_install(
+        self,
+        succeeded: bool,
+        error_message: str = "",
+        canceled: bool = False,
+    ) -> None:
+        process = self._process
+        self._process = None
+        if process is not None:
+            process.deleteLater()
+
+        if self._dialog is not None:
+            self._dialog.close()
+            self._dialog = None
+
+        self._destination = None
+
+        work_dir = self._work_dir
+        self._work_dir = None
+        self._cancel_file = None
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+        if canceled:
+            self._reset_output_state()
+            self._on_finished_callback(False)
+            return
+
+        if not succeeded:
+            slicer.util.errorDisplay(f"Failed to install Meshroom:\n{error_message}")
+            self._reset_output_state()
+            self._on_finished_callback(False)
+            return
+
+        self._reset_output_state()
+        self._on_finished_callback(True)
+
+    def _disconnect_process_signals(self, process) -> None:
+        for signal, slot in (
+            (process.readyReadStandardOutput, self._on_stdout_ready),
+            (process.readyReadStandardError, self._on_stderr_ready),
+            (process.finished, self._on_finished),
+            (process.errorOccurred, self._on_process_error),
+        ):
+            try:
+                signal.disconnect(slot)
+            except Exception:
+                pass
+
+    def _reset_output_state(self) -> None:
+        self._stdout_buffer = ""
+        self._stderr_buffer = ""
+        self._diagnostics: List[str] = []
+        self._child_succeeded = False
+        self._child_error = ""
+        self._process_error = ""
+        self._was_canceled = False

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
@@ -47,9 +47,12 @@ def restore_meshroom_path() -> Optional[Path]:
         return None
 
     meshroom_dir = str(executable.parent)
-    path_entries = os.environ.get("PATH", "").split(os.pathsep)
-    if meshroom_dir not in path_entries:
-        os.environ["PATH"] = os.pathsep.join([meshroom_dir, *path_entries])
+    path_entries = [
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry and entry != meshroom_dir
+    ]
+    os.environ["PATH"] = os.pathsep.join([meshroom_dir, *path_entries])
 
     return executable
 

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -16,10 +17,41 @@ MESHROOM_VERSION = "2025.1.0"
 MESHROOM_WINDOWS_URL = "https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Windows.zip"
 MESHROOM_LINUX_URL = "https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Linux.tar.gz"
 MESHROOM_EXTRACTED_DIR_NAME = "Meshroom-2025.1.0"
+MESHROOM_EXECUTABLE_SETTINGS_KEY = "OpenLIFU/meshroomExecutablePath" # The QSettings key used to persist the path to the installed meshroom_batch executable.
 
 
 def meshroom_install_cli_path() -> Path:
     return Path(__file__).resolve().with_name("meshroom_install_cli.py")
+
+
+def save_meshroom_path(executable: Path) -> None:
+    """Persist the path to the installed meshroom_batch executable in QSettings."""
+    qt.QSettings().setValue(MESHROOM_EXECUTABLE_SETTINGS_KEY, str(executable))
+
+
+def restore_meshroom_path() -> Optional[Path]:
+    """Look up the meshroom_batch executable saved by `save_meshroom_path`.
+
+    If found and still valid, ensures its directory is on the current process's
+    PATH and returns it. If the saved path no longer points to a real file, the
+    stale setting is cleared and None is returned.
+    """
+    settings = qt.QSettings()
+    saved_path = settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY, "")
+    if not saved_path:
+        return None
+
+    executable = Path(str(saved_path))
+    if not executable.is_file():
+        settings.remove(MESHROOM_EXECUTABLE_SETTINGS_KEY)
+        return None
+
+    meshroom_dir = str(executable.parent)
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    if meshroom_dir not in path_entries:
+        os.environ["PATH"] = os.pathsep.join([meshroom_dir, *path_entries])
+
+    return executable
 
 
 class MeshroomInstallController:

--- a/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
+++ b/OpenLIFULib/OpenLIFULib/meshroom_install_gui.py
@@ -71,24 +71,30 @@ class MeshroomInstallController:
         self._destination: Optional[Path] = None
         self._work_dir: Optional[Path] = None
         self._cancel_file: Optional[Path] = None
-        self._background_canceled_process: Optional[qt.QProcess] = None
         self._reset_output_state()
 
     def is_active(self) -> bool:
         return self._process is not None
 
     def cleanup(self) -> None:
-        if self._process is not None:
-            self.cancel_install()
+        process = self._process
+        if process is None:
+            return
+
+        self._on_finished_callback = lambda succeeded: None
+        self._was_canceled = True
+        self._request_child_cancel()
+        self._disconnect_process_signals(process)
+        if process.state() != qt.QProcess.NotRunning:
+            process.terminate()
+            if not process.waitForFinished(2000):
+                process.kill()
+                process.waitForFinished(2000)
+        self._complete_install(False, canceled=True)
 
     def start_install(self, destination: Path, archive_url: str) -> bool:
         if self.is_active():
             slicer.util.warningDisplay("Meshroom installation is already in progress.")
-            return False
-        if self._background_canceled_process is not None:
-            slicer.util.warningDisplay(
-                "The previous Meshroom installation is still canceling. Please wait a moment and try again."
-            )
             return False
 
         python_slicer = shutil.which("PythonSlicer")
@@ -156,21 +162,19 @@ class MeshroomInstallController:
         process = self._process
         if process is None:
             return
+        if self._was_canceled:
+            return
 
         self._was_canceled = True
         self._request_child_cancel()
         if self._dialog is not None:
             self._dialog.setLabelText("Canceling Meshroom installation...")
+            self._dialog.setRange(0, 0)
+            self._dialog.setCancelButton(None)
+            self._dialog.show()
 
         if process.state() == qt.QProcess.NotRunning:
             self._complete_install(False, canceled=True)
-            return
-
-        self._detach_canceled_process(process, self._work_dir)
-        self._process = None
-        self._work_dir = None
-        self._cancel_file = None
-        self._complete_install(False, canceled=True)
 
     def _request_child_cancel(self) -> None:
         cancel_file = self._cancel_file
@@ -181,28 +185,6 @@ class MeshroomInstallController:
             cancel_file.write_text("cancel\n", encoding="utf-8")
         except Exception as exc:
             self._append_diagnostic(f"Could not write cancel file: {exc}")
-
-    def _detach_canceled_process(self, process, work_dir: Optional[Path]) -> None:
-        self._disconnect_process_signals(process)
-        self._background_canceled_process = process
-
-        def cleanup_detached_process(*args, detached_process=process, detached_work_dir=work_dir):
-            self._cleanup_detached_process(detached_process, detached_work_dir)
-
-        process.finished.connect(cleanup_detached_process)
-        if process.state() == qt.QProcess.NotRunning:
-            cleanup_detached_process()
-
-    def _cleanup_detached_process(self, process, work_dir: Optional[Path]) -> None:
-        try:
-            process.finished.disconnect()
-        except Exception:
-            pass
-        if self._background_canceled_process is process:
-            self._background_canceled_process = None
-        process.deleteLater()
-        if work_dir is not None:
-            shutil.rmtree(work_dir, ignore_errors=True)
 
     def _on_stdout_ready(self) -> None:
         process = self._process

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1,6 +1,7 @@
 # Standard library imports
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -589,6 +590,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self._default_anonymous_user = None  # initialized after dependency check
         self._default_admin_user = None  # initialized after dependency check
         self._last_active_user = self._default_anonymous_user
+        self._meshroom_install_controller = None
 
     def setup(self) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
@@ -631,6 +633,8 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self._checkOpenLIFUVersionStatus()
         self.ui.installADBPushButton.clicked.connect(self.onInstallADBClicked)
         self._checkADBStatus()
+        self.ui.installMeshroomPushButton.clicked.connect(self.onInstallMeshroomClicked)
+        self._checkMeshroomStatus()
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
@@ -678,6 +682,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
                 self.logic.active_user = self._default_anonymous_user
             self.updateWidgetLoginState(self._cur_login_state)
             self._checkOpenLIFUVersionStatus()
+        self._checkMeshroomStatus()
         self.updateLoginStateNotificationLabel()
 
     def exit(self) -> None:
@@ -1143,6 +1148,130 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
             "    sudo apt install android-tools-adb\n\n"
             "After installing, reopen the application to verify."
         )
+
+    def _checkMeshroomStatus(self) -> None:
+        meshroom_path = shutil.which("meshroom_batch")
+
+        icon_name = qt.QStyle.SP_DialogApplyButton if meshroom_path else qt.QStyle.SP_DialogCancelButton
+        pixmap = slicer.app.style().standardIcon(icon_name).pixmap(qt.QSize(16, 16))
+        self.ui.meshroomStatusIcon.setPixmap(pixmap)
+        self.ui.meshroomStatusIcon.setText("")
+
+        if meshroom_path:
+            meshroom_dir = Path(meshroom_path).parent
+            dir_name = meshroom_dir.name
+            version_str = dir_name[len("Meshroom-"):] if dir_name.startswith("Meshroom-") else "installed"
+            self.ui.installMeshroomPushButton.setEnabled(False)
+            self.ui.installMeshroomPushButton.setText(f"Meshroom {version_str}")
+        else:
+            self.ui.installMeshroomPushButton.setEnabled(True)
+            self.ui.installMeshroomPushButton.setText("Install Meshroom 2025")
+
+    @display_errors
+    def onInstallMeshroomClicked(self, checked: bool = False) -> None:
+        if sys.platform.startswith("win"):
+            self._installMeshroomWindows()
+        elif sys.platform.startswith("linux"):
+            self._installMeshroomLinux()
+        elif sys.platform == "darwin":
+            slicer.util.infoDisplay("Meshroom does not provide macOS binaries.")
+        else:
+            slicer.util.infoDisplay("Meshroom installation is not supported on this platform.")
+
+    def _startMeshroomInstall(self, archive_url: str) -> None:
+        selected_dir = qt.QFileDialog.getExistingDirectory(
+            slicer.util.mainWindow(),
+            "Choose installation directory for Meshroom",
+            str(Path.home()),
+            qt.QFileDialog.ShowDirsOnly,
+        )
+        if not selected_dir:
+            return
+
+        from OpenLIFULib.meshroom_install_gui import MeshroomInstallController
+
+        self.ui.installMeshroomPushButton.setEnabled(False)
+        self._meshroom_install_controller = MeshroomInstallController(
+            parent=slicer.util.mainWindow(),
+            on_finished=lambda succeeded: self._onMeshroomInstallFinished(succeeded, Path(selected_dir)),
+        )
+        self._meshroom_install_controller.start_install(Path(selected_dir), archive_url)
+
+    def _installMeshroomWindows(self) -> None:
+        from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_WINDOWS_URL
+
+        if not slicer.util.confirmYesNoDisplay(
+            f"This will download Meshroom {MESHROOM_VERSION} (~10 GB) from Zenodo "
+            "and add the installation directory to your Windows user PATH. "
+            "This is a large download and may take a while. Continue?"
+        ):
+            return
+
+        self._startMeshroomInstall(MESHROOM_WINDOWS_URL)
+
+    def _installMeshroomLinux(self) -> None:
+        from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_LINUX_URL
+
+        if not slicer.util.confirmYesNoDisplay(
+            f"This will download Meshroom {MESHROOM_VERSION} (~13 GB) from Zenodo "
+            "and extract it to a directory of your choice. "
+            "This is a large download and may take a while. Continue?"
+        ):
+            return
+
+        self._startMeshroomInstall(MESHROOM_LINUX_URL)
+
+    def _onMeshroomInstallFinished(self, succeeded: bool, install_dir: Path) -> None:
+        if succeeded:
+            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_EXTRACTED_DIR_NAME
+            meshroom_bin_path = str(install_dir / MESHROOM_EXTRACTED_DIR_NAME)
+
+            os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + meshroom_bin_path
+
+            # Write to Windows user PATH registry key for persistence across sessions
+            # User PATH does not require admin permissions
+            if sys.platform.startswith("win"):
+                import winreg
+                try:
+                    with winreg.CreateKey(
+                        winreg.HKEY_CURRENT_USER, "Environment",
+                    ) as reg_key:
+                        try:
+                            current_path, _ = winreg.QueryValueEx(reg_key, "Path")
+                        except FileNotFoundError:
+                            current_path = ""
+                        entries = [p for p in current_path.split(os.pathsep) if p]
+                        if meshroom_bin_path not in entries:
+                            entries.append(meshroom_bin_path)
+                            winreg.SetValueEx(reg_key, "Path", 0, winreg.REG_EXPAND_SZ,
+                                              os.pathsep.join(entries))
+                except OSError as e:
+                    slicer.util.warningDisplay(
+                        f"Meshroom installed, but PATH could not be saved to the registry ({e}). "
+                        f"Add {meshroom_bin_path} to your user PATH manually to persist after restart."
+                    )
+
+                slicer.util.infoDisplay(
+                    f"Meshroom {MESHROOM_VERSION} installed successfully.\n\n"
+                    "To enable GPU acceleration for Meshroom:\n\n"
+                    "1. Open the NVIDIA Control Panel from the Start menu or system tray.\n"
+                    "2. In the left sidebar under '3D Settings', click 'Manage 3D settings'.\n"
+                    "3. Go to the 'Program Settings' tab.\n"
+                    "4. Click 'Add', then browse to and select meshroom_batch.exe\n"
+                    f"   from the folder where Meshroom was installed ({meshroom_bin_path}).\n"
+                    "5. Under 'Select the preferred graphics processor for this program',\n"
+                    "   choose 'High-performance NVIDIA processor'.\n"
+                    "6. Click 'Apply'."
+                )
+            else:
+                slicer.util.infoDisplay(
+                    f"Meshroom {MESHROOM_VERSION} installed successfully.\n\n"
+                    f"To persist across sessions, add the following to your shell profile:\n"
+                    f"    export PATH=\"$PATH:{meshroom_bin_path}\""
+                )
+
+        self._meshroom_install_controller = None
+        self._checkMeshroomStatus()
 
 # OpenLIFULoginLogic
 #

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1343,3 +1343,259 @@ class OpenLIFULoginLogic(ScriptedLoadableModuleLogic):
 
         newOpenLIFUuser = openlifu.db.User.from_dict(user_parameters)
         get_cur_db().write_user(newOpenLIFUuser, on_conflict = openlifu.db.database.OnConflictOpts.OVERWRITE)
+
+
+class OpenLIFULoginTest(ScriptedLoadableModuleTest):
+    """
+    This is the test case for your scripted module.
+    Uses ScriptedLoadableModuleTest base class, available at:
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
+    """
+
+    def _python_slicer_or_skip(self) -> str:
+        python_slicer = shutil.which("PythonSlicer")
+        if python_slicer is None:
+            self.skipTest("PythonSlicer was not found.")
+        return python_slicer
+
+    def _run_python_slicer_script(self, script_path: Path, args: List[str], timeout_seconds: float = 120.0):
+        proc = slicer.util.launchConsoleProcess(
+            [self._python_slicer_or_skip(), str(script_path), *args],
+            useStartupEnvironment=False,
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            self.fail(
+                f"PythonSlicer process timed out after {timeout_seconds} seconds.\n"
+                f"stdout:\n{stdout or ''}\n"
+                f"stderr:\n{stderr or ''}"
+            )
+        return proc.returncode, stdout or "", stderr or ""
+
+    def _process_events_until(self, condition: Callable[[], bool], timeout_seconds: float = 10.0) -> bool:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            slicer.app.processEvents()
+            if condition():
+                return True
+            qt.QThread.msleep(10)
+        slicer.app.processEvents()
+        return condition()
+
+    def _write_fake_meshroom_zip(self, archive_path: Path, extracted_dir_name: str) -> None:
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr(f"{extracted_dir_name}/meshroom_batch.exe", "fake executable")
+            archive.writestr(f"{extracted_dir_name}/meshroom_batch", "fake executable")
+            archive.writestr(f"{extracted_dir_name}/README.md", "Meshroom")
+
+    def _write_fake_meshroom_tarball(self, archive_path: Path, extracted_dir_name: str) -> None:
+        import tarfile
+        with tarfile.open(archive_path, "w:gz") as archive:
+            import io
+            for name, content in [
+                (f"{extracted_dir_name}/meshroom_batch", "fake executable"),
+                (f"{extracted_dir_name}/README.md", "Meshroom"),
+            ]:
+                data = content.encode("utf-8")
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+
+    def test_meshroom_install_cli_extracts_zip(self):
+        from OpenLIFULib.meshroom_install_cli import PROGRESS_LINE_PREFIX
+        from OpenLIFULib.meshroom_install_gui import meshroom_install_cli_path
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            archive_path = temp_dir_path / "Meshroom-2025.1.0-Windows.zip"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            work_dir = temp_dir_path / "work"
+            work_dir.mkdir()
+
+            self._write_fake_meshroom_zip(archive_path, "Meshroom-2025.1.0")
+
+            returncode, stdout, stderr = self._run_python_slicer_script(
+                meshroom_install_cli_path(),
+                [
+                    "--destination", str(destination),
+                    "--work-dir", str(work_dir),
+                    "--archive-url", archive_path.as_uri(),
+                ],
+            )
+
+            self.assertEqual(
+                0, returncode,
+                msg=f"stdout:\n{stdout}\nstderr:\n{stderr}",
+            )
+            progress_events = [
+                json.loads(line[len(PROGRESS_LINE_PREFIX):])
+                for line in stdout.splitlines()
+                if line.startswith(PROGRESS_LINE_PREFIX)
+            ]
+            self.assertTrue(progress_events)
+            self.assertTrue(progress_events[-1].get("success"))
+            self.assertTrue((destination / "Meshroom-2025.1.0" / "meshroom_batch.exe").exists())
+
+    def test_meshroom_install_cli_extracts_tarball(self):
+        from OpenLIFULib.meshroom_install_cli import PROGRESS_LINE_PREFIX
+        from OpenLIFULib.meshroom_install_gui import meshroom_install_cli_path
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            archive_path = temp_dir_path / "Meshroom-2025.1.0-Linux.tar.gz"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            work_dir = temp_dir_path / "work"
+            work_dir.mkdir()
+
+            self._write_fake_meshroom_tarball(archive_path, "Meshroom-2025.1.0")
+
+            returncode, stdout, stderr = self._run_python_slicer_script(
+                meshroom_install_cli_path(),
+                [
+                    "--destination", str(destination),
+                    "--work-dir", str(work_dir),
+                    "--archive-url", archive_path.as_uri(),
+                ],
+            )
+
+            self.assertEqual(
+                0, returncode,
+                msg=f"stdout:\n{stdout}\nstderr:\n{stderr}",
+            )
+            progress_events = [
+                json.loads(line[len(PROGRESS_LINE_PREFIX):])
+                for line in stdout.splitlines()
+                if line.startswith(PROGRESS_LINE_PREFIX)
+            ]
+            self.assertTrue(progress_events)
+            self.assertTrue(progress_events[-1].get("success"))
+            self.assertTrue((destination / "Meshroom-2025.1.0" / "meshroom_batch").exists())
+
+    def test_meshroom_install_cli_cancel(self):
+        from OpenLIFULib.meshroom_install_cli import PROGRESS_LINE_PREFIX
+        from OpenLIFULib.meshroom_install_gui import meshroom_install_cli_path
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            work_dir = temp_dir_path / "work"
+            work_dir.mkdir()
+            cancel_file = work_dir / "cancel-requested"
+            cancel_file.write_text("cancel\n", encoding="utf-8")
+
+            returncode, stdout, stderr = self._run_python_slicer_script(
+                meshroom_install_cli_path(),
+                [
+                    "--destination", str(destination),
+                    "--work-dir", str(work_dir),
+                    "--archive-url", "file:///nonexistent-archive.zip",
+                    "--cancel-file", str(cancel_file),
+                ],
+            )
+
+            self.assertEqual(2, returncode)
+            progress_events = [
+                json.loads(line[len(PROGRESS_LINE_PREFIX):])
+                for line in stdout.splitlines()
+                if line.startswith(PROGRESS_LINE_PREFIX)
+            ]
+            self.assertTrue(progress_events)
+            self.assertTrue(progress_events[-1].get("canceled"))
+
+    def test_meshroom_install_controller_succeeds_with_local_archive(self):
+        self._python_slicer_or_skip()
+        from OpenLIFULib.meshroom_install_gui import MeshroomInstallController
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            archive_path = temp_dir_path / "Meshroom-2025.1.0-Windows.zip"
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+
+            self._write_fake_meshroom_zip(archive_path, "Meshroom-2025.1.0")
+
+            result = {}
+            controller = MeshroomInstallController(
+                parent=None,
+                on_finished=lambda succeeded: result.__setitem__("succeeded", succeeded),
+            )
+            try:
+                self.assertTrue(controller.start_install(destination, archive_path.as_uri()))
+                self.assertTrue(
+                    self._process_events_until(lambda: not controller.is_active(), timeout_seconds=30),
+                    "Meshroom install subprocess did not finish.",
+                )
+                self.assertTrue(result.get("succeeded"), "Controller reported failure.")
+                self.assertTrue((destination / "Meshroom-2025.1.0" / "meshroom_batch.exe").exists())
+            finally:
+                controller.cleanup()
+
+    def test_meshroom_install_controller_cancel(self):
+        self._python_slicer_or_skip()
+        from OpenLIFULib.meshroom_install_gui import MeshroomInstallController
+        from OpenLIFULib.meshroom_install_cli import PROGRESS_LINE_PREFIX
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+
+            slow_cli = temp_dir_path / "slow_meshroom_cli.py"
+            progress_payload = json.dumps({"message": "Waiting...", "value": 0, "maximum": 0})
+            slow_cli.write_text(
+                f"import argparse\n"
+                f"import time\n"
+                f"from pathlib import Path\n"
+                f"parser = argparse.ArgumentParser()\n"
+                f"parser.add_argument('--destination')\n"
+                f"parser.add_argument('--work-dir')\n"
+                f"parser.add_argument('--archive-url')\n"
+                f"parser.add_argument('--cancel-file', default='')\n"
+                f"args = parser.parse_args()\n"
+                f"print({(PROGRESS_LINE_PREFIX + progress_payload)!r}, flush=True)\n"
+                f"deadline = time.monotonic() + 30\n"
+                f"while time.monotonic() < deadline:\n"
+                f"    if args.cancel_file and Path(args.cancel_file).exists():\n"
+                f"        break\n"
+                f"    time.sleep(0.05)\n",
+                encoding="utf-8",
+            )
+
+            result = {}
+            controller = MeshroomInstallController(
+                parent=None,
+                on_finished=lambda succeeded: result.__setitem__("succeeded", succeeded),
+            )
+            try:
+                # Monkey-patch the cli_path to use our slow script
+                import OpenLIFULib.meshroom_install_gui as meshroom_gui
+                original_cli_path = meshroom_gui.meshroom_install_cli_path
+                meshroom_gui.meshroom_install_cli_path = lambda: slow_cli
+                try:
+                    self.assertTrue(controller.start_install(destination, "file:///unused.zip"))
+                finally:
+                    meshroom_gui.meshroom_install_cli_path = original_cli_path
+
+                self.assertTrue(
+                    self._process_events_until(lambda: controller.is_active(), timeout_seconds=10),
+                    "Meshroom install subprocess did not start.",
+                )
+
+                controller.cancel_install()
+                self.assertFalse(controller.is_active())
+                self.assertTrue(
+                    self._process_events_until(
+                        lambda: controller._background_canceled_process is None,
+                        timeout_seconds=10,
+                    ),
+                    "Canceled Meshroom install subprocess did not exit.",
+                )
+                self.assertFalse(result.get("succeeded", True))
+            finally:
+                controller.cleanup()

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1195,7 +1195,9 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
             parent=slicer.util.mainWindow(),
             on_finished=lambda succeeded: self._onMeshroomInstallFinished(succeeded, Path(selected_dir)),
         )
-        self._meshroom_install_controller.start_install(Path(selected_dir), archive_url)
+        if not self._meshroom_install_controller.start_install(Path(selected_dir), archive_url):
+            self._meshroom_install_controller = None
+            self._checkMeshroomStatus()
 
     def _installMeshroomWindows(self) -> None:
         from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_WINDOWS_URL

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1158,14 +1158,22 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         self.ui.meshroomStatusIcon.setText("")
 
         if meshroom_path:
+            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION
+
             meshroom_dir = Path(meshroom_path).parent
             dir_name = meshroom_dir.name
             version_str = dir_name[len("Meshroom-"):] if dir_name.startswith("Meshroom-") else "installed"
-            self.ui.installMeshroomPushButton.setEnabled(False)
-            self.ui.installMeshroomPushButton.setText(f"Meshroom {version_str}")
+            if version_str == MESHROOM_VERSION:
+                self.ui.installMeshroomPushButton.setEnabled(False)
+                self.ui.installMeshroomPushButton.setText(f"Meshroom {version_str}")
+            else:
+                self.ui.installMeshroomPushButton.setEnabled(True)
+                self.ui.installMeshroomPushButton.setText(
+                    f"Install Meshroom {MESHROOM_VERSION} (current version: {version_str})"
+                )
         else:
             self.ui.installMeshroomPushButton.setEnabled(True)
-            self.ui.installMeshroomPushButton.setText("Install Meshroom 2025")
+            self.ui.installMeshroomPushButton.setText("Install Meshroom {MESHROOM_VERSION}")
 
     @display_errors
     def onInstallMeshroomClicked(self, checked: bool = False) -> None:

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -669,6 +669,9 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
+        if self._meshroom_install_controller is not None:
+            self._meshroom_install_controller.cleanup()
+            self._meshroom_install_controller = None
         self.removeObservers()
 
     def enter(self) -> None:
@@ -1607,16 +1610,50 @@ class OpenLIFULoginTest(ScriptedLoadableModuleTest):
                 )
 
                 controller.cancel_install()
-                self.assertFalse(controller.is_active())
+                self.assertTrue(controller.is_active())
+                self.assertNotIn("succeeded", result)
                 self.assertTrue(
                     self._process_events_until(
-                        lambda: controller._background_canceled_process is None,
+                        lambda: not controller.is_active(),
                         timeout_seconds=10,
                     ),
                     "Canceled Meshroom install subprocess did not exit.",
                 )
                 self.assertFalse(result.get("succeeded", True))
             finally:
+                controller.cleanup()
+
+    def test_meshroom_install_controller_cleanup_stops_process(self):
+        self._python_slicer_or_skip()
+        from OpenLIFULib.meshroom_install_gui import MeshroomInstallController
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            destination = temp_dir_path / "destination"
+            destination.mkdir()
+            slow_cli = temp_dir_path / "slow_meshroom_cli.py"
+            slow_cli.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
+
+            result = {}
+            controller = MeshroomInstallController(
+                parent=None,
+                on_finished=lambda succeeded: result.__setitem__("succeeded", succeeded),
+            )
+            import OpenLIFULib.meshroom_install_gui as meshroom_gui
+            original_cli_path = meshroom_gui.meshroom_install_cli_path
+            meshroom_gui.meshroom_install_cli_path = lambda: slow_cli
+            try:
+                self.assertTrue(controller.start_install(destination, "file:///unused.zip"))
+                process = controller._process
+                self.assertIsNotNone(process)
+
+                controller.cleanup()
+
+                self.assertFalse(controller.is_active())
+                self.assertEqual(qt.QProcess.NotRunning, process.state())
+                self.assertEqual({}, result)
+            finally:
+                meshroom_gui.meshroom_install_cli_path = original_cli_path
                 controller.cleanup()
 
     def test_save_and_restore_meshroom_path(self):

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1150,18 +1150,22 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         )
 
     def _checkMeshroomStatus(self) -> None:
-        meshroom_path = shutil.which("meshroom_batch")
+        from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, restore_meshroom_path, save_meshroom_path
 
-        icon_name = qt.QStyle.SP_DialogApplyButton if meshroom_path else qt.QStyle.SP_DialogCancelButton
+        meshroom_executable = restore_meshroom_path()
+        if meshroom_executable is None:
+            which_result = shutil.which("meshroom_batch")
+            if which_result:
+                meshroom_executable = Path(which_result)
+                save_meshroom_path(meshroom_executable) # Since it was previously not saved
+
+        icon_name = qt.QStyle.SP_DialogApplyButton if meshroom_executable else qt.QStyle.SP_DialogCancelButton
         pixmap = slicer.app.style().standardIcon(icon_name).pixmap(qt.QSize(16, 16))
         self.ui.meshroomStatusIcon.setPixmap(pixmap)
         self.ui.meshroomStatusIcon.setText("")
 
-        if meshroom_path:
-            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION
-
-            meshroom_dir = Path(meshroom_path).parent
-            dir_name = meshroom_dir.name
+        if meshroom_executable:
+            dir_name = meshroom_executable.parent.name
             version_str = dir_name[len("Meshroom-"):] if dir_name.startswith("Meshroom-") else "installed"
             if version_str == MESHROOM_VERSION:
                 self.ui.installMeshroomPushButton.setEnabled(False)
@@ -1173,7 +1177,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
                 )
         else:
             self.ui.installMeshroomPushButton.setEnabled(True)
-            self.ui.installMeshroomPushButton.setText("Install Meshroom {MESHROOM_VERSION}")
+            self.ui.installMeshroomPushButton.setText(f"Install Meshroom {MESHROOM_VERSION}")
 
     @display_errors
     def onInstallMeshroomClicked(self, checked: bool = False) -> None:
@@ -1233,8 +1237,11 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def _onMeshroomInstallFinished(self, succeeded: bool, install_dir: Path) -> None:
         if succeeded:
-            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_EXTRACTED_DIR_NAME
-            meshroom_bin_path = str(install_dir / MESHROOM_EXTRACTED_DIR_NAME)
+            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_EXTRACTED_DIR_NAME, save_meshroom_path
+            meshroom_bin_dir = install_dir / MESHROOM_EXTRACTED_DIR_NAME
+            meshroom_bin_path = str(meshroom_bin_dir)
+            meshroom_executable_name = "meshroom_batch.exe" if sys.platform.startswith("win") else "meshroom_batch"
+            save_meshroom_path(meshroom_bin_dir / meshroom_executable_name)
 
             os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + meshroom_bin_path
 
@@ -1275,9 +1282,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
                 )
             else:
                 slicer.util.infoDisplay(
-                    f"Meshroom {MESHROOM_VERSION} installed successfully.\n\n"
-                    f"To persist across sessions, add the following to your shell profile:\n"
-                    f"    export PATH=\"$PATH:{meshroom_bin_path}\""
+                    f"Meshroom {MESHROOM_VERSION} installed successfully."
                 )
 
         self._meshroom_install_controller = None
@@ -1609,3 +1614,58 @@ class OpenLIFULoginTest(ScriptedLoadableModuleTest):
                 self.assertFalse(result.get("succeeded", True))
             finally:
                 controller.cleanup()
+
+    def test_save_and_restore_meshroom_path(self):
+        from OpenLIFULib.meshroom_install_gui import (
+            MESHROOM_EXECUTABLE_SETTINGS_KEY,
+            save_meshroom_path,
+            restore_meshroom_path,
+        )
+
+        settings = qt.QSettings()
+        original_value = settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY, "")
+        original_path_env = os.environ.get("PATH", "")
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                executable = Path(temp_dir) / "meshroom_batch"
+                executable.write_text("fake executable")
+
+                save_meshroom_path(executable)
+                self.assertEqual(str(executable), settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY))
+
+                restored = restore_meshroom_path()
+
+                self.assertEqual(executable, restored)
+                self.assertIn(str(executable.parent), os.environ.get("PATH", "").split(os.pathsep))
+        finally:
+            if original_value:
+                settings.setValue(MESHROOM_EXECUTABLE_SETTINGS_KEY, original_value)
+            else:
+                settings.remove(MESHROOM_EXECUTABLE_SETTINGS_KEY)
+            os.environ["PATH"] = original_path_env
+
+    def test_restore_meshroom_path_clears_stale_entry(self):
+        from OpenLIFULib.meshroom_install_gui import (
+            MESHROOM_EXECUTABLE_SETTINGS_KEY,
+            save_meshroom_path,
+            restore_meshroom_path,
+        )
+
+        settings = qt.QSettings()
+        original_value = settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY, "")
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                executable = Path(temp_dir) / "meshroom_batch"
+                executable.write_text("fake executable")
+                save_meshroom_path(executable)
+                executable.unlink()
+
+                restored = restore_meshroom_path()
+
+            self.assertIsNone(restored)
+            self.assertEqual("", settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY, ""))
+        finally:
+            if original_value:
+                settings.setValue(MESHROOM_EXECUTABLE_SETTINGS_KEY, original_value)
+            else:
+                settings.remove(MESHROOM_EXECUTABLE_SETTINGS_KEY)

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -1237,13 +1237,17 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def _onMeshroomInstallFinished(self, succeeded: bool, install_dir: Path) -> None:
         if succeeded:
-            from OpenLIFULib.meshroom_install_gui import MESHROOM_VERSION, MESHROOM_EXTRACTED_DIR_NAME, save_meshroom_path
+            from OpenLIFULib.meshroom_install_gui import (
+                MESHROOM_VERSION,
+                MESHROOM_EXTRACTED_DIR_NAME,
+                restore_meshroom_path,
+                save_meshroom_path,
+            )
             meshroom_bin_dir = install_dir / MESHROOM_EXTRACTED_DIR_NAME
             meshroom_bin_path = str(meshroom_bin_dir)
             meshroom_executable_name = "meshroom_batch.exe" if sys.platform.startswith("win") else "meshroom_batch"
             save_meshroom_path(meshroom_bin_dir / meshroom_executable_name)
-
-            os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + meshroom_bin_path
+            restore_meshroom_path()
 
             # Write to Windows user PATH registry key for persistence across sessions
             # User PATH does not require admin permissions
@@ -1627,8 +1631,21 @@ class OpenLIFULoginTest(ScriptedLoadableModuleTest):
         original_path_env = os.environ.get("PATH", "")
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
-                executable = Path(temp_dir) / "meshroom_batch"
+                temp_dir_path = Path(temp_dir)
+                executable_name = "meshroom_batch.exe" if sys.platform.startswith("win") else "meshroom_batch"
+                old_meshroom_dir = temp_dir_path / "Meshroom-2024.1.0"
+                configured_meshroom_dir = temp_dir_path / "Meshroom-2025.1.0"
+                old_meshroom_dir.mkdir()
+                configured_meshroom_dir.mkdir()
+                old_executable = old_meshroom_dir / executable_name
+                executable = configured_meshroom_dir / executable_name
+                old_executable.write_text("fake old executable")
                 executable.write_text("fake executable")
+                old_executable.chmod(0o755)
+                executable.chmod(0o755)
+                os.environ["PATH"] = os.pathsep.join(
+                    [str(old_meshroom_dir), str(configured_meshroom_dir), original_path_env]
+                )
 
                 save_meshroom_path(executable)
                 self.assertEqual(str(executable), settings.value(MESHROOM_EXECUTABLE_SETTINGS_KEY))
@@ -1636,7 +1653,10 @@ class OpenLIFULoginTest(ScriptedLoadableModuleTest):
                 restored = restore_meshroom_path()
 
                 self.assertEqual(executable, restored)
-                self.assertIn(str(executable.parent), os.environ.get("PATH", "").split(os.pathsep))
+                path_entries = os.environ.get("PATH", "").split(os.pathsep)
+                self.assertEqual(str(configured_meshroom_dir), path_entries[0])
+                self.assertEqual(1, path_entries.count(str(configured_meshroom_dir)))
+                self.assertEqual(executable, Path(shutil.which(executable_name)))
         finally:
             if original_value:
                 settings.setValue(MESHROOM_EXECUTABLE_SETTINGS_KEY, original_value)

--- a/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
+++ b/OpenLIFULogin/Resources/UI/OpenLIFULogin.ui
@@ -94,6 +94,26 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="meshroomStatusIcon">
+           <property name="text">
+            <string>meshroomStatus</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QPushButton" name="installMeshroomPushButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>2</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install Meshroom 2025</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -75,6 +75,7 @@ from OpenLIFULib.util import add_slicer_log_handler, BusyCursor, get_cloned_node
 from OpenLIFULib.notifications import notify
 from OpenLIFULib.virtual_fit_results import get_virtual_fit_approval_for_target, get_approval_from_virtual_fit_result_node
 from OpenLIFULib.install_asset_dialog import InstallAssetDialog
+from OpenLIFULib.meshroom_install_gui import restore_meshroom_path
 
 # These imports are for IDE and static analysis purposes only
 if TYPE_CHECKING:
@@ -3315,6 +3316,7 @@ class OpenLIFUTransducerLocalizationLogic(ScriptedLoadableModuleLogic):
             sort_by = "filename",
             sampling_rate = sampling_rate,
         )
+        restore_meshroom_path()  # ensure meshroom_batch's directory is on PATH
         with BusyCursor():
             photoscan_openlifu, data_dir = openlifu.nav.photoscan.run_reconstruction(
                 images = photocollection_filepaths,


### PR DESCRIPTION
Addresses #542 

 Adds a button to the login module's "Optional" dependencies section for checking and installing Meshroom 2025.1.0.

Detects Meshroom by looking for meshroom_batch on PATH (the executable required by openlifu). Since meshroom_batch has no --version flag, the version is inferred from the parent directory name (e.g., Meshroom-2025.1.0).

The Meshroom archive is large (~10 GB on Windows, ~13 GB on Linux), so the download runs in a background QProcess with a progress dialog and cancel support - the same approach used for the sample database download. After extraction, the Meshroom directory is added to PATH using the same registry-based approach used for Android Platform Tools. On Windows, a post-install dialog provides step-by-step instructions for enabling NVIDIA GPU acceleration, based on the instructions provided here: https://github.com/OpenwaterHealth/OpenLIFU-python?tab=readme-ov-file#enable-gpu-acceleration

I also added some unit tests to the Login module. 

## For Review

Test it out, and review the overall design. The specifics of the progress bar/download code is mostly borrowed from the sample data functionality 