### PR TITLE
Bump openlifu to v0.21.1

### DIFF
--- a/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
+++ b/OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt
@@ -1,4 +1,4 @@
-openlifu[app]==v0.21.0
+openlifu[app]==v0.21.1
 bcrypt
 threadpoolctl
 requests


### PR DESCRIPTION
openlifu changes being incorporated:

```
$ git log v0.21.0..v0.21.1 --oneline
c0a64b7 (HEAD -> main, tag: v0.21.1, origin/main, origin/HEAD) Add unit test for get_ita (#479)
5b21a92 Adjust time averaged intensity calculation (#479)
b7a3fae Document release process
18cc547 Copy pipeline graph to temp dir to avoid spaces (#473)
206e1cc Bump actions/checkout from 6 to 7 in the actions group
45c0104 Rename CLAUDE.md to AGENTS.md to be more general (#337)
c798e3d Add docs build runtime extras (#337)
395c50c Convert README to Markdown (#338)
a9a53f3 Move contributing guide to repository root (#338)
9f4f28f Update install documentation for dependency extras (#338)
```

The critical one being:

```
5b21a92 Adjust time averaged intensity calculation (#479)
```

https://github.com/OpenwaterHealth/openlifu-python/pull/480