### PR TITLE
Disable user account mode without database (#590)

### DIFF
--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -700,8 +700,14 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
 
     def onDatabaseChanged(self, db: Optional["openlifu.db.Database"] = None):
         if self._cur_login_state == LoginState.LOGGED_IN:
-            slicer.util.infoDisplay(f"You have been logged out because the database location was changed.")
+            slicer.util.infoDisplay(
+                "You have been logged out because the database location was changed."
+            )
             self.logout()
+
+        if db is None and self._parameterNode.user_account_mode:
+            set_user_account_mode_state(False)
+
         self.updateWidgetLoginState(LoginState.NOT_LOGGED_IN)
 
     def initializeParameterNode(self) -> None:


### PR DESCRIPTION
Fixes #590.

## Summary

- automatically disable User Account Mode when the database becomes unavailable
- reuse the existing `onDatabaseChanged()` callback already registered with `OpenLIFUDatabaseLogic`
- preserve the existing logout behavior when the database location changes
- allow existing permission enforcement to re-enable gated UI once UAM is disabled

## Why

When User Account Mode remains enabled after the database is disconnected, the app can enter a dead-end state where database-dependent navigation is disabled and the user has no path back to reconnect.

The login module already receives database change notifications. This change enforces the invariant that User Account Mode cannot remain active without a database.

## Validation

- `python -m py_compile OpenLIFULogin/OpenLIFULogin.py`
- `git diff --check`
- verified database changes flow through `OpenLIFUDatabaseLogic.call_on_db_changed(...)`
- verified permission-gated widgets are re-enabled when User Account Mode is disabled

## Manual regression

1. Connect a database.
2. Enable User Account Mode.
3. Disconnect the database or change the database location to an invalid path.
4. Confirm User Account Mode is automatically disabled.
5. Confirm the user can still navigate to Data and reconnect a database.