### PR TITLE
Clear empty session photoscan affiliations (#619)

### DIFF
--- a/OpenLIFUData/OpenLIFUData.py
+++ b/OpenLIFUData/OpenLIFUData.py
@@ -1882,8 +1882,7 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         
         # Keep track of any photocollections associated with the session
         affiliated_photocollections = get_cur_db().get_photocollection_reference_numbers(subject_id, session_id)
-        if affiliated_photocollections:
-            loaded_session.set_affiliated_photocollections(affiliated_photocollections)
+        loaded_session.set_affiliated_photocollections(affiliated_photocollections)
 
     def update_photoscans_affiliated_with_loaded_session(self) -> None:
 
@@ -1892,9 +1891,11 @@ class OpenLIFUDataLogic(ScriptedLoadableModuleLogic):
         session_id = loaded_session.get_session_id()
         
         # Keep track of any photoscans associated with the session
-        affiliated_photoscans = {id:get_cur_db().load_photoscan(subject_id, session_id, id) for id in get_cur_db().get_photoscan_ids(subject_id, session_id)}
-        if affiliated_photoscans:
-            loaded_session.set_affiliated_photoscans(affiliated_photoscans)
+        affiliated_photoscans = {
+            id: get_cur_db().load_photoscan(subject_id, session_id, id)
+            for id in get_cur_db().get_photoscan_ids(subject_id, session_id)
+        }
+        loaded_session.set_affiliated_photoscans(affiliated_photoscans)
 
     def load_session(self, subject_id, session_id) -> None:
 


### PR DESCRIPTION
Fixes #619.

## Summary

- always refresh the loaded session's affiliated photoscan state from the database
- explicitly set the session's affiliated photoscans to an empty dictionary when the database reports none
- prevent photoscan affiliation state from surviving a switch to a session with no photoscans

## Root cause

`update_photoscans_affiliated_with_loaded_session()` only called
`set_affiliated_photoscans()` when the database returned a non-empty
photoscan dictionary.

When switching from a session with affiliated photoscans to a session with
none, the empty result therefore did not update the session wrapper. This
could leave stale photoscan affiliation state visible to Transducer
Localization.

`set_affiliated_photoscans({})` already correctly clears the wrapper's
affiliated photoscan dictionary, so the refresh should always call it.

## Validation

- `python -m py_compile OpenLIFUData/OpenLIFUData.py`
- `git diff --check`
- change limited to `OpenLIFUData/OpenLIFUData.py`

## Manual regression

1. Load session A with an affiliated photoscan.
2. Exit session A.
3. Load session B with no affiliated photoscans.
4. Navigate to Transducer Localization.
5. Confirm session A's photoscan is no longer presented as affiliated with session B.