### PR TITLE
Skip solution validation during session reload (#617)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1805,6 +1805,9 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         """Check to ensure that the currently active solution is in a valid state, clearing out the solution
         if it is not and returning whether there is an active valid solution."""
 
+        if self.session_loading_unloading_in_progress:
+            return False
+
         solution = self.getParameterNode().loaded_solution
 
         if solution is None:


### PR DESCRIPTION
Fixes #617.

## Summary

- skip `validate_solution()` while a session is being loaded or unloaded
- reuse the existing `session_loading_unloading_in_progress` state
- prevent transient session teardown from triggering solution-invalidated dialogs

## Why

Reloading a session calls `clear_session()`, which removes session-owned volume nodes while the existing solution is still temporarily present.

That node-removal fanout can call `validate_solution()`, which sees the solution's volume nodes disappear and incorrectly reports:

> A volume that was in use by the active solution is now missing.

During session load/unload this is an expected transient state, not a user-facing solution failure.

## Validation

- `python -m py_compile OpenLIFUData/OpenLIFUData.py`
- `git diff --check`
- branch is one commit ahead of `main`
- only `OpenLIFUData/OpenLIFUData.py` changes

## Manual regression

1. Load a session containing at least one solution.
2. Navigate away from the session.
3. Reload the same session.
4. Confirm the solution-invalidated volume popup does not appear.
5. Confirm normal solution validation still runs outside session load/unload.