### PR TITLE
Avoid loading all users during login (#596)

### DIFF
--- a/OpenLIFULogin/OpenLIFULogin.py
+++ b/OpenLIFULogin/OpenLIFULogin.py
@@ -778,12 +778,21 @@ class OpenLIFULoginWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Gui
         if not returncode:
             return
 
-        users = get_cur_db().load_all_users()
         import bcrypt
 
-        verify_password = lambda text, _hash: bcrypt.checkpw(text.encode('utf-8'), _hash.encode('utf-8'))
+        verify_password = lambda text, _hash: bcrypt.checkpw(
+            text.encode("utf-8"), _hash.encode("utf-8")
+        )
 
-        matched_user = next((u for u in users if u.id == user_id and verify_password(password_text, u.password_hash)), None)
+        try:
+            matched_user = get_cur_db().load_user(user_id)
+        except Exception:
+            matched_user = None
+
+        if matched_user is not None and not verify_password(
+            password_text, matched_user.password_hash
+        ):
+            matched_user = None
 
         if not matched_user:
             self.updateWidgetLoginState(LoginState.UNSUCCESSFUL_LOGIN)


### PR DESCRIPTION
Addresses part of #596.

## Summary

- replace `load_all_users()` in the interactive login path with a targeted `load_user(user_id)`
- preserve the same unsuccessful-login behavior for unknown users and incorrect passwords
- catch the documented `FileNotFoundError` raised when a user ID does not exist

## Why

The login path only needs to authenticate a single requested user, but it currently calls `load_all_users()`, which deserializes every user in the database and emits a `Loaded User ...` log entry for each account.

Using `load_user(user_id)` avoids that unnecessary work and reduces log noise during ordinary login.

## Validation

- `python -m py_compile OpenLIFULogin/OpenLIFULogin.py`
- `git diff --check`
- verified `Database.load_user()` raises `FileNotFoundError` when the requested user does not exist
- remaining `load_all_users()` calls are intentionally left unchanged because they serve different multi-user UI/state paths

## Behavior

- valid username + valid password: login succeeds
- valid username + invalid password: unsuccessful login
- unknown username: unsuccessful login