### PR TITLE
Fix custom app page lifecycle guards (#627)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -51,6 +51,7 @@ from OpenLIFULib.util import (
     display_errors,
     ensure_list,
     replace_widget,
+    page_is_entered,
 )
 from OpenLIFULib.volume_thresholding import load_volume_and_threshold_background
 from OpenLIFULib.virtual_fit_results import (
@@ -1489,6 +1490,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -1496,6 +1498,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -1509,7 +1512,7 @@ class OpenLIFUDataWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Guid
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
         self.setupSHNodeObserver()
 

--- a/OpenLIFUDatabase/OpenLIFUDatabase.py
+++ b/OpenLIFUDatabase/OpenLIFUDatabase.py
@@ -35,6 +35,7 @@ from OpenLIFULib.sample_data_gui import (
 from OpenLIFULib.util import (
     display_errors,
     add_slicer_log_handler_for_openlifu_object,
+    page_is_entered,
 )
 
 if TYPE_CHECKING:
@@ -158,6 +159,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -165,6 +167,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -178,7 +181,7 @@ class OpenLIFUDatabaseWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, 
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     @display_errors

--- a/OpenLIFUHome/OpenLIFUHome.py
+++ b/OpenLIFUHome/OpenLIFUHome.py
@@ -21,6 +21,7 @@ from OpenLIFULib import (
 )
 from OpenLIFULib.util import (
     get_openlifu_login_parameter_node,
+    page_is_entered,
 )
 
 from OpenLIFULib.guided_mode_util import set_guided_mode_state, Workflow
@@ -194,12 +195,14 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -213,7 +216,7 @@ class OpenLIFUHomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:

--- a/OpenLIFULib/OpenLIFULib/util.py
+++ b/OpenLIFULib/OpenLIFULib/util.py
@@ -13,6 +13,22 @@ if TYPE_CHECKING:
 
 # Use this to ensure compatibility in Python 3.9
 get_hints = get_type_hints if hasattr(Annotated, '__metadata__') else get_type_hints_ext
+def page_is_entered(widget: Any) -> bool:
+    """Return whether an OpenLIFU page widget is currently entered.
+
+    Vanilla 3D Slicer exposes ``parent.isEntered`` on scripted module widgets.
+    The OpenLIFU custom desktop application reparents page widgets into a plain
+    ``QWidget``, so that attribute is unavailable there.  Custom-app delegates
+    call each page's ``enter()`` / ``exit()`` methods, which maintain the
+    ``_entered`` fallback used here.
+    """
+    parent = getattr(widget, "parent", None)
+    parent_is_entered = getattr(parent, "isEntered", None)
+    if parent_is_entered is not None:
+        return bool(parent_is_entered)
+    return bool(getattr(widget, "_entered", False))
+
+
 class BusyCursor:
     """
     Context manager for showing a busy cursor.  Ensures that cursor reverts to normal in

--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -39,7 +39,7 @@ from OpenLIFULib import (
 from OpenLIFULib.class_definition_widgets import ListTableWidget
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 from OpenLIFULib.user_account_mode_util import UserAccountBanner, set_user_account_mode_state
-from OpenLIFULib.util import display_errors, get_openlifu_data_parameter_node
+from OpenLIFULib.util import display_errors, get_openlifu_data_parameter_node, page_is_entered
 
 if TYPE_CHECKING:
     import openlifu
@@ -669,6 +669,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         dependencies_available = ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -682,6 +683,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -695,7 +697,7 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):

--- a/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
+++ b/OpenLIFUPrePlanning/OpenLIFUPrePlanning.py
@@ -41,6 +41,7 @@ from OpenLIFULib.util import (
     BusyCursor,
     add_slicer_log_handler,
     replace_widget,
+    page_is_entered,
 )
 from OpenLIFULib.notifications import notify
 from OpenLIFULib.virtual_fit_results import (
@@ -243,6 +244,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -250,6 +252,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -263,7 +266,7 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:
@@ -455,6 +458,8 @@ class OpenLIFUPrePlanningWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         self.updateInputOptions()
 
     def onDataParameterNodeModified(self,caller, event) -> None:
+        if not page_is_entered(self):
+            return
         self.updateInputOptions() 
         self.updateWorkflowControls()
         self.updateVirtualFitRelatedLabels()

--- a/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
+++ b/OpenLIFUProtocolConfig/OpenLIFUProtocolConfig.py
@@ -37,6 +37,7 @@ from OpenLIFULib.user_account_mode_util import get_current_user, get_user_accoun
 from OpenLIFULib.util import (
     display_errors,
     replace_widget,
+    page_is_entered,
 )
 
 if TYPE_CHECKING:
@@ -375,6 +376,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         dependencies_available = ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -383,6 +385,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
 
         # Cache a WIP (other modules might load one)
         if self._protocol_editor_widgets_initialized and self._cur_save_state == SaveState.UNSAVED_CHANGES:
@@ -402,7 +405,7 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
@@ -425,6 +428,8 @@ class OpenLIFUProtocolConfigWidget(ScriptedLoadableModuleWidget, VTKObservationM
             self.ui.protocolSelector.setCurrentText(prev_protocol)
 
     def onDataParameterNodeModified(self, caller = None, event = None):
+        if not page_is_entered(self):
+            return
         # Edits to data parameter node should not change selected protocol
         prev_protocol = self.ui.protocolSelector.currentText
 

--- a/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
+++ b/OpenLIFUSonicationControl/OpenLIFUSonicationControl.py
@@ -27,7 +27,7 @@ from OpenLIFULib import (
 )
 from OpenLIFULib.guided_mode_util import GuidedWorkflowMixin
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
-from OpenLIFULib.util import add_slicer_log_handler, display_errors, replace_widget
+from OpenLIFULib.util import add_slicer_log_handler, display_errors, replace_widget, page_is_entered
 
 
 if TYPE_CHECKING:
@@ -338,6 +338,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         logging.debug("OpenLIFUSonicationControlWidget.enter() called")
         dependencies_available = ensure_python_requirements_for_module_enter()
         if dependencies_available and (slicer.app.testingEnabled() or self.logic.cur_lifu_interface is not None):
@@ -350,6 +351,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         logging.debug("OpenLIFUSonicationControlWidget.exit() called")
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
@@ -366,7 +368,7 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
         """Called just after the scene is closed."""
         logging.debug("onSceneEndClose() called")
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:
@@ -393,6 +395,8 @@ class OpenLIFUSonicationControlWidget(ScriptedLoadableModuleWidget, VTKObservati
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
     def onDataParameterNodeModified(self, caller=None, event=None) -> None:
+        if not page_is_entered(self):
+            return
         logging.debug("onDataParameterNodeModified() called")
         self.updateAllButtonsEnabled()
         if (solution_parameter_pack := get_openlifu_data_parameter_node().loaded_solution) is None:

--- a/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
+++ b/OpenLIFUSonicationPlanner/OpenLIFUSonicationPlanner.py
@@ -38,6 +38,7 @@ from OpenLIFULib.util import (
     create_noneditable_QStandardItem,
     display_errors,
     replace_widget,
+    page_is_entered,
 )
 from OpenLIFULib.notifications import notify
 
@@ -192,6 +193,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -199,6 +201,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -212,7 +215,7 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:
@@ -368,6 +371,8 @@ class OpenLIFUSonicationPlannerWidget(ScriptedLoadableModuleWidget, VTKObservati
         self.onPnpOpacitySliderChanged(self.ui.pnpOpacitySlider.value)
 
     def onDataParameterNodeModified(self,caller, event) -> None:
+        if not page_is_entered(self):
+            return
         self.updateInputOptions()
         self.updateSolutionProgressBar()
         self.updateRenderPNPCheckBox()

--- a/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
+++ b/OpenLIFUTransducerLocalization/OpenLIFUTransducerLocalization.py
@@ -71,7 +71,7 @@ from OpenLIFULib.transducer_tracking_wizard_utils import (
     get_threeD_transducer_tracking_view_node,
 )
 from OpenLIFULib.user_account_mode_util import UserAccountBanner
-from OpenLIFULib.util import add_slicer_log_handler, BusyCursor, get_cloned_node, replace_widget, display_errors
+from OpenLIFULib.util import add_slicer_log_handler, BusyCursor, get_cloned_node, replace_widget, display_errors, page_is_entered
 from OpenLIFULib.notifications import notify
 from OpenLIFULib.virtual_fit_results import get_virtual_fit_approval_for_target, get_approval_from_virtual_fit_result_node
 from OpenLIFULib.install_asset_dialog import InstallAssetDialog
@@ -2138,6 +2138,7 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
 
     def enter(self) -> None:
         """Called each time the user opens this module."""
+        self._entered = True
         ensure_python_requirements_for_module_enter()
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
@@ -2145,6 +2146,7 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
 
     def exit(self) -> None:
         """Called each time the user opens a different module."""
+        self._entered = False
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -2158,7 +2160,7 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
     def onSceneEndClose(self, caller, event) -> None:
         """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
-        if self.parent.isEntered:
+        if page_is_entered(self):
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:
@@ -2183,6 +2185,8 @@ class OpenLIFUTransducerLocalizationWidget(ScriptedLoadableModuleWidget, VTKObse
             self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
     def onDataParameterNodeModified(self, caller, event) -> None:
+        if not page_is_entered(self):
+            return
         self.updatePhotoscanGenerationButtons()
         self.updateApprovalStatusLabel()
         self.updateInputOptions()


### PR DESCRIPTION
Fixes #627.

## Summary

This fixes the custom-app page lifecycle regression where `dataChanged` handlers could short-circuit even while a page was visible.

In vanilla Slicer, page widgets can rely on `self.parent.isEntered`, but in the custom desktop app pages are reparented into a plain `QWidget`, so that attribute is unavailable. The previous guard therefore evaluated false and prevented page refresh logic from running.

### Changes

- add a shared `page_is_entered(widget)` helper in `OpenLIFULib.util`
- use `parent.isEntered` when available in vanilla Slicer
- fall back to each widget's `_entered` state in the custom app
- set `_entered` in affected widgets during `enter()` / `exit()`
- replace direct `self.parent.isEntered` and `getattr(..., False)` lifecycle checks with the shared helper
- update `dataChanged` and scene-close guards across the affected pages

## Validation

- `git diff --check` passes
- targeted Python compilation passes for the modified modules that are compilable on the current base
- verified there are no remaining uses of:
  - `self.parent.isEntered`
  - `getattr(self.parent, "isEntered", False)`

`OpenLIFUTransducerLocalization.py` contains a pre-existing unrelated f-string syntax error in the current base snapshot, so full-file compilation for that module is not possible. The changes in this PR do not touch the failing line.

## Scope

This PR is intentionally limited to the page lifecycle / visibility guard regression described in #627. Follow-up behavior around PNP rendering, opacity/window-level state, and other solution-state issues can be handled separately if they remain reproducible after this fix.